### PR TITLE
feat(infra): CI/CD DRY化・Terraform本番同期・Dockerfile EXPOSE修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   pull_request:
     branches: [main]
+  workflow_call: # deploy.yml の ci-gate ジョブから呼び出し可能
 
 jobs:
   quality:

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -1,0 +1,70 @@
+name: Deploy Service (Reusable)
+# 1サービス分のビルド + Cloud Run デプロイを行う再利用可能ワークフロー
+
+on:
+  workflow_call:
+    inputs:
+      service_name:
+        description: "Cloud Run サービス名 (例: hr-api)"
+        type: string
+        required: true
+      app_name:
+        description: "Artifact Registry イメージ名 (例: api, web, worker)"
+        type: string
+        required: true
+      dockerfile_path:
+        description: "Dockerfile の相対パス (例: apps/api/Dockerfile)"
+        type: string
+        required: true
+    secrets:
+      WIF_PROVIDER:
+        required: true
+      WIF_SERVICE_ACCOUNT:
+        required: true
+
+env:
+  PROJECT_ID: hr-system-487809
+  REGION: asia-northeast1
+  AR_REPO: hr-system
+
+jobs:
+  deploy:
+    name: Deploy ${{ inputs.service_name }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Authenticate to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
+          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
+
+      - name: Build & Push image
+        run: |
+          IMAGE="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/${{ inputs.app_name }}"
+          docker build \
+            -t "${IMAGE}:${{ github.sha }}" \
+            -t "${IMAGE}:latest" \
+            -f ${{ inputs.dockerfile_path }} \
+            .
+          docker push "${IMAGE}:${{ github.sha }}"
+          docker push "${IMAGE}:latest"
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy ${{ inputs.service_name }} \
+            --image "${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/${{ inputs.app_name }}:${{ github.sha }}" \
+            --region ${{ env.REGION }} \
+            --platform managed \
+            --quiet

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,16 +4,17 @@ on:
   push:
     branches: [main]
 
-env:
-  PROJECT_ID: hr-system-487809
-  REGION: asia-northeast1
-  AR_REPO: hr-system
-
 jobs:
+  # CI ゲート: lint + typecheck + test をパスしてからデプロイ
+  ci-gate:
+    name: CI Gate
+    uses: ./.github/workflows/ci.yml
+
   # 変更検知: 対象サービスの判定
   detect-changes:
     name: Detect changed services
     runs-on: ubuntu-latest
+    needs: ci-gate
     outputs:
       api: ${{ steps.filter.outputs.api }}
       web: ${{ steps.filter.outputs.web }}
@@ -29,142 +30,59 @@ jobs:
           filters: |
             api:
               - 'apps/api/**'
-              - 'packages/**'
+              - 'packages/db/**'
+              - 'packages/shared/**'
               - 'pnpm-lock.yaml'
             web:
               - 'apps/web/**'
-              - 'packages/**'
+              - 'packages/db/**'
+              - 'packages/shared/**'
               - 'pnpm-lock.yaml'
             worker:
               - 'apps/worker/**'
-              - 'packages/**'
+              - 'packages/db/**'
+              - 'packages/shared/**'
+              - 'packages/ai/**'
               - 'pnpm-lock.yaml'
 
   # API サービスのデプロイ
   deploy-api:
     name: Deploy API
-    runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.api == 'true'
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker
-        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
-
-      - name: Build & Push API image
-        run: |
-          IMAGE="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/api"
-          docker build \
-            -t "${IMAGE}:${{ github.sha }}" \
-            -t "${IMAGE}:latest" \
-            -f apps/api/Dockerfile \
-            .
-          docker push "${IMAGE}:${{ github.sha }}"
-          docker push "${IMAGE}:latest"
-
-      - name: Deploy API to Cloud Run
-        run: |
-          gcloud run deploy hr-api \
-            --image "${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/api:${{ github.sha }}" \
-            --region ${{ env.REGION }} \
-            --platform managed \
-            --quiet
+    uses: ./.github/workflows/deploy-service.yml
+    with:
+      service_name: hr-api
+      app_name: api
+      dockerfile_path: apps/api/Dockerfile
+    secrets:
+      WIF_PROVIDER: ${{ secrets.WIF_PROVIDER }}
+      WIF_SERVICE_ACCOUNT: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
   # Web サービスのデプロイ
   deploy-web:
     name: Deploy Web
-    runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.web == 'true'
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker
-        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
-
-      - name: Build & Push Web image
-        run: |
-          IMAGE="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/web"
-          docker build \
-            -t "${IMAGE}:${{ github.sha }}" \
-            -t "${IMAGE}:latest" \
-            -f apps/web/Dockerfile \
-            .
-          docker push "${IMAGE}:${{ github.sha }}"
-          docker push "${IMAGE}:latest"
-
-      - name: Deploy Web to Cloud Run
-        run: |
-          gcloud run deploy hr-web \
-            --image "${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/web:${{ github.sha }}" \
-            --region ${{ env.REGION }} \
-            --platform managed \
-            --quiet
+    uses: ./.github/workflows/deploy-service.yml
+    with:
+      service_name: hr-web
+      app_name: web
+      dockerfile_path: apps/web/Dockerfile
+    secrets:
+      WIF_PROVIDER: ${{ secrets.WIF_PROVIDER }}
+      WIF_SERVICE_ACCOUNT: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
   # Worker サービスのデプロイ
   deploy-worker:
     name: Deploy Worker
-    runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.worker == 'true'
-    permissions:
-      contents: read
-      id-token: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
-          service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
-
-      - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
-      - name: Configure Docker
-        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev
-
-      - name: Build & Push Worker image
-        run: |
-          IMAGE="${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/worker"
-          docker build \
-            -t "${IMAGE}:${{ github.sha }}" \
-            -t "${IMAGE}:latest" \
-            -f apps/worker/Dockerfile \
-            .
-          docker push "${IMAGE}:${{ github.sha }}"
-          docker push "${IMAGE}:latest"
-
-      - name: Deploy Worker to Cloud Run
-        run: |
-          gcloud run deploy hr-worker \
-            --image "${{ env.REGION }}-docker.pkg.dev/${{ env.PROJECT_ID }}/${{ env.AR_REPO }}/worker:${{ github.sha }}" \
-            --region ${{ env.REGION }} \
-            --platform managed \
-            --quiet
+    uses: ./.github/workflows/deploy-service.yml
+    with:
+      service_name: hr-worker
+      app_name: worker
+      dockerfile_path: apps/worker/Dockerfile
+    secrets:
+      WIF_PROVIDER: ${{ secrets.WIF_PROVIDER }}
+      WIF_SERVICE_ACCOUNT: ${{ secrets.WIF_SERVICE_ACCOUNT }}

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -59,7 +59,7 @@ COPY --from=builder /app/apps/api/dist ./apps/api/dist
 COPY --from=builder /app/packages/db/dist ./packages/db/dist
 COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 
-EXPOSE 3001
+EXPOSE 8080
 
 # 非 root ユーザーで実行
 USER node

--- a/apps/worker/Dockerfile
+++ b/apps/worker/Dockerfile
@@ -71,7 +71,7 @@ COPY --from=builder /app/packages/db/dist ./packages/db/dist
 COPY --from=builder /app/packages/salary/dist ./packages/salary/dist
 COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 
-EXPOSE 3002
+EXPOSE 8080
 
 # 非 root ユーザーで実行
 USER node


### PR DESCRIPTION
## Summary

- **deploy-service.yml 新規作成**: 1サービス分のビルド+デプロイを行う再利用可能ワークフロー。`service_name`/`app_name`/`dockerfile_path` の3インプットでパラメタライズ
- **deploy.yml リライト**: DRY違反を解消。`ci-gate` ジョブで CI を前提条件化、`dorny/paths-filter` を `packages/**` → パッケージ個別指定に精密化（`packages/ai` は worker のみトリガー）
- **ci.yml**: `workflow_call` トリガー追加（deploy.yml から呼出し可能に）
- **Dockerfile EXPOSE 修正**: `api: 3001→8080`、`worker: 3002→8080`（Cloud Run は 8080 を期待）
- **Terraform 全面リライト**: 共有SA → 個別SA 4つ（hr-api/hr-web/hr-worker/hr-pubsub-push）、AR cleanup_policies（最新2件保持）追加、`terraform import` コマンドをコメントで明記

## Test plan

- [ ] CI ワークフローが PR で正常に動作することを確認（typecheck/lint/test）
- [ ] main push 後に変更したサービスのみデプロイされることを確認（paths-filter）
- [ ] `terraform fmt -check` が通ること（✅ 確認済み）
- [ ] Terraform apply は **実行しない**（ドキュメント同期のみ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)