### PR TITLE
feat(web): チャットカードに添付ファイルを展開表示

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/page.tsx
@@ -8,6 +8,7 @@ import {
 } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
+import { AttachmentList } from "@/components/chat/attachment-list";
 import { ContentWithMentions } from "@/components/chat/rich-content";
 import { ChatSyncButton } from "@/components/chat/sync-button";
 import { getChatMessages, getStatsSpaces } from "@/lib/api";
@@ -268,13 +269,18 @@ function MessageCard({ msg }: { msg: ChatMessageSummary }) {
               {msg.intent?.isManualOverride && (
                 <span className="text-xs font-medium text-amber-500">修正済</span>
               )}
-              {msg.attachments.length > 0 && (
-                <span className="flex items-center gap-1 text-xs text-slate-400">
-                  <Paperclip size={11} />
-                  {msg.attachments.length}件の添付
-                </span>
-              )}
             </div>
+
+            {/* Attachments */}
+            {msg.attachments.length > 0 && (
+              <div className="mt-2">
+                <p className="mb-1 flex items-center gap-1 text-xs font-medium text-slate-400">
+                  <Paperclip size={11} />
+                  添付ファイル ({msg.attachments.length}件)
+                </p>
+                <AttachmentList attachments={msg.attachments} />
+              </div>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- 一覧カードの添付ファイル表示をアイコン+件数から `AttachmentList` コンポーネントによる展開表示に変更
- ファイル名・ダウンロードリンク・MIME typeバッジを一覧画面でも確認可能に

## Test plan
- [x] `pnpm --filter @hr-system/web test` — 31テスト通過
- [x] `pnpm --filter @hr-system/web typecheck` — 型チェック通過
- [x] `pnpm lint` — エラーなし

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)