### PR TITLE
feat: approval state machine (Task D)

### DIFF
--- a/packages/shared/src/__tests__/approval.test.ts
+++ b/packages/shared/src/__tests__/approval.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from "vitest";
+import { getNextActions, validateTransition } from "../approval.js";
+
+describe("validateTransition", () => {
+  describe("正常系", () => {
+    it("hr_manager が mechanical draft→reviewed できる", () => {
+      const result = validateTransition("draft", "reviewed", "hr_manager", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("hr_staff が mechanical draft→reviewed できる", () => {
+      const result = validateTransition("draft", "reviewed", "hr_staff", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("hr_manager が mechanical reviewed→approved できる", () => {
+      const result = validateTransition("reviewed", "approved", "hr_manager", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("hr_manager が discretionary reviewed→pending_ceo_approval できる", () => {
+      const result = validateTransition(
+        "reviewed",
+        "pending_ceo_approval",
+        "hr_manager",
+        "discretionary",
+      );
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("ceo が pending_ceo_approval→approved できる", () => {
+      const result = validateTransition("pending_ceo_approval", "approved", "ceo", "discretionary");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("ceo が pending_ceo_approval→draft（差し戻し）できる", () => {
+      const result = validateTransition("pending_ceo_approval", "draft", "ceo", "discretionary");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("hr_staff が reviewed→draft（差し戻し）できる", () => {
+      const result = validateTransition("reviewed", "draft", "hr_staff", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("hr_staff が rejected→draft できる", () => {
+      const result = validateTransition("rejected", "draft", "hr_staff", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("hr_staff が draft→rejected できる", () => {
+      const result = validateTransition("draft", "rejected", "hr_staff", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("system が approved→processing できる", () => {
+      const result = validateTransition("approved", "processing", "system", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("system が processing→completed できる", () => {
+      const result = validateTransition("processing", "completed", "system", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("system が processing→failed できる", () => {
+      const result = validateTransition("processing", "failed", "system", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("hr_staff が failed→processing（リトライ）できる", () => {
+      const result = validateTransition("failed", "processing", "hr_staff", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("hr_manager が failed→reviewed（手動介入）できる", () => {
+      const result = validateTransition("failed", "reviewed", "hr_manager", "mechanical");
+      expect(result).toEqual({ valid: true });
+    });
+  });
+
+  describe("不正な遷移", () => {
+    it("存在しない遷移 approved→draft はエラー", () => {
+      const result = validateTransition("approved", "draft", "hr_manager", "mechanical");
+      expect(result).toEqual({
+        valid: false,
+        error: "Invalid transition: approved → draft",
+      });
+    });
+
+    it("存在しない遷移 completed→draft はエラー", () => {
+      const result = validateTransition("completed", "draft", "hr_manager", "mechanical");
+      expect(result).toEqual({
+        valid: false,
+        error: "Invalid transition: completed → draft",
+      });
+    });
+  });
+
+  describe("権限不足", () => {
+    it("hr_staff が reviewed→approved できない", () => {
+      const result = validateTransition("reviewed", "approved", "hr_staff", "mechanical");
+      expect(result).toEqual({
+        valid: false,
+        error: "Role hr_staff is not allowed to transition from reviewed to approved",
+      });
+    });
+
+    it("ceo が draft→reviewed できない", () => {
+      const result = validateTransition("draft", "reviewed", "ceo", "mechanical");
+      expect(result).toEqual({
+        valid: false,
+        error: "Role ceo is not allowed to transition from draft to reviewed",
+      });
+    });
+
+    it("hr_staff が failed→reviewed できない（hr_managerのみ）", () => {
+      const result = validateTransition("failed", "reviewed", "hr_staff", "mechanical");
+      expect(result).toEqual({
+        valid: false,
+        error: "Role hr_staff is not allowed to transition from failed to reviewed",
+      });
+    });
+
+    it("hr_manager が approved→processing できない（systemのみ）", () => {
+      const result = validateTransition("approved", "processing", "hr_manager", "mechanical");
+      expect(result).toEqual({
+        valid: false,
+        error: "Role hr_manager is not allowed to transition from approved to processing",
+      });
+    });
+  });
+
+  describe("changeType 不一致", () => {
+    it("hr_manager が discretionary reviewed→approved できない", () => {
+      const result = validateTransition("reviewed", "approved", "hr_manager", "discretionary");
+      expect(result).toEqual({
+        valid: false,
+        error: "Transition reviewed → approved requires changeType mechanical",
+      });
+    });
+
+    it("hr_manager が mechanical reviewed→pending_ceo_approval できない", () => {
+      const result = validateTransition(
+        "reviewed",
+        "pending_ceo_approval",
+        "hr_manager",
+        "mechanical",
+      );
+      expect(result).toEqual({
+        valid: false,
+        error: "Transition reviewed → pending_ceo_approval requires changeType discretionary",
+      });
+    });
+  });
+});
+
+describe("getNextActions", () => {
+  it("hr_manager + mechanical + reviewed → approved と draft が含まれる", () => {
+    const actions = getNextActions("reviewed", "hr_manager", "mechanical");
+    expect(actions).toContain("approved");
+    expect(actions).toContain("draft");
+    expect(actions).not.toContain("pending_ceo_approval");
+  });
+
+  it("hr_manager + discretionary + reviewed → pending_ceo_approval と draft が含まれる", () => {
+    const actions = getNextActions("reviewed", "hr_manager", "discretionary");
+    expect(actions).toContain("pending_ceo_approval");
+    expect(actions).toContain("draft");
+    expect(actions).not.toContain("approved");
+  });
+
+  it("system + mechanical + processing → completed と failed", () => {
+    const actions = getNextActions("processing", "system", "mechanical");
+    expect(actions).toContain("completed");
+    expect(actions).toContain("failed");
+  });
+
+  it("hr_staff + mechanical + draft → reviewed と rejected", () => {
+    const actions = getNextActions("draft", "hr_staff", "mechanical");
+    expect(actions).toContain("reviewed");
+    expect(actions).toContain("rejected");
+  });
+
+  it("ceo + discretionary + pending_ceo_approval → approved と draft", () => {
+    const actions = getNextActions("pending_ceo_approval", "ceo", "discretionary");
+    expect(actions).toContain("approved");
+    expect(actions).toContain("draft");
+  });
+
+  it("hr_staff + mechanical + completed → 空配列", () => {
+    const actions = getNextActions("completed", "hr_staff", "mechanical");
+    expect(actions).toEqual([]);
+  });
+
+  it("hr_staff に reviewed→approved の権限がないので含まれない", () => {
+    const actions = getNextActions("reviewed", "hr_staff", "mechanical");
+    expect(actions).not.toContain("approved");
+    expect(actions).not.toContain("pending_ceo_approval");
+    expect(actions).toContain("draft");
+  });
+});

--- a/packages/shared/src/approval.ts
+++ b/packages/shared/src/approval.ts
@@ -1,0 +1,86 @@
+import type { ActorRole, ChangeType, DraftStatus } from "./types.js";
+import { VALID_TRANSITIONS } from "./types.js";
+
+/**
+ * 遷移ごとの許可ロールマトリックス
+ * キー: "from→to" 形式
+ */
+const TRANSITION_ROLES: Record<string, readonly (ActorRole | "system")[]> = {
+  "draft→reviewed": ["hr_staff", "hr_manager"],
+  "draft→rejected": ["hr_staff", "hr_manager"],
+  "reviewed→approved": ["hr_manager"],
+  "reviewed→pending_ceo_approval": ["hr_manager"],
+  "reviewed→draft": ["hr_staff", "hr_manager"],
+  "pending_ceo_approval→approved": ["ceo"],
+  "pending_ceo_approval→draft": ["ceo"],
+  "rejected→draft": ["hr_staff", "hr_manager"],
+  "approved→processing": ["system"],
+  "processing→completed": ["system"],
+  "processing→failed": ["system"],
+  "failed→processing": ["hr_staff", "hr_manager"],
+  "failed→reviewed": ["hr_manager"],
+};
+
+/**
+ * changeType 制約がある遷移
+ * 制約がない遷移はここに含めない
+ */
+const CHANGE_TYPE_CONSTRAINTS: Record<string, ChangeType> = {
+  "reviewed→approved": "mechanical",
+  "reviewed→pending_ceo_approval": "discretionary",
+};
+
+/**
+ * ステータス遷移を検証する
+ *
+ * 検証順序:
+ * 1. VALID_TRANSITIONS に存在する遷移か
+ * 2. ロールに権限があるか
+ * 3. changeType 制約を満たすか
+ */
+export function validateTransition(
+  from: DraftStatus,
+  to: DraftStatus,
+  actorRole: ActorRole | "system",
+  changeType: ChangeType,
+): { valid: boolean; error?: string } {
+  // 1. 遷移自体が有効か
+  const validTargets = VALID_TRANSITIONS[from];
+  if (!validTargets.includes(to)) {
+    return { valid: false, error: `Invalid transition: ${from} → ${to}` };
+  }
+
+  const key = `${from}→${to}`;
+
+  // 2. ロール権限チェック
+  const allowedRoles = TRANSITION_ROLES[key];
+  if (!allowedRoles?.includes(actorRole)) {
+    return {
+      valid: false,
+      error: `Role ${actorRole} is not allowed to transition from ${from} to ${to}`,
+    };
+  }
+
+  // 3. changeType 制約チェック
+  const requiredChangeType = CHANGE_TYPE_CONSTRAINTS[key];
+  if (requiredChangeType && changeType !== requiredChangeType) {
+    return {
+      valid: false,
+      error: `Transition ${from} → ${to} requires changeType ${requiredChangeType}`,
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * 現在のステータス・ロール・変更種別から実行可能な遷移先を返す
+ */
+export function getNextActions(
+  current: DraftStatus,
+  actorRole: ActorRole | "system",
+  changeType: ChangeType,
+): DraftStatus[] {
+  const candidates = VALID_TRANSITIONS[current];
+  return candidates.filter((to) => validateTransition(current, to, actorRole, changeType).valid);
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export { getNextActions, validateTransition } from "./approval.js";
 export type {
   ActorRole,
   AllowanceType,
@@ -9,7 +10,6 @@ export type {
   EmploymentType,
   SalaryItemType,
 } from "./types.js";
-
 export {
   ACTOR_ROLES,
   ALLOWANCE_TYPES,


### PR DESCRIPTION
## Summary
- `validateTransition()`: ロールベース権限 + changeType 制約検証
- `getNextActions()`: 現在ステータス・ロール・変更種別から実行可能な遷移先一覧
- 機械的変更（hr_manager承認）と裁量的変更（CEO承認）の両フロー対応

## Changed Files
- `packages/shared/src/approval.ts` - validateTransition / getNextActions 実装
- `packages/shared/src/__tests__/approval.test.ts` - 29テストケース
- `packages/shared/src/index.ts` - export 追加

## Design
| 遷移 | 許可ロール | changeType 制約 |
|------|-----------|----------------|
| draft→reviewed | hr_staff, hr_manager | - |
| reviewed→approved | hr_manager | mechanical のみ |
| reviewed→pending_ceo_approval | hr_manager | discretionary のみ |
| pending_ceo_approval→approved | ceo | - |
| approved→processing | system | - |

## Test plan
- [x] 正常系: 全ロール × 全遷移
- [x] 異常系: 権限不足 → error メッセージ付き false
- [x] 異常系: changeType 不一致 → error メッセージ付き false
- [x] 異常系: 不正遷移 → error メッセージ付き false
- [x] getNextActions: system + processing → [completed, failed]
- [x] 合計 39テスト (status-transitions 10件 + approval 29件) 全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)