### PR TITLE
feat: Gemini intent classification (Task F)

### DIFF
--- a/packages/ai/package.json
+++ b/packages/ai/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@hr-system/ai",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "biome check src/",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@hr-system/shared": "workspace:*",
+    "@google-cloud/vertexai": "^1.9.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/ai/src/__tests__/intent-classifier.test.ts
+++ b/packages/ai/src/__tests__/intent-classifier.test.ts
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @google-cloud/vertexai before importing the module under test
+const mockGenerateContent = vi.fn();
+
+vi.mock("@google-cloud/vertexai", () => ({
+  VertexAI: vi.fn().mockImplementation(() => ({
+    getGenerativeModel: () => ({
+      generateContent: mockGenerateContent,
+    }),
+  })),
+}));
+
+// Import after mocking
+const { classifyIntent } = await import("../intent-classifier.js");
+
+function mockGeminiResponse(text: string) {
+  mockGenerateContent.mockResolvedValueOnce({
+    response: {
+      candidates: [
+        {
+          content: {
+            parts: [{ text }],
+          },
+        },
+      ],
+    },
+  });
+}
+
+describe("classifyIntent", () => {
+  beforeEach(() => {
+    mockGenerateContent.mockReset();
+  });
+
+  it("給与変更メッセージをsalaryに分類する", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        category: "salary",
+        confidence: 0.95,
+        reasoning: "給与変更に関するメッセージです",
+      }),
+    );
+
+    const result = await classifyIntent("田中さんの給与を30万に変更してください");
+
+    expect(result.category).toBe("salary");
+    expect(result.confidence).toBeGreaterThan(0.8);
+    expect(result.reasoning).toBeTruthy();
+  });
+
+  it("退職メッセージをretirementに分類する", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        category: "retirement",
+        confidence: 0.92,
+        reasoning: "退職に関するメッセージです",
+      }),
+    );
+
+    const result = await classifyIntent("山田さんが退職します");
+
+    expect(result.category).toBe("retirement");
+  });
+
+  it("健康診断メッセージをhealth_checkに分類する", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        category: "health_check",
+        confidence: 0.88,
+        reasoning: "健康診断に関するメッセージです",
+      }),
+    );
+
+    const result = await classifyIntent("健康診断の予約をお願いします");
+
+    expect(result.category).toBe("health_check");
+  });
+
+  it("confidenceが0-1の範囲であること", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        category: "salary",
+        confidence: 0.85,
+        reasoning: "給与に関するメッセージ",
+      }),
+    );
+
+    const result = await classifyIntent("昇給の相談です");
+
+    expect(result.confidence).toBeGreaterThanOrEqual(0);
+    expect(result.confidence).toBeLessThanOrEqual(1);
+  });
+
+  it("LLMが不正JSONを返した場合にエラーを投げる", async () => {
+    mockGeminiResponse("これはJSONではありません");
+
+    await expect(classifyIntent("テストメッセージ")).rejects.toThrow();
+  });
+
+  it("LLMが不正なcategoryを返した場合にエラーを投げる", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        category: "invalid_category",
+        confidence: 0.9,
+        reasoning: "不正なカテゴリ",
+      }),
+    );
+
+    await expect(classifyIntent("テストメッセージ")).rejects.toThrow();
+  });
+
+  it("confidenceが範囲外の場合にクランプされる", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        category: "salary",
+        confidence: 1.5,
+        reasoning: "高い確信度",
+      }),
+    );
+
+    const result = await classifyIntent("給与の件");
+
+    expect(result.confidence).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/ai/src/__tests__/param-extractor.test.ts
+++ b/packages/ai/src/__tests__/param-extractor.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock @google-cloud/vertexai before importing the module under test
+const mockGenerateContent = vi.fn();
+
+vi.mock("@google-cloud/vertexai", () => ({
+  VertexAI: vi.fn().mockImplementation(() => ({
+    getGenerativeModel: () => ({
+      generateContent: mockGenerateContent,
+    }),
+  })),
+}));
+
+// Import after mocking
+const { extractSalaryParams } = await import("../param-extractor.js");
+
+function mockGeminiResponse(text: string) {
+  mockGenerateContent.mockResolvedValueOnce({
+    response: {
+      candidates: [
+        {
+          content: {
+            parts: [{ text }],
+          },
+        },
+      ],
+    },
+  });
+}
+
+describe("extractSalaryParams", () => {
+  beforeEach(() => {
+    mockGenerateContent.mockReset();
+  });
+
+  it("給与変更メッセージからパラメータを抽出する", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        employeeIdentifier: "田中",
+        changeType: "discretionary",
+        targetSalary: 300000,
+        allowanceType: null,
+        reasoning: "直接的な金額指定による裁量的変更",
+      }),
+    );
+
+    const result = await extractSalaryParams("田中さんの給与を30万に変更");
+
+    expect(result.employeeIdentifier).toBe("田中");
+    expect(result.targetSalary).toBe(300000);
+    expect(result.changeType).toBe("discretionary");
+  });
+
+  it("資格取得による機械的変更を抽出する", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        employeeIdentifier: "鈴木",
+        changeType: "mechanical",
+        targetSalary: null,
+        allowanceType: "qualification",
+        reasoning: "資格取得に伴う資格手当の付与",
+      }),
+    );
+
+    const result = await extractSalaryParams("鈴木さんが介護福祉士を取得した");
+
+    expect(result.employeeIdentifier).toBe("鈴木");
+    expect(result.allowanceType).toBe("qualification");
+    expect(result.changeType).toBe("mechanical");
+  });
+
+  it("従業員が特定できない場合にnullを返す", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        employeeIdentifier: null,
+        changeType: "discretionary",
+        targetSalary: 250000,
+        allowanceType: null,
+        reasoning: "従業員名が特定できません",
+      }),
+    );
+
+    const result = await extractSalaryParams("給与を25万にしてほしい");
+
+    expect(result.employeeIdentifier).toBeNull();
+    expect(result.targetSalary).toBe(250000);
+  });
+
+  it("LLMが不正JSONを返した場合にエラーを投げる", async () => {
+    mockGeminiResponse("不正なレスポンスです");
+
+    await expect(extractSalaryParams("テストメッセージ")).rejects.toThrow();
+  });
+
+  it("不正なchangeTypeの場合にエラーを投げる", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        employeeIdentifier: "佐藤",
+        changeType: "unknown_type",
+        targetSalary: null,
+        allowanceType: null,
+        reasoning: "不正な変更タイプ",
+      }),
+    );
+
+    await expect(extractSalaryParams("佐藤さんの件")).rejects.toThrow();
+  });
+});

