### PR TITLE
feat(salary): deterministic salary calculation engine (Task C)

### DIFF
--- a/packages/salary/package.json
+++ b/packages/salary/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@hr-system/salary",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "biome check src/",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@hr-system/shared": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/salary/src/__tests__/calculator.test.ts
+++ b/packages/salary/src/__tests__/calculator.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from "vitest";
+import {
+  applyMechanicalChange,
+  buildBreakdown,
+  generateDiscretionaryProposals,
+  toChangeItems,
+} from "../calculator.js";
+import type { AllowanceEntry, MasterData, PitchEntry, SalaryBreakdown } from "../types.js";
+
+/** テスト用マスターデータ */
+const PITCH_TABLE: PitchEntry[] = [
+  { grade: 1, step: 1, amount: 55000 },
+  { grade: 1, step: 2, amount: 60000 },
+  { grade: 2, step: 1, amount: 105000 },
+  { grade: 2, step: 5, amount: 125000 },
+  { grade: 3, step: 1, amount: 155000 },
+  { grade: 3, step: 5, amount: 175000 },
+  { grade: 3, step: 10, amount: 200000 },
+  { grade: 4, step: 1, amount: 205000 },
+  { grade: 4, step: 5, amount: 225000 },
+  { grade: 5, step: 10, amount: 300000 },
+];
+
+const ALLOWANCE_MASTER: AllowanceEntry[] = [
+  { allowanceType: "position", code: "MGR_SECT", name: "課長手当", amount: 30000 },
+  { allowanceType: "position", code: "LEAD", name: "主任手当", amount: 15000 },
+  { allowanceType: "position", code: "STAFF", name: "一般", amount: 0 },
+  { allowanceType: "region", code: "URBAN", name: "都市部手当", amount: 20000 },
+  { allowanceType: "region", code: "RURAL", name: "地方", amount: 0 },
+  { allowanceType: "qualification", code: "CARE_WORKER", name: "介護福祉士手当", amount: 10000 },
+  { allowanceType: "qualification", code: "NURSE", name: "看護師手当", amount: 15000 },
+  { allowanceType: "qualification", code: "NONE", name: "資格なし", amount: 0 },
+];
+
+const MASTER: MasterData = { pitchTable: PITCH_TABLE, allowanceMaster: ALLOWANCE_MASTER };
+
+/** テスト用現行給与 */
+const CURRENT: SalaryBreakdown = {
+  baseSalary: 155000,
+  positionAllowance: 15000,
+  regionAllowance: 20000,
+  qualificationAllowance: 0,
+  otherAllowance: 0,
+  total: 190000,
+};
+
+describe("buildBreakdown", () => {
+  it("total を正しく計算する", () => {
+    const result = buildBreakdown(155000, 15000, 20000, 0, 0);
+    expect(result.total).toBe(190000);
+  });
+
+  it("全ての内訳が保持される", () => {
+    const result = buildBreakdown(200000, 30000, 10000, 5000, 3000);
+    expect(result.baseSalary).toBe(200000);
+    expect(result.positionAllowance).toBe(30000);
+    expect(result.regionAllowance).toBe(10000);
+    expect(result.qualificationAllowance).toBe(5000);
+    expect(result.otherAllowance).toBe(3000);
+    expect(result.total).toBe(248000);
+  });
+});
+
+describe("toChangeItems", () => {
+  it("変更がない場合は isChanged = false", () => {
+    const items = toChangeItems(CURRENT, CURRENT);
+    for (const item of items) {
+      expect(item.isChanged).toBe(false);
+    }
+  });
+
+  it("baseSalary が変わった場合 isChanged = true", () => {
+    const after = { ...CURRENT, baseSalary: 175000, total: 210000 };
+    const items = toChangeItems(CURRENT, after);
+    const baseItem = items.find((i) => i.itemType === "base_salary");
+    expect(baseItem?.isChanged).toBe(true);
+    expect(baseItem?.beforeAmount).toBe(155000);
+    expect(baseItem?.afterAmount).toBe(175000);
+  });
+
+  it("全5項目が返る", () => {
+    const items = toChangeItems(CURRENT, CURRENT);
+    expect(items).toHaveLength(5);
+    const types = items.map((i) => i.itemType);
+    expect(types).toContain("base_salary");
+    expect(types).toContain("position_allowance");
+    expect(types).toContain("region_allowance");
+    expect(types).toContain("qualification_allowance");
+    expect(types).toContain("other_allowance");
+  });
+});
+
+describe("applyMechanicalChange - pitch_change", () => {
+  it("等級3号俸5 → 等級3号俸10 に昇給", () => {
+    const result = applyMechanicalChange(
+      { kind: "pitch_change", current: CURRENT, newGrade: 3, newStep: 10 },
+      MASTER,
+    );
+    expect(result.changeType).toBe("mechanical");
+    expect(result.before.baseSalary).toBe(155000);
+    expect(result.after.baseSalary).toBe(200000);
+    expect(result.after.positionAllowance).toBe(CURRENT.positionAllowance);
+    expect(result.after.total).toBe(200000 + 15000 + 20000);
+  });
+
+  it("存在しない grade/step は Error を throw", () => {
+    expect(() =>
+      applyMechanicalChange(
+        { kind: "pitch_change", current: CURRENT, newGrade: 9, newStep: 99 },
+        MASTER,
+      ),
+    ).toThrow(/Pitch entry not found/);
+  });
+
+  it("baseSalary 変更項目の isChanged = true", () => {
+    const result = applyMechanicalChange(
+      { kind: "pitch_change", current: CURRENT, newGrade: 3, newStep: 10 },
+      MASTER,
+    );
+    const base = result.items.find((i) => i.itemType === "base_salary");
+    expect(base?.isChanged).toBe(true);
+  });
+});
+
+describe("applyMechanicalChange - add_allowance", () => {
+  it("資格手当（介護福祉士）を追加する", () => {
+    const result = applyMechanicalChange(
+      {
+        kind: "add_allowance",
+        current: CURRENT,
+        allowanceType: "qualification",
+        allowanceCode: "CARE_WORKER",
+      },
+      MASTER,
+    );
+    expect(result.changeType).toBe("mechanical");
+    expect(result.before.qualificationAllowance).toBe(0);
+    expect(result.after.qualificationAllowance).toBe(10000);
+    expect(result.after.total).toBe(CURRENT.total + 10000);
+  });
+
+  it("役職手当を追加する", () => {
+    const result = applyMechanicalChange(
+      {
+        kind: "add_allowance",
+        current: CURRENT,
+        allowanceType: "position",
+        allowanceCode: "MGR_SECT",
+      },
+      MASTER,
+    );
+    expect(result.after.positionAllowance).toBe(30000);
+    expect(result.after.total).toBe(CURRENT.total - CURRENT.positionAllowance + 30000);
+  });
+
+  it("存在しない allowanceCode は Error を throw", () => {
+    expect(() =>
+      applyMechanicalChange(
+        {
+          kind: "add_allowance",
+          current: CURRENT,
+          allowanceType: "qualification",
+          allowanceCode: "NONEXISTENT",
+        },
+        MASTER,
+      ),
+    ).toThrow(/Allowance not found/);
+  });
+});
+
+describe("applyMechanicalChange - remove_allowance", () => {
+  it("地域手当を削除する", () => {
+    const result = applyMechanicalChange(
+      { kind: "remove_allowance", current: CURRENT, allowanceType: "region" },
+      MASTER,
+    );
+    expect(result.before.regionAllowance).toBe(20000);
+    expect(result.after.regionAllowance).toBe(0);
+    expect(result.after.total).toBe(CURRENT.total - 20000);
+  });
+});
+
+describe("generateDiscretionaryProposals", () => {
+  it("最低2案を返す", () => {
+    const proposals = generateDiscretionaryProposals(
+      { current: CURRENT, targetTotal: 250000 },
+      MASTER,
+    );
+    expect(proposals.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("各提案の changeType が discretionary", () => {
+    const proposals = generateDiscretionaryProposals(
+      { current: CURRENT, targetTotal: 250000 },
+      MASTER,
+    );
+    for (const p of proposals) {
+      expect(p.result.changeType).toBe("discretionary");
+    }
+  });
+
+  it("各提案の proposalNumber が 1 から連番", () => {
+    const proposals = generateDiscretionaryProposals(
+      { current: CURRENT, targetTotal: 250000 },
+      MASTER,
+    );
+    proposals.forEach((p, idx) => {
+      expect(p.proposalNumber).toBe(idx + 1);
+    });
+  });
+
+  it("各提案に description がある", () => {
+    const proposals = generateDiscretionaryProposals(
+      { current: CURRENT, targetTotal: 250000 },
+      MASTER,
+    );
+    for (const p of proposals) {
+      expect(p.description.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("before の total が current.total と一致する", () => {
+    const proposals = generateDiscretionaryProposals(
+      { current: CURRENT, targetTotal: 250000 },
+      MASTER,
+    );
+    for (const p of proposals) {
+      expect(p.result.before.total).toBe(CURRENT.total);
+    }
+  });
+
+  it("after の total がそれぞれ target に近い（±20%以内）", () => {
+    const target = 250000;
+    const proposals = generateDiscretionaryProposals(
+      { current: CURRENT, targetTotal: target },
+      MASTER,
+    );
+    for (const p of proposals) {
+      expect(Math.abs(p.result.after.total - target) / target).toBeLessThan(0.2);
+    }
+  });
+
+  it("Pitchテーブルが空のとき空配列を返す", () => {
+    const emptyMaster: MasterData = { pitchTable: [], allowanceMaster: ALLOWANCE_MASTER };
+    const proposals = generateDiscretionaryProposals(
+      { current: CURRENT, targetTotal: 250000 },
+      emptyMaster,
+    );
+    expect(proposals).toEqual([]);
+  });
+
+  it("提案の baseSalary がいずれも Pitch テーブルの有効な値である", () => {
+    const proposals = generateDiscretionaryProposals(
+      { current: CURRENT, targetTotal: 250000 },
+      MASTER,
+    );
+    const validAmounts = new Set(PITCH_TABLE.map((p) => p.amount));
+    for (const p of proposals) {
+      expect(validAmounts.has(p.result.after.baseSalary)).toBe(true);
+    }
+  });
+});

--- a/packages/salary/src/calculator.ts
+++ b/packages/salary/src/calculator.ts
@@ -1,0 +1,189 @@
+import type { SalaryItemType } from "@hr-system/shared";
+import type {
+  DiscretionaryChangeParams,
+  MasterData,
+  MechanicalChangeParams,
+  SalaryBreakdown,
+  SalaryCalculationResult,
+  SalaryChangeItem,
+  SalaryProposal,
+} from "./types.js";
+
+/** 給与内訳を組み立て、total を計算して返す */
+export function buildBreakdown(
+  baseSalary: number,
+  positionAllowance: number,
+  regionAllowance: number,
+  qualificationAllowance: number,
+  otherAllowance: number,
+): SalaryBreakdown {
+  return {
+    baseSalary,
+    positionAllowance,
+    regionAllowance,
+    qualificationAllowance,
+    otherAllowance,
+    total:
+      baseSalary + positionAllowance + regionAllowance + qualificationAllowance + otherAllowance,
+  };
+}
+
+/** Before/After から変更項目リストを生成する */
+export function toChangeItems(before: SalaryBreakdown, after: SalaryBreakdown): SalaryChangeItem[] {
+  const fields: Array<{ itemType: SalaryItemType; itemName: string; key: keyof SalaryBreakdown }> =
+    [
+      { itemType: "base_salary", itemName: "基本給", key: "baseSalary" },
+      { itemType: "position_allowance", itemName: "役職手当", key: "positionAllowance" },
+      { itemType: "region_allowance", itemName: "地域手当", key: "regionAllowance" },
+      {
+        itemType: "qualification_allowance",
+        itemName: "資格手当",
+        key: "qualificationAllowance",
+      },
+      { itemType: "other_allowance", itemName: "その他手当", key: "otherAllowance" },
+    ];
+
+  return fields.map(({ itemType, itemName, key }) => ({
+    itemType,
+    itemName,
+    beforeAmount: before[key] as number,
+    afterAmount: after[key] as number,
+    isChanged: before[key] !== after[key],
+  }));
+}
+
+/**
+ * 機械的変更を適用して計算結果を返す（ADR-007: 確定的コードで計算）
+ *
+ * @throws {Error} Pitch エントリが見つからない場合
+ * @throws {Error} 手当コードが見つからない場合
+ */
+export function applyMechanicalChange(
+  params: MechanicalChangeParams,
+  master: MasterData,
+): SalaryCalculationResult {
+  const before = params.current;
+  let after: SalaryBreakdown;
+
+  switch (params.kind) {
+    case "pitch_change": {
+      const entry = master.pitchTable.find(
+        (p) => p.grade === params.newGrade && p.step === params.newStep,
+      );
+      if (!entry) {
+        throw new Error(`Pitch entry not found: grade=${params.newGrade}, step=${params.newStep}`);
+      }
+      after = buildBreakdown(
+        entry.amount,
+        before.positionAllowance,
+        before.regionAllowance,
+        before.qualificationAllowance,
+        before.otherAllowance,
+      );
+      break;
+    }
+
+    case "add_allowance": {
+      const entry = master.allowanceMaster.find(
+        (a) => a.allowanceType === params.allowanceType && a.code === params.allowanceCode,
+      );
+      if (!entry) {
+        throw new Error(
+          `Allowance not found: type=${params.allowanceType}, code=${params.allowanceCode}`,
+        );
+      }
+      after = buildBreakdown(
+        before.baseSalary,
+        params.allowanceType === "position" ? entry.amount : before.positionAllowance,
+        params.allowanceType === "region" ? entry.amount : before.regionAllowance,
+        params.allowanceType === "qualification" ? entry.amount : before.qualificationAllowance,
+        before.otherAllowance,
+      );
+      break;
+    }
+
+    case "remove_allowance": {
+      after = buildBreakdown(
+        before.baseSalary,
+        params.allowanceType === "position" ? 0 : before.positionAllowance,
+        params.allowanceType === "region" ? 0 : before.regionAllowance,
+        params.allowanceType === "qualification" ? 0 : before.qualificationAllowance,
+        before.otherAllowance,
+      );
+      break;
+    }
+  }
+
+  return {
+    changeType: "mechanical",
+    before,
+    after,
+    items: toChangeItems(before, after),
+  };
+}
+
+/**
+ * 裁量的変更の複数提案を生成する（ADR-007: 確定的コードで計算）
+ *
+ * 目標合計額に近い Pitch エントリをベースに最大3案を提案する。
+ * 各提案は baseSalary のみを変更し、他の手当は現行のまま維持する。
+ */
+export function generateDiscretionaryProposals(
+  params: DiscretionaryChangeParams,
+  master: MasterData,
+): SalaryProposal[] {
+  const { current, targetTotal } = params;
+  const { pitchTable } = master;
+
+  if (pitchTable.length === 0) {
+    return [];
+  }
+
+  // 目標 baseSalary = targetTotal - 現行の手当合計
+  const currentAllowances =
+    current.positionAllowance +
+    current.regionAllowance +
+    current.qualificationAllowance +
+    current.otherAllowance;
+  const targetBase = targetTotal - currentAllowances;
+
+  // Pitch エントリを目標 baseSalary との差の絶対値でソート
+  const sorted = [...pitchTable].sort(
+    (a, b) => Math.abs(a.amount - targetBase) - Math.abs(b.amount - targetBase),
+  );
+
+  // 重複した amount を除去して上位3件を選ぶ
+  const seen = new Set<number>();
+  const candidates = sorted.filter((entry) => {
+    if (seen.has(entry.amount)) return false;
+    seen.add(entry.amount);
+    return true;
+  });
+
+  return candidates.slice(0, 3).map((entry, idx) => {
+    const after = buildBreakdown(
+      entry.amount,
+      current.positionAllowance,
+      current.regionAllowance,
+      current.qualificationAllowance,
+      current.otherAllowance,
+    );
+    const diff = after.total - current.total;
+    const sign = diff >= 0 ? "+" : "";
+    const description =
+      `提案${idx + 1}: 基本給 ${entry.amount.toLocaleString()}円 ` +
+      `(等級${entry.grade}/号俸${entry.step}) → ` +
+      `合計 ${after.total.toLocaleString()}円 (${sign}${diff.toLocaleString()}円)`;
+
+    return {
+      proposalNumber: idx + 1,
+      description,
+      result: {
+        changeType: "discretionary" as const,
+        before: current,
+        after,
+        items: toChangeItems(current, after),
+      },
+    };
+  });
+}

--- a/packages/salary/src/index.ts
+++ b/packages/salary/src/index.ts
@@ -1,0 +1,17 @@
+export {
+  applyMechanicalChange,
+  buildBreakdown,
+  generateDiscretionaryProposals,
+  toChangeItems,
+} from "./calculator.js";
+export type {
+  AllowanceEntry,
+  DiscretionaryChangeParams,
+  MasterData,
+  MechanicalChangeParams,
+  PitchEntry,
+  SalaryBreakdown,
+  SalaryCalculationResult,
+  SalaryChangeItem,
+  SalaryProposal,
+} from "./types.js";

--- a/packages/salary/src/types.ts
+++ b/packages/salary/src/types.ts
@@ -1,0 +1,84 @@
+import type { AllowanceType, ChangeType, SalaryItemType } from "@hr-system/shared";
+
+/** 給与内訳（計算入出力用） */
+export interface SalaryBreakdown {
+  baseSalary: number;
+  positionAllowance: number;
+  regionAllowance: number;
+  qualificationAllowance: number;
+  otherAllowance: number;
+  total: number;
+}
+
+/** 変更項目（Before/After 差分） */
+export interface SalaryChangeItem {
+  itemType: SalaryItemType;
+  itemName: string;
+  beforeAmount: number;
+  afterAmount: number;
+  isChanged: boolean;
+}
+
+/** Pitchテーブルエントリ（計算用・DB 非依存） */
+export interface PitchEntry {
+  grade: number;
+  step: number;
+  amount: number;
+}
+
+/** 手当マスターエントリ（計算用・DB 非依存） */
+export interface AllowanceEntry {
+  allowanceType: AllowanceType;
+  code: string;
+  name: string;
+  amount: number;
+}
+
+/** 計算に必要なマスターデータ（DB から注入） */
+export interface MasterData {
+  pitchTable: PitchEntry[];
+  allowanceMaster: AllowanceEntry[];
+}
+
+/** 機械的変更パラメータ（LLM が抽出した値を受け取る） */
+export type MechanicalChangeParams =
+  | {
+      kind: "pitch_change";
+      current: SalaryBreakdown;
+      newGrade: number;
+      newStep: number;
+    }
+  | {
+      kind: "add_allowance";
+      current: SalaryBreakdown;
+      allowanceType: AllowanceType;
+      allowanceCode: string;
+    }
+  | {
+      kind: "remove_allowance";
+      current: SalaryBreakdown;
+      allowanceType: AllowanceType;
+    };
+
+/** 裁量的変更パラメータ */
+export interface DiscretionaryChangeParams {
+  current: SalaryBreakdown;
+  /** 目標合計支給額 */
+  targetTotal: number;
+}
+
+/** 給与計算結果（単一案） */
+export interface SalaryCalculationResult {
+  changeType: ChangeType;
+  before: SalaryBreakdown;
+  after: SalaryBreakdown;
+  items: SalaryChangeItem[];
+}
+
+/** 裁量的変更の提案（複数案の1つ） */
+export interface SalaryProposal {
+  proposalNumber: number;
+  /** 人事担当者向けの提案説明 */
+  description: string;
+  result: SalaryCalculationResult;
+}

--- a/packages/salary/tsconfig.build.json
+++ b/packages/salary/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "outDir": "./dist"
+  }
+}

--- a/packages/salary/tsconfig.json
+++ b/packages/salary/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,19 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
 
+  packages/salary:
+    dependencies:
+      '@hr-system/shared':
+        specifier: workspace:*
+        version: link:../shared
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.11)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.21.0)
+
   packages/shared:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary

- `packages/salary` パッケージを新規追加し、ADR-007 に従った確定的給与計算エンジンを実装
- LLM による金銭計算を完全に排除し、Pitch テーブル・手当マスターを参照した確定的コードで計算
- 機械的変更（Pitch 昇格・手当追加/削除）と裁量的変更（目標合計額ベース複数提案）の 2 種類をサポート

## 変更内容

| ファイル | 内容 |
|--------|------|
| `packages/salary/src/types.ts` | `SalaryBreakdown`, `MechanicalChangeParams`, `DiscretionaryChangeParams`, `SalaryProposal` 等の型定義 |
| `packages/salary/src/calculator.ts` | `buildBreakdown` / `toChangeItems` / `applyMechanicalChange` / `generateDiscretionaryProposals` の実装 |
| `packages/salary/src/__tests__/calculator.test.ts` | 20 テスト（境界値・異常系含む） |
| `packages/salary/src/index.ts` | パブリック API エクスポート |

## ADR 準拠

- **ADR-007**: 金銭計算は LLM に委任せず確定的コードで実行
  - `applyMechanicalChange`: Pitch テーブル / 手当マスターを直接参照して計算
  - `generateDiscretionaryProposals`: 目標合計額に最も近い Pitch エントリを最大 3 案選出

## Test plan

- [x] `buildBreakdown`: total 計算正確性、全内訳フィールドの保持
- [x] `toChangeItems`: isChanged フラグ、5 項目の完全性
- [x] `applyMechanicalChange - pitch_change`: Pitch 昇格、存在しない grade/step でエラー
- [x] `applyMechanicalChange - add_allowance`: 資格手当・役職手当の追加、不正コードでエラー
- [x] `applyMechanicalChange - remove_allowance`: 地域手当の削除
- [x] `generateDiscretionaryProposals`: 最低 2 案、changeType・proposalNumber・description の検証、目標±20%以内、Pitch テーブル空で空配列、baseSalary が有効 Pitch 値
- [x] lint (Biome): No issues
- [x] typecheck (tsc): No errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)