### PR TITLE
fix(web): メンション表示バグ修正 & 空senderName対応

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/page.tsx
@@ -179,8 +179,9 @@ function MessageCard({ msg }: { msg: ChatMessageSummary }) {
     ? (CATEGORY_CONFIG[msg.intent.category] ?? CATEGORY_CONFIG.other)
     : null;
   const accent = catCfg?.accent ?? "border-l-slate-200";
-  const avatarBg = getAvatarColor(msg.senderName);
-  const ini = getInitials(msg.senderName);
+  const senderDisplay = msg.senderName || "不明";
+  const avatarBg = getAvatarColor(senderDisplay);
+  const ini = getInitials(senderDisplay);
   const isReply = msg.messageType === "THREAD_REPLY";
   const statCfg = msg.intent ? (STATUS_CONFIG[msg.intent.responseStatus] ?? null) : null;
   const methCfg = msg.intent ? (METHOD_CONFIG[msg.intent.classificationMethod] ?? null) : null;
@@ -188,7 +189,7 @@ function MessageCard({ msg }: { msg: ChatMessageSummary }) {
   return (
     <Link href={`/chat-messages/${msg.id}`} className="block group">
       <div
-        className={`relative border-l-4 ${accent} rounded-r-xl bg-white px-5 py-4 shadow-sm ring-1 ring-slate-200/80 transition-shadow group-hover:shadow-md group-hover:ring-slate-300 ${
+        className={`relative border-l-4 ${accent} rounded-r-xl bg-white px-5 py-4 shadow-sm ring-1 ring-slate-200/80 transition-all duration-150 group-hover:shadow-md group-hover:ring-slate-300 ${
           isReply ? "ml-8" : ""
         }`}
       >
@@ -201,7 +202,9 @@ function MessageCard({ msg }: { msg: ChatMessageSummary }) {
         <div className="flex gap-3">
           {/* Avatar */}
           <div
-            className={`mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white ${avatarBg}`}
+            className={`mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-full text-xs font-bold text-white ${avatarBg} ${
+              senderDisplay === "不明" ? "opacity-50" : ""
+            }`}
           >
             {ini}
           </div>
@@ -211,8 +214,10 @@ function MessageCard({ msg }: { msg: ChatMessageSummary }) {
             {/* Header row */}
             <div className="mb-1.5 flex items-center justify-between gap-2">
               <div className="flex min-w-0 items-center gap-2">
-                <span className="truncate text-sm font-semibold text-slate-800">
-                  {msg.senderName}
+                <span
+                  className={`truncate text-sm font-semibold ${senderDisplay === "不明" ? "italic text-slate-400" : "text-slate-800"}`}
+                >
+                  {senderDisplay}
                 </span>
                 {msg.isEdited && (
                   <span className="flex shrink-0 items-center gap-0.5 text-[11px] text-slate-400">

--- a/apps/web/src/components/chat/mention-badge.tsx
+++ b/apps/web/src/components/chat/mention-badge.tsx
@@ -8,13 +8,14 @@ interface MentionBadgeProps {
 }
 
 export function MentionBadge({ displayName }: MentionBadgeProps) {
-  const initial = displayName.slice(0, 1);
+  const name = displayName || "不明ユーザー";
+  const initial = name.slice(0, 1);
   return (
     <span className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700">
       <span className="flex h-4 w-4 items-center justify-center rounded-full bg-indigo-200 text-[10px] font-bold text-indigo-700">
         {initial}
       </span>
-      @{displayName}
+      @{name}
     </span>
   );
 }

--- a/apps/web/src/components/chat/rich-content.tsx
+++ b/apps/web/src/components/chat/rich-content.tsx
@@ -104,7 +104,7 @@ export function resolveHtmlMentions(html: string, mentionedUsers: MentionedUser[
   return html.replace(/<users\/([^>]+)>/g, (_, rawId) => {
     const userId = `users/${rawId}`;
     const user = mentionedUsers.find((u) => u.userId === userId);
-    return `@${user?.displayName ?? rawId}`;
+    return `@${user?.displayName || rawId}`;
   });
 }
 
@@ -159,7 +159,7 @@ export function ContentWithMentions({
         if (match?.[1] !== undefined) {
           const userId = `users/${match[1]}`;
           const user = mentionedUsers.find((u) => u.userId === userId);
-          return <MentionBadge key={key} displayName={user?.displayName ?? match[1]} />;
+          return <MentionBadge key={key} displayName={user?.displayName || match[1] || ""} />;
         }
         return part;
       })}


### PR DESCRIPTION
## Summary

- `MentionBadge`: `displayName=""` のとき `@` だけになっていたバグを修正。`||` フォールバックで「不明ユーザー」を表示
- `resolveHtmlMentions` / `ContentWithMentions`: `??` → `||` に変更し、空文字列（旧 Firestore データで `displayName: ""`）もフォールバックするよう対応
- `page.tsx`: `senderName` が空のとき「不明」を表示し、アバターを淡色（`opacity-50`）で表示。アバターサイズを `h-9 w-9` に微調整

## Root cause

PR #62 以前の Firestore データは `mentionedUsers` が `[]` または `displayName: ""` のまま保存されており、新しい UI でメンションが `@` だけになっていた。

## Test plan

- [x] `pnpm test` — 全52テスト pass
- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm lint` — warnings のみ（既存 confusion-matrix-table.tsx の non-null assertion、本 PR とは無関係）
- [x] `pnpm build` — ビルド成功

Closes #66
Contributes to #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)