--- a/packages/ai/src/gemini-client.ts
+++ b/packages/ai/src/gemini-client.ts
@@ -1,0 +1,10 @@
+import { VertexAI } from "@google-cloud/vertexai";
+
+const PROJECT = process.env.GCP_PROJECT_ID ?? "hr-system-487809";
+const LOCATION = "asia-northeast1";
+const MODEL = "gemini-2.5-flash";
+
+export function getGenerativeModel() {
+  const vertex = new VertexAI({ project: PROJECT, location: LOCATION });
+  return vertex.getGenerativeModel({ model: MODEL });
+}

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -1,0 +1,13 @@
+export { getGenerativeModel } from "./gemini-client.js";
+export {
+  classifyIntent,
+  type IntentClassificationResult,
+} from "./intent-classifier.js";
+export {
+  extractSalaryParams,
+  type SalaryChangeParams,
+} from "./param-extractor.js";
+export {
+  INTENT_CLASSIFICATION_PROMPT,
+  SALARY_PARAM_EXTRACTION_PROMPT,
+} from "./prompts.js";

--- a/packages/ai/src/intent-classifier.ts
+++ b/packages/ai/src/intent-classifier.ts
@@ -1,0 +1,55 @@
+import { CHAT_CATEGORIES, type ChatCategory } from "@hr-system/shared";
+import { getGenerativeModel } from "./gemini-client.js";
+import { INTENT_CLASSIFICATION_PROMPT } from "./prompts.js";
+
+export interface IntentClassificationResult {
+  category: ChatCategory;
+  confidence: number;
+  reasoning: string;
+}
+
+function extractJson(text: string): string {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenced?.[1]) return fenced[1].trim();
+  return text.trim();
+}
+
+export async function classifyIntent(message: string): Promise<IntentClassificationResult> {
+  const model = getGenerativeModel();
+  const response = await model.generateContent({
+    contents: [
+      { role: "user", parts: [{ text: INTENT_CLASSIFICATION_PROMPT }] },
+      {
+        role: "model",
+        parts: [{ text: "理解しました。チャットメッセージをJSON形式で分類します。" }],
+      },
+      { role: "user", parts: [{ text: message }] },
+    ],
+  });
+
+  const text = response.response.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(extractJson(text));
+  } catch {
+    throw new Error(`Intent classification failed: invalid JSON response: ${text}`);
+  }
+
+  const result = parsed as Record<string, unknown>;
+
+  if (
+    typeof result.category !== "string" ||
+    !CHAT_CATEGORIES.includes(result.category as ChatCategory)
+  ) {
+    throw new Error(`Intent classification failed: invalid category "${result.category}"`);
+  }
+
+  const confidence = Math.max(0, Math.min(1, Number(result.confidence) || 0));
+
+  return {
+    category: result.category as ChatCategory,
+    confidence,
+    reasoning: String(result.reasoning ?? ""),
+  };
+}

