### PR TITLE
fix(ci): pnpm バージョンを packageManager から自動検出 — startup_failure 解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Summary

- `pnpm/action-setup@v4` の `version: 9` ハードコードを削除
- `package.json` に `"packageManager": "pnpm@10.15.0"` が定義されており、action が自動検出する
- これにより全 PR の CI が `startup_failure` で落ちていた問題を解消

## Root Cause

```yaml
# Before (pnpm v9 を強制指定 → v10 と不一致でエラー)
- uses: pnpm/action-setup@v4
  with:
    version: 9

# After (packageManager フィールドから自動検出)
- uses: pnpm/action-setup@v4
```

## Test plan

- [ ] このPR自体のCIが通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)