### PR TITLE
feat: align type definitions with PRD (Task A - #3)

### DIFF
--- a/docs/architecture/draft-status-transitions.md
+++ b/docs/architecture/draft-status-transitions.md
@@ -1,0 +1,58 @@
+# SalaryDraft ステータス遷移図
+
+ADR-006 および PRD §6.5 に基づく状態遷移の定義。
+
+実装: `packages/shared/src/types.ts` の `VALID_TRANSITIONS`
+
+## 遷移マップ
+
+| From | To | 条件 |
+|------|-----|------|
+| `draft` | `reviewed` | 人事担当者が確認・編集完了 |
+| `draft` | `rejected` | 人事担当者が差し戻し |
+| `reviewed` | `approved` | **機械的変更**: 人事承認 |
+| `reviewed` | `pending_ceo_approval` | **裁量的変更**: 人事チェック完了 |
+| `reviewed` | `draft` | 人事担当者が再編集のため差し戻し |
+| `pending_ceo_approval` | `approved` | 社長承認 |
+| `pending_ceo_approval` | `draft` | 社長が差し戻し |
+| `rejected` | `draft` | 差し戻し後に再開 |
+| `approved` | `processing` | 通知・外部連携の開始 |
+| `processing` | `completed` | 全連携完了（**終端**） |
+| `processing` | `failed` | 連携失敗 |
+| `failed` | `processing` | リトライ |
+| `failed` | `reviewed` | 手動介入が必要な場合 |
+
+## Mermaid 図
+
+```mermaid
+stateDiagram-v2
+    [*] --> draft : AI がドラフト作成完了
+
+    draft --> reviewed : 人事担当者が確認・編集
+    draft --> rejected : 人事担当者が差し戻し
+
+    reviewed --> approved : 機械的変更 / 人事承認
+    reviewed --> pending_ceo_approval : 裁量的変更 / 人事チェック完了
+    reviewed --> draft : 人事が差し戻し（再編集）
+
+    pending_ceo_approval --> approved : 社長承認
+    pending_ceo_approval --> draft : 社長が差し戻し
+
+    rejected --> draft : 差し戻し後再開
+
+    approved --> processing : 通知・外部連携 開始
+
+    processing --> completed : 全連携完了
+    processing --> failed : 連携失敗
+
+    failed --> processing : リトライ
+    failed --> reviewed : 手動介入
+
+    completed --> [*] : 終端
+```
+
+## 行き止まりチェック
+
+- **終端ステータス**: `completed` のみ（意図的）
+- **その他の全ステータス**: 1つ以上の遷移先あり ✅
+- テスト: `packages/shared/src/__tests__/status-transitions.test.ts` で自動検証

--- a/packages/db/src/collections.ts
+++ b/packages/db/src/collections.ts
@@ -8,11 +8,14 @@ import { db } from "./client.js";
 import type {
   AllowanceMaster,
   ApprovalLog,
+  AuditLog,
   ChatMessage,
   Employee,
+  IntentRecord,
   PitchTable,
   Salary,
   SalaryDraft,
+  SalaryDraftItem,
 } from "./types.js";
 
 function typedCollection<T extends DocumentData>(name: string): CollectionReference<T> {
@@ -31,8 +34,11 @@ export const collections = {
   employees: typedCollection<Employee>("employees"),
   salaries: typedCollection<Salary>("salaries"),
   salaryDrafts: typedCollection<SalaryDraft>("salary_drafts"),
+  salaryDraftItems: typedCollection<SalaryDraftItem>("salary_draft_items"),
   chatMessages: typedCollection<ChatMessage>("chat_messages"),
+  intentRecords: typedCollection<IntentRecord>("intent_records"),
   approvalLogs: typedCollection<ApprovalLog>("approval_logs"),
+  auditLogs: typedCollection<AuditLog>("audit_logs"),
   pitchTables: typedCollection<PitchTable>("pitch_tables"),
   allowanceMasters: typedCollection<AllowanceMaster>("allowance_masters"),
 };

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -3,9 +3,12 @@ export { collections } from "./collections.js";
 export type {
   AllowanceMaster,
   ApprovalLog,
+  AuditLog,
   ChatMessage,
   Employee,
+  IntentRecord,
   PitchTable,
   Salary,
   SalaryDraft,
+  SalaryDraftItem,
 } from "./types.js";

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -9,9 +9,11 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "lint": "biome check src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/shared/src/__tests__/status-transitions.test.ts
+++ b/packages/shared/src/__tests__/status-transitions.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import { DRAFT_STATUSES, TERMINAL_STATUSES, VALID_TRANSITIONS } from "../types.js";
+
+describe("DraftStatus state machine", () => {
+  it("VALID_TRANSITIONS covers all statuses in DRAFT_STATUSES", () => {
+    for (const status of DRAFT_STATUSES) {
+      expect(VALID_TRANSITIONS).toHaveProperty(status);
+    }
+  });
+
+  it("all transition targets are valid DraftStatus values", () => {
+    const validStatuses = new Set<string>(DRAFT_STATUSES);
+    for (const [, targets] of Object.entries(VALID_TRANSITIONS)) {
+      for (const target of targets) {
+        expect(validStatuses.has(target)).toBe(true);
+      }
+    }
+  });
+
+  it("terminal states have no outgoing transitions", () => {
+    for (const status of TERMINAL_STATUSES) {
+      expect(VALID_TRANSITIONS[status]).toHaveLength(0);
+    }
+  });
+
+  it("non-terminal states have at least one outgoing transition (no dead ends)", () => {
+    for (const status of DRAFT_STATUSES) {
+      if (TERMINAL_STATUSES.includes(status)) continue;
+      expect(VALID_TRANSITIONS[status].length).toBeGreaterThan(0);
+    }
+  });
+
+  it("rejected status can transition back (no dead end)", () => {
+    expect(VALID_TRANSITIONS.rejected.length).toBeGreaterThan(0);
+  });
+
+  it("failed status can transition to retry or manual intervention", () => {
+    expect(VALID_TRANSITIONS.failed.length).toBeGreaterThan(0);
+  });
+
+  it("includes 'failed' status for processing failures", () => {
+    expect(DRAFT_STATUSES).toContain("failed");
+  });
+
+  it("mechanical change path: draft → reviewed → approved → processing → completed", () => {
+    expect(VALID_TRANSITIONS.draft).toContain("reviewed");
+    expect(VALID_TRANSITIONS.reviewed).toContain("approved");
+    expect(VALID_TRANSITIONS.approved).toContain("processing");
+    expect(VALID_TRANSITIONS.processing).toContain("completed");
+  });
+
+  it("discretionary change path: draft → reviewed → pending_ceo_approval → approved", () => {
+    expect(VALID_TRANSITIONS.draft).toContain("reviewed");
+    expect(VALID_TRANSITIONS.reviewed).toContain("pending_ceo_approval");
+    expect(VALID_TRANSITIONS.pending_ceo_approval).toContain("approved");
+  });
+
+  it("rejection paths return to draft for rework", () => {
+    expect(VALID_TRANSITIONS.rejected).toContain("draft");
+    expect(VALID_TRANSITIONS.pending_ceo_approval).toContain("draft");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,2 +1,25 @@
-export type { ActorRole, ChangeType, ChatCategory, DraftStatus } from "./types.js";
-export { ACTOR_ROLES, CHANGE_TYPES, CHAT_CATEGORIES, DRAFT_STATUSES } from "./types.js";
+export type {
+  ActorRole,
+  AllowanceType,
+  ApprovalAction,
+  AuditEventType,
+  ChangeType,
+  ChatCategory,
+  DraftStatus,
+  EmploymentType,
+  SalaryItemType,
+} from "./types.js";
+
+export {
+  ACTOR_ROLES,
+  ALLOWANCE_TYPES,
+  APPROVAL_ACTIONS,
+  AUDIT_EVENT_TYPES,
+  CHANGE_TYPES,
+  CHAT_CATEGORIES,
+  DRAFT_STATUSES,
+  EMPLOYMENT_TYPES,
+  SALARY_ITEM_TYPES,
+  TERMINAL_STATUSES,
+  VALID_TRANSITIONS,
+} from "./types.js";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1,4 +1,4 @@
-/** ドラフトステータス (ADR-006) */
+/** ドラフトステータス (ADR-006 + PRD 状態遷移図) */
 export const DRAFT_STATUSES = [
   "draft",
   "reviewed",
@@ -7,8 +7,31 @@ export const DRAFT_STATUSES = [
   "processing",
   "completed",
   "rejected",
+  "failed",
 ] as const;
 export type DraftStatus = (typeof DRAFT_STATUSES)[number];
+
+/** 終端ステータス（遷移先なし） */
+export const TERMINAL_STATUSES: readonly DraftStatus[] = ["completed"] as const;
+
+/**
+ * 有効なステータス遷移マップ (ADR-006 + PRD)
+ *
+ * 機械的変更: draft → reviewed → approved → processing → completed
+ * 裁量的変更: draft → reviewed → pending_ceo_approval → approved → processing → completed
+ * 差戻し: rejected → draft, pending_ceo_approval → draft, reviewed → draft
+ * 処理失敗: processing → failed, failed → processing (リトライ) or → reviewed (手動介入)
+ */
+export const VALID_TRANSITIONS: Record<DraftStatus, readonly DraftStatus[]> = {
+  draft: ["reviewed", "rejected"],
+  reviewed: ["approved", "pending_ceo_approval", "draft"],
+  pending_ceo_approval: ["approved", "draft"],
+  approved: ["processing"],
+  processing: ["completed", "failed"],
+  completed: [],
+  rejected: ["draft"],
+  failed: ["processing", "reviewed"],
+} as const;
 
 /** 変更種別 (ADR-006) */
 export const CHANGE_TYPES = ["mechanical", "discretionary"] as const;
@@ -32,3 +55,37 @@ export type ChatCategory = (typeof CHAT_CATEGORIES)[number];
 /** 承認者ロール */
 export const ACTOR_ROLES = ["hr_staff", "hr_manager", "ceo"] as const;
 export type ActorRole = (typeof ACTOR_ROLES)[number];
+
+/** 雇用区分 */
+export const EMPLOYMENT_TYPES = ["full_time", "part_time", "visiting_nurse"] as const;
+export type EmploymentType = (typeof EMPLOYMENT_TYPES)[number];
+
+/** 手当種別 */
+export const ALLOWANCE_TYPES = ["position", "region", "qualification"] as const;
+export type AllowanceType = (typeof ALLOWANCE_TYPES)[number];
+
+/** 給与項目種別（Before/After 比較用） */
+export const SALARY_ITEM_TYPES = [
+  "base_salary",
+  "position_allowance",
+  "region_allowance",
+  "qualification_allowance",
+  "other_allowance",
+] as const;
+export type SalaryItemType = (typeof SALARY_ITEM_TYPES)[number];
+
+/** 承認アクション種別 */
+export const APPROVAL_ACTIONS = ["reviewed", "approved", "rejected", "modified"] as const;
+export type ApprovalAction = (typeof APPROVAL_ACTIONS)[number];
+
+/** 監査イベント種別 */
+export const AUDIT_EVENT_TYPES = [
+  "chat_received",
+  "intent_classified",
+  "draft_created",
+  "draft_modified",
+  "status_changed",
+  "notification_sent",
+  "external_sync",
+] as const;
+export type AuditEventType = (typeof AUDIT_EVENT_TYPES)[number];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
 packages:
 


### PR DESCRIPTION
## Summary

- `failed` ステータス追加 + `VALID_TRANSITIONS` / `TERMINAL_STATUSES` を shared に定義
- 新型: `EmploymentType`, `AllowanceType`, `SalaryItemType`, `ApprovalAction`, `AuditEventType`
- `Employee` に `googleChatUserId` 追加・`EmploymentType` 共通型に統一
- `SalaryDraft` の Before/After を明示フィールド化（`beforeBaseSalary`, `afterBaseSalary` 等）
- 新インターフェース: `SalaryDraftItem`, `IntentRecord`, `AuditLog`
- `ApprovalLog` の型強化（`fromStatus`/`toStatus` を `DraftStatus` に、`action` と `modifiedFields` 追加）
- Firestore コレクション追加: `salaryDraftItems`, `intentRecords`, `auditLogs`
- 状態遷移の行き止まりなし検証テスト（10件）
- 状態遷移図を `docs/architecture/draft-status-transitions.md` に記録

## Test plan

- [x] `pnpm test` — 状態遷移テスト 10件パス
- [x] `pnpm typecheck` — 全パッケージ型チェックパス
- [x] `pnpm lint` — lint エラーなし
- [x] draw.io で状態遷移図を目視確認（行き止まりなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)