### PR TITLE
feat(infra): API + Web Cloud Run デプロイ Dockerfile 追加

### DIFF
--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,67 @@
+# ============================================================================
+# HR System API — Multi-stage Docker Build
+# Base: node:22-slim
+# Package manager: pnpm (version from packageManager field in package.json)
+#
+# Stage 1 (builder): pnpm install + turbo build --filter=@hr-system/api...
+# Stage 2 (runner):  pnpm install --prod + dist/ のみコピー
+# ============================================================================
+
+FROM node:22-slim AS base
+WORKDIR /app
+
+# corepack 有効化（package.json の packageManager フィールドに従い pnpm を使用）
+RUN corepack enable
+
+# ===== Stage 1: builder =====
+FROM base AS builder
+
+# 依存関係のキャッシュ効率化:
+# package.json ファイルのみを先にコピーして pnpm install を実行する
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/db/package.json ./packages/db/
+COPY packages/shared/package.json ./packages/shared/
+
+# 全依存関係をインストール（devDeps 含む: tsc, turbo が必要）
+RUN pnpm install --frozen-lockfile
+
+# ソースコードをコピー
+COPY apps/api/src ./apps/api/src
+COPY apps/api/tsconfig.json ./apps/api/
+COPY apps/api/tsconfig.build.json ./apps/api/
+COPY packages/db/src ./packages/db/src
+COPY packages/db/tsconfig.json ./packages/db/
+COPY packages/db/tsconfig.build.json ./packages/db/
+COPY packages/shared/src ./packages/shared/src
+COPY packages/shared/tsconfig.json ./packages/shared/
+COPY packages/shared/tsconfig.build.json ./packages/shared/
+COPY tsconfig.json ./
+
+# API とその依存パッケージをビルド（shared → db → api の順）
+RUN pnpm turbo build --filter=@hr-system/api...
+
+# ===== Stage 2: runner =====
+FROM base AS runner
+
+ENV NODE_ENV=production
+
+# 本番依存のみインストール（devDeps 除外）
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY apps/api/package.json ./apps/api/
+COPY packages/db/package.json ./packages/db/
+COPY packages/shared/package.json ./packages/shared/
+
+RUN pnpm install --frozen-lockfile --prod
+
+# ビルド済み JS ファイルのみコピー（src は不要）
+COPY --from=builder /app/apps/api/dist ./apps/api/dist
+COPY --from=builder /app/packages/db/dist ./packages/db/dist
+COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
+
+EXPOSE 3001
+
+# 非 root ユーザーで実行
+USER node
+
+CMD ["node", "apps/api/dist/index.js"]

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,70 @@
+# ============================================================================
+# HR System Web — Multi-stage Docker Build (Next.js standalone)
+# Base: node:22-slim
+# Package manager: pnpm (version from packageManager field in package.json)
+#
+# Stage 1 (builder): pnpm install + turbo build --filter=@hr-system/web...
+# Stage 2 (runner):  .next/standalone のみコピー（node_modules 同梱）
+# ============================================================================
+
+FROM node:22-slim AS base
+WORKDIR /app
+
+# corepack 有効化（package.json の packageManager フィールドに従い pnpm を使用）
+RUN corepack enable
+
+# ===== Stage 1: builder =====
+FROM base AS builder
+
+# 依存関係のキャッシュ効率化:
+# package.json ファイルのみを先にコピーして pnpm install を実行する
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json ./
+COPY apps/web/package.json ./apps/web/
+COPY packages/db/package.json ./packages/db/
+COPY packages/shared/package.json ./packages/shared/
+
+# 全依存関係をインストール（devDeps 含む: next build, turbo が必要）
+RUN pnpm install --frozen-lockfile
+
+# ソースコードと設定ファイルをコピー
+COPY apps/web/src ./apps/web/src
+COPY apps/web/tsconfig.json ./apps/web/
+COPY apps/web/next.config.ts ./apps/web/
+COPY apps/web/postcss.config.mjs ./apps/web/
+COPY apps/web/components.json ./apps/web/
+COPY apps/web/next-env.d.ts ./apps/web/
+COPY packages/db/src ./packages/db/src
+COPY packages/db/tsconfig.json ./packages/db/
+COPY packages/db/tsconfig.build.json ./packages/db/
+COPY packages/shared/src ./packages/shared/src
+COPY packages/shared/tsconfig.json ./packages/shared/
+COPY packages/shared/tsconfig.build.json ./packages/shared/
+COPY tsconfig.json ./
+
+# Web とその依存パッケージをビルド（shared → db → web の順）
+# NEXT_TELEMETRY_DISABLED: ビルド時の telemetry 送信を無効化
+ENV NEXT_TELEMETRY_DISABLED=1
+RUN pnpm turbo build --filter=@hr-system/web...
+
+# ===== Stage 2: runner =====
+FROM base AS runner
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+# Cloud Run から外部アクセスを受け付けるため 0.0.0.0 をバインド
+ENV HOSTNAME=0.0.0.0
+ENV PORT=3000
+
+# standalone ビルドに node_modules が同梱されているため pnpm install 不要
+# monorepo の standalone は apps/web/.next/standalone/ 配下にパス構造が再現される
+COPY --from=builder /app/apps/web/.next/standalone ./
+COPY --from=builder /app/apps/web/.next/static ./apps/web/.next/static
+# public/ は現在未使用のためスキップ
+# COPY --from=builder /app/apps/web/public ./apps/web/public
+
+EXPOSE 3000
+
+# 非 root ユーザーで実行
+USER node
+
+CMD ["node", "apps/web/server.js"]


### PR DESCRIPTION
## Summary

- `apps/api/Dockerfile` 追加 — Worker パターンを踏襲した multi-stage build（port 3001）
- `apps/web/Dockerfile` 追加 — Next.js standalone 専用構成（port 3000、HOSTNAME=0.0.0.0）
- monorepo standalone の実際のサーバーパス確認済み: `/app/apps/web/server.js`

## デプロイ結果

| サービス | URL | 確認 |
|---------|-----|------|
| API     | https://hr-api-1021020088552.asia-northeast1.run.app | `{"status":"healthy"}` ✓ |
| Web     | https://hr-web-1021020088552.asia-northeast1.run.app | 未認証 → /login 307 ✓ |

## インフラ設定（このPR外で実施済み）

- SA 作成: `hr-api`, `hr-web`（roles/datastore.user + roles/secretmanager.secretAccessor）
- Secret Manager: `AUTH_SECRET`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET` 登録済み
- Artifact Registry クリーンアップポリシー: 最新2件保持に設定

## 残作業（OAuth redirect URI）

Google OAuth コンソールで以下を追加:
- 承認済み JS オリジン: `https://hr-web-1021020088552.asia-northeast1.run.app`
- リダイレクト URI: `https://hr-web-1021020088552.asia-northeast1.run.app/api/auth/callback/google`

## Test plan

- [x] `curl /api/health` → `{"status":"healthy",...}`
- [x] `/login` → HTTP 200
- [x] `/` → 307 → `/login`（未認証リダイレクト）
- [ ] Google OAuth ログイン（OAuth redirect URI 追加後）
- [ ] ダッシュボード統計データ表示（ログイン後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)