### PR TITLE
feat(web): チャットカードに Google Chat メッセージへの遷移リンクを追加

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, MessageSquare, Paperclip } from "lucide-react";
+import { ArrowLeft, ExternalLink, MessageSquare, Paperclip } from "lucide-react";
 import Link from "next/link";
 import { AttachmentList } from "@/components/chat/attachment-list";
 import { MentionBadge } from "@/components/chat/mention-badge";
@@ -49,6 +49,13 @@ function formatDateTime(iso: string) {
   return new Date(iso).toLocaleString("ja-JP");
 }
 
+/** googleMessageId ("spaces/{spaceId}/messages/{messageId}") から Google Chat URL を生成 */
+function buildChatUrl(googleMessageId: string): string {
+  const match = googleMessageId.match(/^spaces\/([^/]+)\/messages\/([^/]+)$/);
+  if (!match) return "";
+  return `https://chat.google.com/room/${match[1]}/${match[2]}`;
+}
+
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="flex justify-between gap-4">
@@ -76,17 +83,30 @@ export default async function ChatMessageDetailPage({ params }: Props) {
       </Link>
 
       {/* ヘッダー */}
-      <div className="flex items-center gap-3">
-        <h1 className="text-2xl font-bold">メッセージ詳細</h1>
-        {msg.messageType === "THREAD_REPLY" && (
-          <span className="rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs text-amber-700">
-            ↩ スレッド返信
-          </span>
-        )}
-        {msg.isEdited && (
-          <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-            編集済
-          </span>
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <h1 className="text-2xl font-bold">メッセージ詳細</h1>
+          {msg.messageType === "THREAD_REPLY" && (
+            <span className="rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs text-amber-700">
+              ↩ スレッド返信
+            </span>
+          )}
+          {msg.isEdited && (
+            <span className="rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
+              編集済
+            </span>
+          )}
+        </div>
+        {buildChatUrl(msg.googleMessageId) && (
+          <a
+            href={buildChatUrl(msg.googleMessageId)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-sm text-slate-600 transition-colors hover:bg-slate-50 hover:text-slate-900"
+          >
+            <ExternalLink className="h-4 w-4" />
+            Google Chat で開く
+          </a>
         )}
       </div>
 

--- a/apps/web/src/app/(protected)/chat-messages/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/page.tsx
@@ -2,6 +2,7 @@ import {
   ChevronLeft,
   ChevronRight,
   CornerDownRight,
+  ExternalLink,
   MessageSquare,
   Paperclip,
   Pencil,
@@ -128,6 +129,13 @@ function getInitials(name: string): string {
   return name.slice(0, 2);
 }
 
+/** googleMessageId ("spaces/{spaceId}/messages/{messageId}") から Google Chat URL を生成 */
+function buildChatUrl(googleMessageId: string): string {
+  const match = googleMessageId.match(/^spaces\/([^/]+)\/messages\/([^/]+)$/);
+  if (!match) return "";
+  return `https://chat.google.com/room/${match[1]}/${match[2]}`;
+}
+
 function formatDateTime(iso: string): string {
   return new Date(iso).toLocaleString("ja-JP", {
     month: "2-digit",
@@ -227,9 +235,23 @@ function MessageCard({ msg }: { msg: ChatMessageSummary }) {
                   </span>
                 )}
               </div>
-              <time className="shrink-0 font-mono text-xs text-slate-400 tabular-nums">
-                {formatDateTime(msg.createdAt)}
-              </time>
+              <div className="flex shrink-0 items-center gap-2">
+                <time className="font-mono text-xs text-slate-400 tabular-nums">
+                  {formatDateTime(msg.createdAt)}
+                </time>
+                {buildChatUrl(msg.googleMessageId) && (
+                  <a
+                    href={buildChatUrl(msg.googleMessageId)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    onClick={(e) => e.stopPropagation()}
+                    className="text-slate-400 transition-colors hover:text-slate-600"
+                    title="Google Chat で開く"
+                  >
+                    <ExternalLink size={12} />
+                  </a>
+                )}
+              </div>
             </div>
 
             {/* Content */}


### PR DESCRIPTION
## Summary
- 一覧カードのヘッダー行に Google Chat 外部リンクアイコンを追加
- 詳細ページのヘッダーに「Google Chat で開く」ボタンを追加
- `googleMessageId` (`spaces/{spaceId}/messages/{messageId}`) から `chat.google.com/room/` URL を生成

## Test plan
- [x] `pnpm --filter @hr-system/web test` — 31テスト通過
- [x] `pnpm --filter @hr-system/web typecheck` — 型チェック通過
- [x] `pnpm lint` — エラーなし

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)