### PR TITLE
feat: master data seed scripts (Task B)

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -11,13 +11,15 @@
   "scripts": {
     "build": "tsc -p tsconfig.build.json",
     "lint": "biome check src/",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
   },
   "dependencies": {
     "@hr-system/shared": "workspace:*",
     "firebase-admin": "^13.6.0"
   },
   "devDependencies": {
-    "@types/node": "^22.0.0"
+    "@types/node": "^22.0.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/packages/db/src/seed/__tests__/seed.test.ts
+++ b/packages/db/src/seed/__tests__/seed.test.ts
@@ -1,0 +1,98 @@
+import type { AllowanceType, EmploymentType } from "@hr-system/shared";
+import { ALLOWANCE_TYPES, EMPLOYMENT_TYPES } from "@hr-system/shared";
+import { describe, expect, it } from "vitest";
+import { ALLOWANCE_MASTER_DATA } from "../allowance-master.js";
+import { TEST_EMPLOYEES } from "../employees.js";
+import { PITCH_TABLE_DATA } from "../pitch-table.js";
+
+describe("PitchTable seed data", () => {
+  it("should have exactly 50 rows (grade 1-5 x step 1-10)", () => {
+    expect(PITCH_TABLE_DATA).toHaveLength(50);
+  });
+
+  it("should cover all grade-step combinations", () => {
+    const combinations = new Set(PITCH_TABLE_DATA.map((p) => `${p.grade}-${p.step}`));
+    expect(combinations.size).toBe(50);
+
+    for (let grade = 1; grade <= 5; grade++) {
+      for (let step = 1; step <= 10; step++) {
+        expect(combinations.has(`${grade}-${step}`)).toBe(true);
+      }
+    }
+  });
+
+  it("should calculate amount correctly: grade * 50000 + step * 5000", () => {
+    for (const row of PITCH_TABLE_DATA) {
+      expect(row.amount).toBe(row.grade * 50000 + row.step * 5000);
+    }
+  });
+
+  it("should have no negative amounts", () => {
+    for (const row of PITCH_TABLE_DATA) {
+      expect(row.amount).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("should have isActive set to true for all rows", () => {
+    for (const row of PITCH_TABLE_DATA) {
+      expect(row.isActive).toBe(true);
+    }
+  });
+});
+
+describe("AllowanceMaster seed data", () => {
+  it("should have valid allowanceType for all entries", () => {
+    const validTypes: readonly AllowanceType[] = ALLOWANCE_TYPES;
+    for (const entry of ALLOWANCE_MASTER_DATA) {
+      expect(validTypes).toContain(entry.allowanceType);
+    }
+  });
+
+  it("should have no negative amounts", () => {
+    for (const entry of ALLOWANCE_MASTER_DATA) {
+      expect(entry.amount).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("should have unique codes", () => {
+    const codes = ALLOWANCE_MASTER_DATA.map((e) => e.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it("should have position, region, and qualification types", () => {
+    const types = new Set(ALLOWANCE_MASTER_DATA.map((e) => e.allowanceType));
+    expect(types.has("position")).toBe(true);
+    expect(types.has("region")).toBe(true);
+    expect(types.has("qualification")).toBe(true);
+  });
+
+  it("should have isActive set to true for all entries", () => {
+    for (const entry of ALLOWANCE_MASTER_DATA) {
+      expect(entry.isActive).toBe(true);
+    }
+  });
+});
+
+describe("Employee seed data", () => {
+  it("should have 7 test employees", () => {
+    expect(TEST_EMPLOYEES).toHaveLength(7);
+  });
+
+  it("should have valid employmentType for all employees", () => {
+    const validTypes: readonly EmploymentType[] = EMPLOYMENT_TYPES;
+    for (const emp of TEST_EMPLOYEES) {
+      expect(validTypes).toContain(emp.employmentType);
+    }
+  });
+
+  it("should have unique employee numbers", () => {
+    const numbers = TEST_EMPLOYEES.map((e) => e.employeeNumber);
+    expect(new Set(numbers).size).toBe(numbers.length);
+  });
+
+  it("should have isActive set to true for all employees", () => {
+    for (const emp of TEST_EMPLOYEES) {
+      expect(emp.isActive).toBe(true);
+    }
+  });
+});

--- a/packages/db/src/seed/allowance-master.ts
+++ b/packages/db/src/seed/allowance-master.ts
@@ -1,0 +1,90 @@
+import type { AllowanceType } from "@hr-system/shared";
+import type { Timestamp } from "firebase-admin/firestore";
+import type { AllowanceMaster } from "../types.js";
+
+type AllowanceMasterSeed = Omit<AllowanceMaster, "createdAt"> & {
+  createdAt?: Timestamp;
+};
+
+export const ALLOWANCE_MASTER_DATA: AllowanceMasterSeed[] = [
+  // 役職手当
+  {
+    allowanceType: "position" as AllowanceType,
+    code: "MGR_DEPT",
+    name: "部長手当",
+    amount: 50000,
+    isActive: true,
+  },
+  {
+    allowanceType: "position" as AllowanceType,
+    code: "MGR_SECT",
+    name: "課長手当",
+    amount: 30000,
+    isActive: true,
+  },
+  {
+    allowanceType: "position" as AllowanceType,
+    code: "LEAD",
+    name: "主任手当",
+    amount: 15000,
+    isActive: true,
+  },
+  {
+    allowanceType: "position" as AllowanceType,
+    code: "STAFF",
+    name: "一般",
+    amount: 0,
+    isActive: true,
+  },
+  // 地域手当
+  {
+    allowanceType: "region" as AllowanceType,
+    code: "URBAN",
+    name: "都市部手当",
+    amount: 20000,
+    isActive: true,
+  },
+  {
+    allowanceType: "region" as AllowanceType,
+    code: "SUBURB",
+    name: "郊外手当",
+    amount: 10000,
+    isActive: true,
+  },
+  {
+    allowanceType: "region" as AllowanceType,
+    code: "RURAL",
+    name: "地方",
+    amount: 0,
+    isActive: true,
+  },
+  // 資格手当
+  {
+    allowanceType: "qualification" as AllowanceType,
+    code: "CARE_WORKER",
+    name: "介護福祉士手当",
+    amount: 10000,
+    isActive: true,
+  },
+  {
+    allowanceType: "qualification" as AllowanceType,
+    code: "NURSE",
+    name: "看護師手当",
+    amount: 15000,
+    isActive: true,
+  },
+  {
+    allowanceType: "qualification" as AllowanceType,
+    code: "HELPER",
+    name: "ヘルパー手当",
+    amount: 5000,
+    isActive: true,
+  },
+  {
+    allowanceType: "qualification" as AllowanceType,
+    code: "NONE",
+    name: "資格なし",
+    amount: 0,
+    isActive: true,
+  },
+];

--- a/packages/db/src/seed/employees.ts
+++ b/packages/db/src/seed/employees.ts
@@ -1,0 +1,82 @@
+import type { EmploymentType } from "@hr-system/shared";
+import type { Timestamp } from "firebase-admin/firestore";
+import type { Employee } from "../types.js";
+
+type EmployeeSeed = Omit<Employee, "hireDate" | "createdAt" | "updatedAt"> & {
+  hireDate?: Timestamp;
+  createdAt?: Timestamp;
+  updatedAt?: Timestamp;
+};
+
+export const TEST_EMPLOYEES: EmployeeSeed[] = [
+  {
+    employeeNumber: "EMP001",
+    name: "田中太郎",
+    email: "tanaka@example.com",
+    googleChatUserId: null,
+    employmentType: "full_time" as EmploymentType,
+    department: "人事部",
+    position: "課長",
+    isActive: true,
+  },
+  {
+    employeeNumber: "EMP002",
+    name: "鈴木花子",
+    email: "suzuki@example.com",
+    googleChatUserId: null,
+    employmentType: "full_time" as EmploymentType,
+    department: "営業部",
+    position: "主任",
+    isActive: true,
+  },
+  {
+    employeeNumber: "EMP003",
+    name: "佐藤一郎",
+    email: "sato@example.com",
+    googleChatUserId: null,
+    employmentType: "full_time" as EmploymentType,
+    department: "介護部",
+    position: "介護福祉士",
+    isActive: true,
+  },
+  {
+    employeeNumber: "EMP004",
+    name: "山田美咲",
+    email: "yamada@example.com",
+    googleChatUserId: null,
+    employmentType: "part_time" as EmploymentType,
+    department: "介護部",
+    position: null,
+    isActive: true,
+  },
+  {
+    employeeNumber: "EMP005",
+    name: "高橋健太",
+    email: "takahashi@example.com",
+    googleChatUserId: null,
+    employmentType: "part_time" as EmploymentType,
+    department: "調理部",
+    position: null,
+    isActive: true,
+  },
+  {
+    employeeNumber: "EMP006",
+    name: "伊藤さくら",
+    email: "ito@example.com",
+    googleChatUserId: null,
+    employmentType: "visiting_nurse" as EmploymentType,
+    department: "訪問看護部",
+    position: null,
+    isActive: true,
+  },
+  {
+    employeeNumber: "EMP007",
+    name: "渡辺浩二",
+    email: "watanabe@example.com",
+    googleChatUserId: null,
+    employmentType: "visiting_nurse" as EmploymentType,
+    department: "訪問看護部",
+    position: null,
+    isActive: true,
+  },
+];

--- a/packages/db/src/seed/index.ts
+++ b/packages/db/src/seed/index.ts
@@ -1,0 +1,68 @@
+import { Timestamp } from "firebase-admin/firestore";
+import { collections } from "../collections.js";
+import { ALLOWANCE_MASTER_DATA } from "./allowance-master.js";
+import { TEST_EMPLOYEES } from "./employees.js";
+import { PITCH_TABLE_DATA } from "./pitch-table.js";
+
+async function seedPitchTable(): Promise<void> {
+  const col = collections.pitchTables;
+  const batch = col.firestore.batch();
+
+  for (const row of PITCH_TABLE_DATA) {
+    const docId = `grade${row.grade}_step${row.step}`;
+    batch.set(col.doc(docId), {
+      ...row,
+      createdAt: Timestamp.now(),
+    });
+  }
+
+  await batch.commit();
+  console.log(`Seeded ${PITCH_TABLE_DATA.length} pitch table rows`);
+}
+
+async function seedAllowanceMaster(): Promise<void> {
+  const col = collections.allowanceMasters;
+  const batch = col.firestore.batch();
+
+  for (const entry of ALLOWANCE_MASTER_DATA) {
+    const docId = `${entry.allowanceType}_${entry.code}`;
+    batch.set(col.doc(docId), {
+      ...entry,
+      createdAt: Timestamp.now(),
+    });
+  }
+
+  await batch.commit();
+  console.log(`Seeded ${ALLOWANCE_MASTER_DATA.length} allowance master rows`);
+}
+
+async function seedEmployees(): Promise<void> {
+  const col = collections.employees;
+  const batch = col.firestore.batch();
+  const now = Timestamp.now();
+
+  for (const emp of TEST_EMPLOYEES) {
+    batch.set(col.doc(emp.employeeNumber), {
+      ...emp,
+      hireDate: now,
+      createdAt: now,
+      updatedAt: now,
+    });
+  }
+
+  await batch.commit();
+  console.log(`Seeded ${TEST_EMPLOYEES.length} test employees`);
+}
+
+async function main(): Promise<void> {
+  console.log("Starting seed...");
+  await seedPitchTable();
+  await seedAllowanceMaster();
+  await seedEmployees();
+  console.log("Seed completed successfully");
+}
+
+main().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});

--- a/packages/db/src/seed/pitch-table.ts
+++ b/packages/db/src/seed/pitch-table.ts
@@ -1,0 +1,24 @@
+import type { Timestamp } from "firebase-admin/firestore";
+import type { PitchTable } from "../types.js";
+
+/** Timestamp のプレースホルダー（投入時に Firestore.Timestamp.now() で上書き） */
+type PitchTableSeed = Omit<PitchTable, "createdAt"> & {
+  createdAt?: Timestamp;
+};
+
+function generatePitchTableData(): PitchTableSeed[] {
+  const data: PitchTableSeed[] = [];
+  for (let grade = 1; grade <= 5; grade++) {
+    for (let step = 1; step <= 10; step++) {
+      data.push({
+        grade,
+        step,
+        amount: grade * 50000 + step * 5000,
+        isActive: true,
+      });
+    }
+  }
+  return data;
+}
+
+export const PITCH_TABLE_DATA = generatePitchTableData();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,6 +68,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
+  packages/ai:
+    dependencies:
+      '@google-cloud/vertexai':
+        specifier: ^1.9.3
+        version: 1.10.0
+      '@hr-system/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/db:
     dependencies:
       '@hr-system/shared':
@@ -80,6 +96,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.11
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
   packages/shared:
     devDependencies:
@@ -362,6 +381,10 @@ packages:
   '@google-cloud/storage@7.19.0':
     resolution: {integrity: sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==}
     engines: {node: '>=14'}
+
+  '@google-cloud/vertexai@1.10.0':
+    resolution: {integrity: sha512-HqYqoivNtkq59po8m7KI0n+lWKdz4kabENncYQXZCX/hBWJfXtKAfR/2nUQsP+TwSfHKoA7zDL2RrJYIv/j3VQ==}
+    engines: {node: '>=18.0.0'}
 
   '@grpc/grpc-js@1.14.3':
     resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
@@ -1985,6 +2008,13 @@ snapshots:
       - encoding
       - supports-color
     optional: true
+
+  '@google-cloud/vertexai@1.10.0':
+    dependencies:
+      google-auth-library: 9.15.1
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   '@grpc/grpc-js@1.14.3':
     dependencies:


### PR DESCRIPTION
## Summary
- Pitchテーブル（50行: grade 1-5 × step 1-10）のシードデータ追加
- 手当マスター（役職/地域/資格 11種類）のシードデータ追加
- テスト用従業員7名のシードデータ追加（full_time 3名/part_time 2名/visiting_nurse 2名）
- Firestore batch write によるシードエントリポイント

## Changed Files
- `packages/db/src/seed/pitch-table.ts` - Pitchテーブルデータ定義・投入関数
- `packages/db/src/seed/allowance-master.ts` - 手当マスターデータ定義・投入関数
- `packages/db/src/seed/employees.ts` - テスト従業員データ定義・投入関数
- `packages/db/src/seed/index.ts` - Firestore batch write エントリポイント
- `packages/db/src/seed/__tests__/seed.test.ts` - データ構造検証テスト 14件

## Test plan
- [x] seed.test.ts: Pitchテーブル 50件検証
- [x] seed.test.ts: 全手当マスターの allowanceType が valid
- [x] seed.test.ts: 全従業員の employmentType が valid
- [x] seed.test.ts: amount が負数でないこと
- [x] typecheck: TypeScript型チェッククリア
- [x] lint: Biomeクリア

🤖 Generated with [Claude Code](https://claude.com/claude-code)