### PR TITLE
fix: チャットパイプラインのメタデータ欠損バグを修正

### DIFF
--- a/apps/web/src/__tests__/rich-content.test.ts
+++ b/apps/web/src/__tests__/rich-content.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveHtmlMentions } from "../components/chat/rich-content";
+
+describe("resolveHtmlMentions", () => {
+  const users = [
+    { userId: "users/12345", displayName: "山田 花子" },
+    { userId: "users/99999", displayName: "田中 太郎" },
+  ];
+
+  it("<users/ID> を @displayName に変換する", () => {
+    const result = resolveHtmlMentions("<b>こんにちは</b><users/12345>さん", users);
+    expect(result).toBe("<b>こんにちは</b>@山田 花子さん");
+  });
+
+  it("複数のメンションを変換する", () => {
+    const result = resolveHtmlMentions("<users/12345>と<users/99999>", users);
+    expect(result).toBe("@山田 花子と@田中 太郎");
+  });
+
+  it("mentionedUsers に存在しない ID は rawId をフォールバックにする", () => {
+    const result = resolveHtmlMentions("<users/00000>", users);
+    expect(result).toBe("@00000");
+  });
+
+  it("メンションがない場合はそのまま返す", () => {
+    const html = "<b>メンションなし</b>";
+    expect(resolveHtmlMentions(html, users)).toBe(html);
+  });
+
+  it("mentionedUsers が空配列の場合は rawId をフォールバックにする", () => {
+    const result = resolveHtmlMentions("<users/12345>", []);
+    expect(result).toBe("@12345");
+  });
+
+  it("空文字列はそのまま返す", () => {
+    expect(resolveHtmlMentions("", users)).toBe("");
+  });
+});

--- a/apps/worker/src/__tests__/enrich-event.test.ts
+++ b/apps/worker/src/__tests__/enrich-event.test.ts
@@ -128,6 +128,26 @@ describe("enrichChatEvent", () => {
 
       expect(result.isDeleted).toBe(true);
     });
+
+    it("senderName が Chat API の sender.displayName で更新される", async () => {
+      const client = makeMockClient({
+        sender: { name: "users/12345", displayName: "鈴木 一郎", type: "HUMAN" },
+      });
+      const event = makeEvent({ senderName: "" }); // Pub/Sub からは空
+
+      const result = await enrichChatEvent(event, client);
+
+      expect(result.senderName).toBe("鈴木 一郎");
+    });
+
+    it("sender.displayName がない場合は元の senderName を維持する", async () => {
+      const client = makeMockClient({ formattedText: "テスト" }); // sender なし
+      const event = makeEvent({ senderName: "田中 太郎" });
+
+      const result = await enrichChatEvent(event, client);
+
+      expect(result.senderName).toBe("田中 太郎");
+    });
   });
 
   describe("API 失敗 / null — best-effort", () => {

--- a/apps/worker/src/lib/enrich-event.ts
+++ b/apps/worker/src/lib/enrich-event.ts
@@ -55,6 +55,9 @@ export async function enrichChatEvent(event: ChatEvent, client: ChatApiClient): 
         : event.isEdited;
     const isDeleted = message.deleteTime !== undefined ? !!message.deleteTime : event.isDeleted;
 
+    // senderName: Pub/Sub ペイロードには displayName が含まれないため API の値で補完
+    const senderName = message.sender?.displayName ?? event.senderName;
+
     return {
       ...event,
       formattedText,
@@ -63,6 +66,7 @@ export async function enrichChatEvent(event: ChatEvent, client: ChatApiClient): 
       attachments,
       isEdited,
       isDeleted,
+      senderName,
     };
   } catch (e) {
     console.warn(`[Worker] Chat API enrichment failed for ${event.googleMessageId}: ${String(e)}`);


### PR DESCRIPTION
## Summary

- **Issue #60**: Worker (`enrich-event.ts`) が Chat API の `sender.displayName` を `senderName` に反映せず、投稿者列が全行空白になっていた
- **Issue #61**: 定期同期 (`chat-sync.ts`) が `annotations`/`attachments`/`parentMessageId` をハードコードで空にしていたため、定期取得メッセージのメタデータが欠損していた
- **HTMLパスのメンション**: `ContentWithMentions` の HTML レンダリングパスで `<users/ID>` が `sanitizeHtml` に除去されてメンションが不可視になっていた

## 修正詳細

### `apps/worker/src/lib/enrich-event.ts` (Issue #60)
- Chat REST API レスポンスの `message.sender?.displayName` を `senderName` に反映
- Pub/Sub ペイロードは `displayName` を含まないため `...event` スプレッドで空文字が維持されていた

### `apps/api/src/services/chat-sync.ts` (Issue #61)
- `annotations`: `ChatAnnotation[]` 型で正規化して保存（`annotations: []` ハードコードを除去）
- `attachments`: `ChatAttachment[]` 型で正規化して保存（`attachments: []` ハードコードを除去）
- `parentMessageId`: `quotedMessageMetadata.name` から取得（`null` ハードコードを除去）
- `content`: `text` のみ使用（`formattedText` への誤ったフォールバックを除去）

### `apps/web/src/components/chat/rich-content.tsx`
- `resolveHtmlMentions()` ヘルパーを追加（export 済み）
- HTML パスで `sanitizeHtml` 前に `<users/ID>` → `@displayName` 変換を実行

## テスト

- `apps/worker/src/__tests__/enrich-event.test.ts`: senderName 補完テスト 2件追加
- `apps/api/src/__tests__/chat-sync.test.ts`: annotations/attachments/parentMessageId/content テスト 4件追加
- `apps/web/src/__tests__/rich-content.test.ts`: `resolveHtmlMentions` テスト 6件 (新規)

## Test plan

- [ ] typecheck: `pnpm typecheck` でエラーなしを確認
- [ ] test: `pnpm test --run` で全 52 テスト通過を確認
- [ ] build: `pnpm build` で全パッケージ成功を確認
- [ ] 動作確認: チャット一覧ページで投稿者名が正しく表示されることを確認
- [ ] 動作確認: メンションが `@displayName` 形式で表示されることを確認

> **注意**: 既存 Firestore データ（定期同期/Worker 経由で蓄積済みのメッセージ）の修復には別途 backfill 再実行が必要です。

Closes #60
Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)