--- a/packages/ai/src/param-extractor.ts
+++ b/packages/ai/src/param-extractor.ts
@@ -1,0 +1,58 @@
+import { CHANGE_TYPES, type ChangeType } from "@hr-system/shared";
+import { getGenerativeModel } from "./gemini-client.js";
+import { SALARY_PARAM_EXTRACTION_PROMPT } from "./prompts.js";
+
+export interface SalaryChangeParams {
+  employeeIdentifier: string | null;
+  changeType: ChangeType;
+  targetSalary: number | null;
+  allowanceType: string | null;
+  reasoning: string;
+}
+
+function extractJson(text: string): string {
+  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)```/);
+  if (fenced?.[1]) return fenced[1].trim();
+  return text.trim();
+}
+
+export async function extractSalaryParams(message: string): Promise<SalaryChangeParams> {
+  const model = getGenerativeModel();
+  const response = await model.generateContent({
+    contents: [
+      { role: "user", parts: [{ text: SALARY_PARAM_EXTRACTION_PROMPT }] },
+      {
+        role: "model",
+        parts: [{ text: "理解しました。給与変更パラメータをJSON形式で抽出します。" }],
+      },
+      { role: "user", parts: [{ text: message }] },
+    ],
+  });
+
+  const text = response.response.candidates?.[0]?.content?.parts?.[0]?.text ?? "";
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(extractJson(text));
+  } catch {
+    throw new Error(`Parameter extraction failed: invalid JSON response: ${text}`);
+  }
+
+  const result = parsed as Record<string, unknown>;
+
+  if (
+    typeof result.changeType !== "string" ||
+    !CHANGE_TYPES.includes(result.changeType as ChangeType)
+  ) {
+    throw new Error(`Parameter extraction failed: invalid changeType "${result.changeType}"`);
+  }
+
+  return {
+    employeeIdentifier:
+      typeof result.employeeIdentifier === "string" ? result.employeeIdentifier : null,
+    changeType: result.changeType as ChangeType,
+    targetSalary: typeof result.targetSalary === "number" ? result.targetSalary : null,
+    allowanceType: typeof result.allowanceType === "string" ? result.allowanceType : null,
+    reasoning: String(result.reasoning ?? ""),
+  };
+}

--- a/packages/ai/src/prompts.ts
+++ b/packages/ai/src/prompts.ts
@@ -1,0 +1,34 @@
+export const INTENT_CLASSIFICATION_PROMPT = `あなたは人事業務の専門家です。以下のチャットメッセージを分析し、適切なカテゴリに分類してください。
+
+## カテゴリ一覧
+- salary: 給与・社会保険に関する内容（昇給、減給、手当変更、社会保険手続き等）
+- retirement: 退職・休職に関する内容（退職届、休職申請、復職等）
+- hiring: 入社・採用に関する内容（新規採用、入社手続き等）
+- contract: 契約変更に関する内容（雇用形態変更、契約更新等）
+- transfer: 施設・異動に関する内容（配置転換、転勤等）
+- foreigner: 外国人・ビザに関する内容（在留資格、ビザ更新等）
+- training: 研修・監査に関する内容（研修参加、監査対応等）
+- health_check: 健康診断に関する内容（健診予約、結果管理等）
+- attendance: 勤怠・休暇に関する内容（有給申請、勤怠修正等）
+- other: 上記のいずれにも該当しない内容
+
+## 回答形式
+必ず以下のJSON形式のみで回答してください。JSON以外のテキストは含めないでください。
+
+{"category": "カテゴリ名", "confidence": 0.0〜1.0の数値, "reasoning": "分類理由"}`;
+
+export const SALARY_PARAM_EXTRACTION_PROMPT = `あなたは人事業務の専門家です。以下の給与変更に関するチャットメッセージから、必要なパラメータを抽出してください。
+
+## 変更タイプの判断基準
+- mechanical（機械的変更）: 資格取得、等級変更、法令改正など、規定に基づく定型的な変更
+- discretionary（裁量的変更）: 昇給、減給、個別の金額指定など、裁量が伴う変更
+
+## 回答形式
+必ず以下のJSON形式のみで回答してください。JSON以外のテキストは含めないでください。
+
+{"employeeIdentifier": "従業員名または番号（不明の場合はnull）", "changeType": "mechanical または discretionary", "targetSalary": 目標金額の数値（不明の場合はnull）, "allowanceType": "手当種別（position/region/qualification、該当なしの場合はnull）", "reasoning": "抽出理由"}
+
+## 注意事項
+- 金額は数値に変換してください（例: 「30万」→ 300000、「25万円」→ 250000）
+- 従業員名から敬称（さん、様等）は除去してください
+- 不明な項目はnullとしてください`;

--- a/packages/ai/tsconfig.build.json
+++ b/packages/ai/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "./dist"
+  }
+}

--- a/packages/ai/tsconfig.json
+++ b/packages/ai/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- `packages/ai/` 新規パッケージ作成 (Vertex AI Gemini 統合)
- `classifyIntent()`: チャットメッセージを10カテゴリに分類
- `extractSalaryParams()`: 給与変更パラメータ抽出 (従業員識別子、変更タイプ、目標金額、手当種別)
- Gemini `gemini-2.5-flash` モデル使用 (GA, asia-northeast1 リージョン)
- ADR-007 準拠: LLM はパラメータ抽出のみ、金銭計算は行わない

## Implementation details
- `gemini-client.ts`: Vertex AI クライアント初期化
- `prompts.ts`: Intent分類 / パラメータ抽出プロンプトテンプレート (日本語)
- `intent-classifier.ts`: 10カテゴリ分類 + JSON パース + バリデーション
- `param-extractor.ts`: 給与変更パラメータ抽出 + mechanical/discretionary 判定
- JSON fenced block の自動抽出対応
- confidence 値の 0-1 クランプ処理

## Test plan
- [x] Vertex AI モック化テスト (vi.mock)
- [x] salary / retirement / health_check カテゴリ分類
- [x] 給与変更パラメータ抽出 (金額指定、資格取得)
- [x] 従業員未特定時の null ハンドリング
- [x] 不正 JSON レスポンスのエラーハンドリング
- [x] 不正カテゴリ / 不正 changeType のバリデーション
- [x] confidence 範囲外値のクランプ
- **12 tests, all passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)