### PR TITLE
fix(ci): API Dockerfile に packages/ai を追加 — ビルド失敗修正

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,7 @@ jobs:
           filters: |
             api:
               - 'apps/api/**'
+              - 'packages/ai/**'
               - 'packages/db/**'
               - 'packages/shared/**'
               - 'pnpm-lock.yaml'

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -20,6 +20,7 @@ FROM base AS builder
 # package.json ファイルのみを先にコピーして pnpm install を実行する
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json ./
 COPY apps/api/package.json ./apps/api/
+COPY packages/ai/package.json ./packages/ai/
 COPY packages/db/package.json ./packages/db/
 COPY packages/shared/package.json ./packages/shared/
 
@@ -30,6 +31,9 @@ RUN pnpm install --frozen-lockfile
 COPY apps/api/src ./apps/api/src
 COPY apps/api/tsconfig.json ./apps/api/
 COPY apps/api/tsconfig.build.json ./apps/api/
+COPY packages/ai/src ./packages/ai/src
+COPY packages/ai/tsconfig.json ./packages/ai/
+COPY packages/ai/tsconfig.build.json ./packages/ai/
 COPY packages/db/src ./packages/db/src
 COPY packages/db/tsconfig.json ./packages/db/
 COPY packages/db/tsconfig.build.json ./packages/db/
@@ -49,6 +53,7 @@ ENV NODE_ENV=production
 # 本番依存のみインストール（devDeps 除外）
 COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
 COPY apps/api/package.json ./apps/api/
+COPY packages/ai/package.json ./packages/ai/
 COPY packages/db/package.json ./packages/db/
 COPY packages/shared/package.json ./packages/shared/
 
@@ -56,6 +61,7 @@ RUN pnpm install --frozen-lockfile --prod
 
 # ビルド済み JS ファイルのみコピー（src は不要）
 COPY --from=builder /app/apps/api/dist ./apps/api/dist
+COPY --from=builder /app/packages/ai/dist ./packages/ai/dist
 COPY --from=builder /app/packages/db/dist ./packages/db/dist
 COPY --from=builder /app/packages/shared/dist ./packages/shared/dist
 


### PR DESCRIPTION
## Summary
- PR #48 で `apps/api` に `@hr-system/ai` 依存が追加されたが、API の Dockerfile に `packages/ai` が含まれておらず CI ビルドが失敗していた
- `apps/api/Dockerfile` の builder/runner 両ステージに `packages/ai` を追加（Worker Dockerfile のパターンに倣う）
- `deploy.yml` の API 変更検知フィルターに `packages/ai/**` を追加

## Changes
1. **`apps/api/Dockerfile`** — `packages/ai` の package.json, src, tsconfig, dist をコピーするステップを追加
2. **`.github/workflows/deploy.yml`** — API の paths-filter に `packages/ai/**` を追加

## Test plan
- [x] `pnpm typecheck` — 全7パッケージ成功
- [ ] CI パイプライン通過確認
- [ ] マージ後 `workflow_dispatch` + `force_deploy_all=true` でデプロイ成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)