### PR TITLE
feat(ai,worker): スレッドコンテキストによる Intent 分類精度向上

### DIFF
--- a/packages/ai/src/__tests__/intent-classifier.test.ts
+++ b/packages/ai/src/__tests__/intent-classifier.test.ts
@@ -14,6 +14,8 @@ vi.mock("@google-cloud/vertexai", () => ({
 // Import after mocking
 const { classifyIntent } = await import("../intent-classifier.js");
 
+import type { ThreadContext } from "../intent-classifier.js";
+
 function mockGeminiResponse(text: string) {
   mockGenerateContent.mockResolvedValueOnce({
     response: {
@@ -122,5 +124,84 @@ describe("classifyIntent", () => {
     const result = await classifyIntent("給与の件");
 
     expect(result.confidence).toBeLessThanOrEqual(1);
+  });
+});
+
+describe("classifyIntent — ThreadContext", () => {
+  beforeEach(() => {
+    mockGenerateContent.mockReset();
+  });
+
+  const salaryContext: ThreadContext = {
+    parentCategory: "salary",
+    parentConfidence: 0.95,
+    parentSnippet: "田中さんの給与を変更してください",
+    replyCount: 1,
+  };
+
+  it("親confidence >= 0.90 の場合、返信は同カテゴリを継承する（AI 呼び出しなし）", async () => {
+    const result = await classifyIntent("承知しました", salaryContext);
+
+    expect(result.category).toBe("salary");
+    expect(result.confidence).toBeCloseTo(0.95 * 0.9, 5);
+    expect(result.classificationMethod).toBe("regex");
+    expect(result.regexPattern).toBe("thread_context_inheritance");
+    // AI が呼ばれていないこと
+    expect(mockGenerateContent).not.toHaveBeenCalled();
+  });
+
+  it("親confidence < 0.90 の場合、コンテキスト付きプロンプトで Gemini にフォールバック", async () => {
+    const lowConfidenceContext: ThreadContext = {
+      parentCategory: "other",
+      parentConfidence: 0.6,
+      parentSnippet: "よろしくお願いします",
+      replyCount: 0,
+    };
+
+    mockGeminiResponse(
+      JSON.stringify({
+        category: "salary",
+        confidence: 0.8,
+        reasoning: "給与に関する返信",
+      }),
+    );
+
+    const result = await classifyIntent("田中さんの件はどうなりましたか", lowConfidenceContext);
+
+    expect(result.category).toBe("salary");
+    expect(result.classificationMethod).toBe("ai");
+    expect(mockGenerateContent).toHaveBeenCalledOnce();
+  });
+
+  it("context を渡さない場合（後方互換）、従来通りの動作をする", async () => {
+    mockGeminiResponse(
+      JSON.stringify({
+        category: "other",
+        confidence: 0.72,
+        reasoning: "分類不明のメッセージ",
+      }),
+    );
+
+    // context 引数なし（後方互換）— regex にマッチしない曖昧なメッセージ
+    const result = await classifyIntent("例の件について確認したいのですが");
+
+    expect(result.category).toBe("other");
+    expect(result.classificationMethod).toBe("ai");
+    expect(mockGenerateContent).toHaveBeenCalledOnce();
+  });
+
+  it("親confidence が境界値 0.90 ちょうどの場合、スレッド継承が発動する", async () => {
+    const boundaryContext: ThreadContext = {
+      parentCategory: "contract",
+      parentConfidence: 0.9,
+      parentSnippet: "契約変更の件",
+      replyCount: 2,
+    };
+
+    const result = await classifyIntent("了解です", boundaryContext);
+
+    expect(result.category).toBe("contract");
+    expect(result.classificationMethod).toBe("regex");
+    expect(mockGenerateContent).not.toHaveBeenCalled();
   });
 });

--- a/packages/ai/src/index.ts
+++ b/packages/ai/src/index.ts
@@ -2,6 +2,7 @@ export { getGenerativeModel } from "./gemini-client.js";
 export {
   classifyIntent,
   type IntentClassificationResult,
+  type ThreadContext,
 } from "./intent-classifier.js";
 export {
   extractSalaryParams,


### PR DESCRIPTION
## Summary

- `ThreadContext` 型を `@hr-system/ai` に追加。`parentCategory`, `parentConfidence`, `parentSnippet`, `replyCount` の4フィールド
- `classifyIntent(message, context?)` に第2引数を追加（後方互換）:
  - `parentConfidence >= 0.90` → AI 呼び出しなしで同カテゴリを `confidence × 0.9` で継承
  - context 存在時は Gemini プロンプトにスレッド情報を追記して分類精度向上
- `process-message.ts` に **Step 3.5** を追加:
  - `threadName` 付きメッセージで Firestore から親メッセージの `IntentRecord` を取得
  - 取得失敗時は best-effort で処理を継続（NACK しない）
  - 既存の `threadName + createdAt(asc)` 複合インデックスを活用（新規インデックス不要）

## Test plan

- [x] `pnpm --filter @hr-system/ai test` — 16テスト全通過
- [x] `pnpm --filter @hr-system/worker test` — 50テスト全通過
- [x] `pnpm typecheck` — 型エラーなし
- [x] `pnpm lint` — Biome エラーなし
- [x] `pnpm test` — 全パッケージ通過

## 実装詳細

| ファイル | 変更内容 |
|---------|---------|
| `packages/ai/src/intent-classifier.ts` | `ThreadContext` 型追加、`classifyIntent` 拡張、`buildContextualPrompt` 追加 |
| `packages/ai/src/index.ts` | `ThreadContext` を export 追加 |
| `apps/worker/src/pipeline/process-message.ts` | Step 3.5 追加（`getThreadContext` ヘルパー） |
| `packages/ai/src/__tests__/intent-classifier.test.ts` | ThreadContext テスト 4ケース追加 |
| `apps/worker/src/__tests__/process-message.test.ts` | スレッド返信テスト 4ケース追加、モックをチェーンオブジェクトパターンに修正 |

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)