### PR TITLE
feat(web): メンションを本文にインライン表示

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -2,7 +2,7 @@ import { ArrowLeft, MessageSquare, Paperclip } from "lucide-react";
 import Link from "next/link";
 import { AttachmentList } from "@/components/chat/attachment-list";
 import { MentionBadge } from "@/components/chat/mention-badge";
-import { RichContent } from "@/components/chat/rich-content";
+import { ContentWithMentions } from "@/components/chat/rich-content";
 import { ThreadView } from "@/components/chat/thread-view";
 import { ReclassifyForm } from "@/components/reclassify-form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -120,9 +120,9 @@ export default async function ChatMessageDetailPage({ params }: Props) {
               </div>
             )}
 
-            {/* 本文（リッチテキスト対応） */}
+            {/* 本文（メンションインライン対応） */}
             <div className="rounded-md bg-muted p-4 text-base">
-              <RichContent formattedContent={msg.formattedContent} content={msg.content} />
+              <ContentWithMentions formattedContent={msg.formattedContent} content={msg.content} />
             </div>
 
             {/* 添付ファイル */}

--- a/apps/web/src/app/(protected)/chat-messages/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/page.tsx
@@ -1,6 +1,5 @@
 import Link from "next/link";
-import { MentionBadge } from "@/components/chat/mention-badge";
-import { stripHtml } from "@/components/chat/rich-content";
+import { ContentWithMentions, stripHtml } from "@/components/chat/rich-content";
 import { Button } from "@/components/ui/button";
 import {
   Table,
@@ -272,23 +271,15 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
                     </TableCell>
                     <TableCell>
                       <Link href={`/chat-messages/${msg.id}`} className="block">
-                        <div className="flex max-w-[400px] flex-col gap-1">
+                        <div className="max-w-[400px]">
                           {msg.isEdited && (
-                            <span className="text-xs text-muted-foreground">[編集済]</span>
+                            <span className="text-xs text-muted-foreground">[編集済] </span>
                           )}
-                          {msg.mentionedUsers.length > 0 && (
-                            <div className="flex flex-wrap gap-1">
-                              {msg.mentionedUsers.slice(0, 3).map((u) => (
-                                <MentionBadge key={u.userId} displayName={u.displayName} />
-                              ))}
-                              {msg.mentionedUsers.length > 3 && (
-                                <span className="text-xs text-muted-foreground">
-                                  +{msg.mentionedUsers.length - 3}人
-                                </span>
-                              )}
-                            </div>
-                          )}
-                          <span className="truncate text-sm">{preview}</span>
+                          <ContentWithMentions
+                            content={preview}
+                            formattedContent={null}
+                            className="line-clamp-2 text-sm"
+                          />
                         </div>
                       </Link>
                     </TableCell>

--- a/apps/web/src/components/chat/rich-content.tsx
+++ b/apps/web/src/components/chat/rich-content.tsx
@@ -6,6 +6,7 @@
  *   <b>, <i>, <strike>, <font color="...">, <a href="...">, <br>, <pre>, <ul>, <li>
  * DOMPurify 相当のサニタイズを独自実装する（外部依存を避けるため）。
  */
+import { MentionBadge } from "./mention-badge";
 
 interface RichContentProps {
   /** リッチテキスト（HTML形式）。null の場合は content フォールバック */
@@ -91,4 +92,40 @@ export function RichContent({ formattedContent, content }: RichContentProps) {
   }
 
   return <div className="whitespace-pre-wrap leading-relaxed">{content}</div>;
+}
+
+/**
+ * メンションをインラインバッジで表示するコンテンツコンポーネント。
+ * プレーンテキスト内の @数字.名前 パターンを MentionBadge に変換する。
+ * formattedContent がある場合は RichContent と同じHTML表示にフォールバックする。
+ */
+export function ContentWithMentions({
+  content,
+  formattedContent,
+  className,
+}: RichContentProps & { className?: string }) {
+  if (formattedContent) {
+    const safeHtml = sanitizeHtml(formattedContent);
+    return (
+      <div
+        className={`leading-relaxed [&_a]:text-primary [&_a]:underline [&_b]:font-bold [&_i]:italic [&_pre]:rounded [&_pre]:bg-muted [&_pre]:p-2 [&_pre]:font-mono [&_pre]:text-xs [&_s]:line-through [&_strike]:line-through [&_ul]:list-inside [&_ul]:list-disc ${className ?? ""}`}
+        // biome-ignore lint/security/noDangerouslySetInnerHtml: sanitized above
+        dangerouslySetInnerHTML={{ __html: safeHtml }}
+      />
+    );
+  }
+
+  // @数字.名前 パターン（例: @159.有川智浩）をインラインバッジに変換
+  const parts = content.split(/(@\d+\.[^\s\n@,、。！？]+)/g);
+  return (
+    <div className={`whitespace-pre-wrap leading-relaxed ${className ?? ""}`}>
+      {parts.map((part) => {
+        const match = part.match(/^@\d+\.(.+)$/);
+        if (match?.[1]) {
+          return <MentionBadge key={part} displayName={match[1]} />;
+        }
+        return part;
+      })}
+    </div>
+  );
 }

--- a/apps/web/src/components/chat/thread-view.tsx
+++ b/apps/web/src/components/chat/thread-view.tsx
@@ -3,7 +3,7 @@
  * 親メッセージ → 返信メッセージのインデント付き会話ビューを表示する。
  */
 import { MessageSquare } from "lucide-react";
-import { RichContent } from "./rich-content";
+import { ContentWithMentions } from "./rich-content";
 
 interface ThreadMessage {
   id: string;
@@ -66,7 +66,10 @@ function MessageBubble({ message, isReply }: { message: ThreadMessage; isReply: 
           </time>
         </div>
         <div className="rounded-md bg-muted/40 px-3 py-2 text-sm">
-          <RichContent formattedContent={message.formattedContent} content={message.content} />
+          <ContentWithMentions
+            formattedContent={message.formattedContent}
+            content={message.content}
+          />
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

- `ContentWithMentions` コンポーネントを新規追加（`rich-content.tsx`）
- `@数字.名前` パターン（例: `@159.有川智浩`）を正規表現で分割し、`MentionBadge` をインライン挿入
- スレッドビュー・メッセージ一覧・詳細ページの3箇所に適用

### 変更前
- 一覧ページ: メンションが本文の**上**に別行バッジとして表示（本文と分離）
- スレッドビュー: `@1990.今里安江` がプレーンテキストのまま表示

### 変更後
- 一覧ページ: 本文内にインラインバッジで表示（`line-clamp-2` で2行折り返し）
- スレッドビュー: 本文中の `@ID.名前` が MentionBadge に変換
- 詳細ページ: メッセージ本文内でインライン表示（「メンション」サマリー欄は維持）

## Test plan

- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過（警告2件は既存）
- [x] `pnpm test` 通過（16テスト全 passed）
- [ ] 一覧ページでメンション付きメッセージのインライン表示確認
- [ ] スレッド詳細でメンションがバッジ表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)