### PR TITLE
feat(ci): workflow_dispatch + force_deploy_all — Phase 2 強制デプロイ対応

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,12 @@ name: Deploy to Cloud Run
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_deploy_all:
+        description: "全サービスを強制デプロイ (true = 変更検知をスキップ)"
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -53,7 +59,7 @@ jobs:
   deploy-api:
     name: Deploy API
     needs: detect-changes
-    if: needs.detect-changes.outputs.api == 'true'
+    if: needs.detect-changes.outputs.api == 'true' || inputs.force_deploy_all == true
     uses: ./.github/workflows/deploy-service.yml
     with:
       service_name: hr-api
@@ -67,7 +73,7 @@ jobs:
   deploy-web:
     name: Deploy Web
     needs: detect-changes
-    if: needs.detect-changes.outputs.web == 'true'
+    if: needs.detect-changes.outputs.web == 'true' || inputs.force_deploy_all == true
     uses: ./.github/workflows/deploy-service.yml
     with:
       service_name: hr-web
@@ -81,7 +87,7 @@ jobs:
   deploy-worker:
     name: Deploy Worker
     needs: detect-changes
-    if: needs.detect-changes.outputs.worker == 'true'
+    if: needs.detect-changes.outputs.worker == 'true' || inputs.force_deploy_all == true
     uses: ./.github/workflows/deploy-service.yml
     with:
       service_name: hr-worker


### PR DESCRIPTION
## Summary

- `workflow_dispatch` トリガーを追加（GitHub Actions UI から手動実行可能）
- `force_deploy_all` オプション: `true` で変更検知をスキップして全サービスをデプロイ

## 背景

startup_failure（PR #50, #51 で修正済み）により PR #47/#48/#49 の Phase 2 変更が本番未反映。
このPRマージ後に `force_deploy_all=true` で手動実行して全サービスを最新コードに更新する。

## 使い方

```bash
# マージ後に実行
gh workflow run deploy.yml --field force_deploy_all=true
```

## Test plan

- [ ] CI pass
- [ ] マージ後に `gh workflow run deploy.yml --field force_deploy_all=true` で全3サービスがデプロイされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)