### PR TITLE
feat(db): backfill-chat.ts に --repair フラグ追加 — 欠損 senderName 補完

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -24,6 +24,7 @@
     "build": "tsc -p tsconfig.build.json",
     "db:seed": "tsx src/seed/index.ts",
     "db:backfill": "tsx src/seed/backfill-chat.ts",
+    "db:repair": "tsx src/seed/backfill-chat.ts --repair",
     "lint": "biome check src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"


### PR DESCRIPTION
## Summary

- `packages/db/src/seed/backfill-chat.ts` に `repairChatMessages()` 関数を追加
- PR #62 マージ前の旧データ（`senderName === ""`）を Chat REST API で補完
- `packages/db/package.json` に `db:repair` スクリプトを追加

## 修復対象

| フィールド | 欠損源 | 修復 |
|-----------|--------|------|
| `senderName` | Worker (Pub/Sub) 経由の旧メッセージ | ✅ |
| `annotations` | 修復時に合わせて更新 | ✅ |
| `mentionedUsers` | `annotations` 再抽出 | ✅ |
| `attachments` | 修復時に合わせて更新 | ✅ |
| `parentMessageId` | 修復時に合わせて更新 | ✅ |
| `formattedContent` | 修復時に合わせて更新 | ✅ |

## 非破壊設計

- `update()` を使用（`set()` ではない）
- `processedAt` / `createdAt` / `intentRecords` には触らない
- `isManualOverride` / `responseStatus` を保護

## 実行方法

```bash
# 認証トークンを取得（Chat スコープが必要）
GOOGLE_ACCESS_TOKEN=$(gcloud auth print-access-token) \
  pnpm --filter @hr-system/db db:repair

# DWD を使う場合
DWD_SA_KEY_FILE=/path/to/key.json DWD_SUBJECT=user@domain.com \
  pnpm --filter @hr-system/db db:repair
```

## Test plan

- [ ] `pnpm --filter @hr-system/db typecheck` → 通過
- [ ] `pnpm --filter @hr-system/db lint` → 通過
- [ ] `pnpm --filter @hr-system/db test` → 10 tests 通過
- [ ] 本番実行: `db:repair` で senderName 欠損ドキュメントが補完されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)