### PR TITLE
fix(ci): deploy.yml に permissions id-token: write を追加 — startup_failure 解消

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   # CI ゲート: lint + typecheck + test をパスしてからデプロイ
   ci-gate:


### PR DESCRIPTION
## Summary

- `deploy.yml` に `permissions: id-token: write` を追加
- `deploy-service.yml` が Workload Identity Federation のために `id-token: write` を要求しているが、呼び出し元 `deploy.yml` に permissions が未設定だったため全デプロイが `startup_failure` に

## Root Cause

```
Error: "The nested job 'deploy' is requesting 'id-token: write', but is only allowed 'id-token: none'."
```

reusable workflow (`deploy-service.yml`) が `id-token: write` を要求しているが、
呼び出し元 (`deploy.yml`) の `permissions` が設定されていなかった。

## Fix

```yaml
# deploy.yml に追加
permissions:
  contents: read
  id-token: write
```

## Test plan

- [ ] CI (Lint/Typecheck/Test) が pass
- [ ] deploy.yml の `startup_failure` が解消され、変更検知 + デプロイジョブが実行されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)