### PR TITLE
fix(web): formatDateTime に timeZone 指定を追加し Hydration mismatch (#418) を修正

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -113,6 +113,7 @@ function buildChatUrl(googleMessageId: string): string {
 
 function formatDateTime(iso: string): string {
   return new Date(iso).toLocaleString("ja-JP", {
+    timeZone: "Asia/Tokyo",
     month: "2-digit",
     day: "2-digit",
     hour: "2-digit",


### PR DESCRIPTION
## Summary

- `message-card.tsx` の `formatDateTime` に `timeZone: "Asia/Tokyo"` を追加

## 原因

`MessageCard` は Client Component (`"use client"`) だが、Next.js App Router では SSR でプリレンダリングされる。  
サーバー（Cloud Run / UTC）とブラウザ（JST = UTC+9）でタイムゾーンが異なる場合、`toLocaleString("ja-JP")` の出力が一致せず **React error #418 (Hydration failed)** が発生していた。

## 修正

```diff
-    month: "2-digit",
+    timeZone: "Asia/Tokyo",
+    month: "2-digit",
```

`timeZone` を明示することでサーバー・クライアント双方が同一の文字列を生成する。

## Test plan

- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス
- [x] `pnpm test` パス（全31テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)