### PR TITLE
fix(web): メンションの数字IDを非表示 — 名前不明時は「不明ユーザー」を表示

### DIFF
--- a/apps/web/src/__tests__/resolve-user-mentions.test.ts
+++ b/apps/web/src/__tests__/resolve-user-mentions.test.ts
@@ -19,12 +19,12 @@ describe("resolveUserMentions", () => {
     );
   });
 
-  it("未知のuserIdはIDのみ（users/プレフィックスなし）にフォールバックする", () => {
-    expect(resolveUserMentions("<users/99999>", users)).toBe("99999");
+  it("未知のuserIdは「不明ユーザー」を表示する", () => {
+    expect(resolveUserMentions("<users/99999>", users)).toBe("不明ユーザー");
   });
 
-  it("mentionedUsersが空配列の場合はIDのみにフォールバックする", () => {
-    expect(resolveUserMentions("<users/12345>", [])).toBe("12345");
+  it("mentionedUsersが空配列の場合は「不明ユーザー」を表示する", () => {
+    expect(resolveUserMentions("<users/12345>", [])).toBe("不明ユーザー");
   });
 
   it("<users/ID> を含まないテキストはそのまま返す", () => {

--- a/apps/web/src/__tests__/rich-content.test.ts
+++ b/apps/web/src/__tests__/rich-content.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { resolveHtmlMentions } from "../components/chat/rich-content";
+import { resolveHtmlMentions, resolveUserMentions } from "../components/chat/rich-content";
+
+const users = [
+  { userId: "users/12345", displayName: "山田 花子" },
+  { userId: "users/99999", displayName: "田中 太郎" },
+];
 
 describe("resolveHtmlMentions", () => {
-  const users = [
-    { userId: "users/12345", displayName: "山田 花子" },
-    { userId: "users/99999", displayName: "田中 太郎" },
-  ];
-
   it("<users/ID> を @displayName に変換する", () => {
     const result = resolveHtmlMentions("<b>こんにちは</b><users/12345>さん", users);
     expect(result).toBe("<b>こんにちは</b>@山田 花子さん");
@@ -17,9 +17,9 @@ describe("resolveHtmlMentions", () => {
     expect(result).toBe("@山田 花子と@田中 太郎");
   });
 
-  it("mentionedUsers に存在しない ID は rawId をフォールバックにする", () => {
+  it("mentionedUsers に存在しない ID は「不明ユーザー」を表示する", () => {
     const result = resolveHtmlMentions("<users/00000>", users);
-    expect(result).toBe("@00000");
+    expect(result).toBe("@不明ユーザー");
   });
 
   it("メンションがない場合はそのまま返す", () => {
@@ -27,12 +27,29 @@ describe("resolveHtmlMentions", () => {
     expect(resolveHtmlMentions(html, users)).toBe(html);
   });
 
-  it("mentionedUsers が空配列の場合は rawId をフォールバックにする", () => {
+  it("mentionedUsers が空配列の場合は「不明ユーザー」を表示する", () => {
     const result = resolveHtmlMentions("<users/12345>", []);
-    expect(result).toBe("@12345");
+    expect(result).toBe("@不明ユーザー");
   });
 
   it("空文字列はそのまま返す", () => {
     expect(resolveHtmlMentions("", users)).toBe("");
+  });
+});
+
+describe("resolveUserMentions", () => {
+  it("<users/ID> を displayName に変換する", () => {
+    const result = resolveUserMentions("こんにちは<users/12345>さん", users);
+    expect(result).toBe("こんにちは山田 花子さん");
+  });
+
+  it("mentionedUsers に存在しない ID は「不明ユーザー」を表示する", () => {
+    const result = resolveUserMentions("<users/00000>", users);
+    expect(result).toBe("不明ユーザー");
+  });
+
+  it("mentionedUsers が空配列の場合は「不明ユーザー」を表示する", () => {
+    const result = resolveUserMentions("<users/12345>", []);
+    expect(result).toBe("不明ユーザー");
   });
 });

--- a/apps/web/src/components/chat/rich-content.tsx
+++ b/apps/web/src/components/chat/rich-content.tsx
@@ -92,7 +92,7 @@ export function resolveUserMentions(content: string, mentionedUsers: MentionedUs
   return content.replace(/<users\/([^>]+)>/g, (_, rawId) => {
     const userId = `users/${rawId}`;
     const user = mentionedUsers.find((u) => u.userId === userId);
-    return user?.displayName ?? rawId;
+    return user?.displayName ?? "不明ユーザー";
   });
 }
 
@@ -104,7 +104,7 @@ export function resolveHtmlMentions(html: string, mentionedUsers: MentionedUser[
   return html.replace(/<users\/([^>]+)>/g, (_, rawId) => {
     const userId = `users/${rawId}`;
     const user = mentionedUsers.find((u) => u.userId === userId);
-    return `@${user?.displayName || rawId}`;
+    return `@${user?.displayName || "不明ユーザー"}`;
   });
 }
 
@@ -159,7 +159,7 @@ export function ContentWithMentions({
         if (match?.[1] !== undefined) {
           const userId = `users/${match[1]}`;
           const user = mentionedUsers.find((u) => u.userId === userId);
-          return <MentionBadge key={key} displayName={user?.displayName || match[1] || ""} />;
+          return <MentionBadge key={key} displayName={user?.displayName || "不明ユーザー"} />;
         }
         return part;
       })}


### PR DESCRIPTION
## Summary
- `resolveHtmlMentions` / `resolveUserMentions` / `ContentWithMentions` の3箇所で rawId フォールバックを「不明ユーザー」に変更
- displayName が解決できない場合に数字IDが露出する問題を修正

## Test plan
- [x] `rich-content.test.ts` — 9テスト通過（フォールバック期待値を更新）
- [x] `resolve-user-mentions.test.ts` — 6テスト通過（フォールバック期待値を更新）
- [x] 全31テスト通過

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)