### PR TITLE
fix(chat): チャット分析ページのメンション表示を修正

### DIFF
--- a/apps/api/src/routes/chat-messages.ts
+++ b/apps/api/src/routes/chat-messages.ts
@@ -169,6 +169,7 @@ chatMessageRoutes.get("/:id", async (c) => {
         content: d.data().content,
         formattedContent: d.data().formattedContent ?? null,
         messageType: d.data().messageType,
+        mentionedUsers: d.data().mentionedUsers ?? [],
         createdAt: toISO(d.data().createdAt),
       }));
   }

--- a/apps/web/src/__tests__/api-contract.test.ts
+++ b/apps/web/src/__tests__/api-contract.test.ts
@@ -148,6 +148,7 @@ const sampleChatMessageDetail: ChatMessageDetail = {
       content: "確認しました",
       formattedContent: null,
       messageType: "THREAD_REPLY",
+      mentionedUsers: [],
       createdAt: "2026-02-18T01:00:00.000Z",
     },
   ],

--- a/apps/web/src/__tests__/resolve-user-mentions.test.ts
+++ b/apps/web/src/__tests__/resolve-user-mentions.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveUserMentions } from "../components/chat/rich-content";
+
+describe("resolveUserMentions", () => {
+  const users = [
+    { userId: "users/12345", displayName: "田中 太郎" },
+    { userId: "users/67890", displayName: "鈴木 花子" },
+  ];
+
+  it("単一の <users/ID> をdisplayNameに変換する", () => {
+    expect(resolveUserMentions("<users/12345> さん、こんにちは", users)).toBe(
+      "田中 太郎 さん、こんにちは",
+    );
+  });
+
+  it("複数の <users/ID> を変換する", () => {
+    expect(resolveUserMentions("<users/12345> と <users/67890>", users)).toBe(
+      "田中 太郎 と 鈴木 花子",
+    );
+  });
+
+  it("未知のuserIdはIDのみ（users/プレフィックスなし）にフォールバックする", () => {
+    expect(resolveUserMentions("<users/99999>", users)).toBe("99999");
+  });
+
+  it("mentionedUsersが空配列の場合はIDのみにフォールバックする", () => {
+    expect(resolveUserMentions("<users/12345>", [])).toBe("12345");
+  });
+
+  it("<users/ID> を含まないテキストはそのまま返す", () => {
+    const text = "普通のメッセージです";
+    expect(resolveUserMentions(text, users)).toBe(text);
+  });
+
+  it("空文字列はそのまま返す", () => {
+    expect(resolveUserMentions("", users)).toBe("");
+  });
+});

--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -122,7 +122,11 @@ export default async function ChatMessageDetailPage({ params }: Props) {
 
             {/* 本文（メンションインライン対応） */}
             <div className="rounded-md bg-muted p-4 text-base">
-              <ContentWithMentions formattedContent={msg.formattedContent} content={msg.content} />
+              <ContentWithMentions
+                formattedContent={msg.formattedContent}
+                content={msg.content}
+                mentionedUsers={msg.mentionedUsers}
+              />
             </div>
 
             {/* 添付ファイル */}

--- a/apps/web/src/app/(protected)/chat-messages/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/page.tsx
@@ -1,5 +1,5 @@
 import Link from "next/link";
-import { ContentWithMentions, stripHtml } from "@/components/chat/rich-content";
+import { ContentWithMentions } from "@/components/chat/rich-content";
 import { ChatSyncButton } from "@/components/chat/sync-button";
 import { Button } from "@/components/ui/button";
 import {
@@ -273,9 +273,6 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
               </TableRow>
             ) : (
               messages.map((msg) => {
-                const preview = msg.formattedContent
-                  ? stripHtml(msg.formattedContent)
-                  : msg.content;
                 return (
                   <TableRow
                     key={msg.id}
@@ -301,8 +298,9 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
                             <span className="text-xs text-muted-foreground">[編集済] </span>
                           )}
                           <ContentWithMentions
-                            content={preview}
-                            formattedContent={null}
+                            content={msg.content}
+                            formattedContent={msg.formattedContent}
+                            mentionedUsers={msg.mentionedUsers}
                             className="line-clamp-2 text-sm"
                           />
                         </div>

--- a/apps/web/src/components/chat/thread-view.tsx
+++ b/apps/web/src/components/chat/thread-view.tsx
@@ -11,6 +11,7 @@ interface ThreadMessage {
   content: string;
   formattedContent: string | null;
   messageType: "MESSAGE" | "THREAD_REPLY";
+  mentionedUsers?: Array<{ userId: string; displayName: string }>;
   createdAt: string;
 }
 
@@ -69,6 +70,7 @@ function MessageBubble({ message, isReply }: { message: ThreadMessage; isReply: 
           <ContentWithMentions
             formattedContent={message.formattedContent}
             content={message.content}
+            mentionedUsers={message.mentionedUsers}
           />
         </div>
       </div>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -283,6 +283,7 @@ export interface ChatMessageDetail extends ChatMessageSummary {
     content: string;
     formattedContent: string | null;
     messageType: "MESSAGE" | "THREAD_REPLY";
+    mentionedUsers: Array<{ userId: string; displayName: string }>;
     createdAt: string;
   }>;
 }


### PR DESCRIPTION
## Summary

- **#56 (P0)**: `<users/ID>` 形式のメンションが生テキストで表示されていた問題を修正
- **#57 (P1)**: 一覧ページで `formattedContent={null}` 固定になっていた問題を修正
- **#58 (P1)**: `ContentWithMentions` を Google Chat API 実形式 (`<users/ID>`) に対応する形に刷新

## 変更内容

### コア修正 (`rich-content.tsx`)
- `ContentWithMentions` に `mentionedUsers?: MentionedUser[]` prop を追加
- `<users/ID>` パターンを `mentionedUsers` 配列から `displayName` を解決して `MentionBadge` にレンダリング
- 旧 `@\d+\.名前` regex を廃止（Google Chat が実際には生成しないパターン）
- `resolveUserMentions()` ユーティリティ関数をエクスポート（テスト可能）

### 波及修正
| ファイル | 修正内容 |
|---------|---------|
| `chat-messages/page.tsx` | `formattedContent={null}` 固定を解除、`mentionedUsers` 追加 |
| `chat-messages/[id]/page.tsx` | `mentionedUsers` を渡すよう修正 |
| `thread-view.tsx` | `ThreadMessage` 型と渡し先に `mentionedUsers` 追加 |
| `chat-messages.ts` (API) | `threadMessages` レスポンスに `mentionedUsers` 追加 |
| `types.ts` | `threadMessages.mentionedUsers` を型定義に追加 |

## Test plan

- [x] `resolveUserMentions` ユニットテスト 6件追加（境界値・異常系含む）
- [x] `api-contract.test.ts` の `threadMessages` サンプルデータを型定義に合わせ更新
- [x] 全テスト通過: API 48件 + Web 22件
- [x] TypeScript 型チェック通過
- [x] Biome lint 通過（エラーなし）
- [x] プロダクションビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)