### PR TITLE
fix(web): 添付ファイルクリックで Google Chat メッセージに遷移

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -156,7 +156,10 @@ export default async function ChatMessageDetailPage({ params }: Props) {
                   <Paperclip className="h-3.5 w-3.5" />
                   添付ファイル ({msg.attachments.length}件)
                 </p>
-                <AttachmentList attachments={msg.attachments} />
+                <AttachmentList
+                  attachments={msg.attachments}
+                  chatUrl={buildChatUrl(msg.googleMessageId) || undefined}
+                />
               </div>
             )}
           </CardContent>

--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -252,7 +252,10 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
                   <Paperclip size={11} />
                   添付ファイル ({msg.attachments.length}件)
                 </p>
-                <AttachmentList attachments={msg.attachments} />
+                <AttachmentList
+                  attachments={msg.attachments}
+                  chatUrl={buildChatUrl(msg.googleMessageId) || undefined}
+                />
               </div>
             )}
           </div>

--- a/apps/web/src/components/chat/attachment-list.tsx
+++ b/apps/web/src/components/chat/attachment-list.tsx
@@ -13,9 +13,11 @@ interface Attachment {
 
 interface AttachmentListProps {
   attachments: Attachment[];
+  /** 添付ファイルクリック時の遷移先 Google Chat メッセージ URL。downloadUri が認証を要求する場合のフォールバック。 */
+  chatUrl?: string;
 }
 
-export function AttachmentList({ attachments }: AttachmentListProps) {
+export function AttachmentList({ attachments, chatUrl }: AttachmentListProps) {
   if (attachments.length === 0) return null;
 
   return (
@@ -30,7 +32,17 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
           ) : (
             <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
           )}
-          {att.downloadUri ? (
+          {chatUrl ? (
+            <a
+              href={chatUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex-1 truncate text-primary hover:underline"
+              title="Google Chat でファイルを開く"
+            >
+              {att.contentName ?? att.name}
+            </a>
+          ) : att.downloadUri ? (
             <a
               href={att.downloadUri}
               target="_blank"


### PR DESCRIPTION
## Summary

- `AttachmentList` コンポーネントに `chatUrl?: string` prop を追加
- `chatUrl` が渡された場合、ファイル名クリックで Google Chat の該当メッセージへ遷移
- 詳細ページ・カード一覧ページ両方に `buildChatUrl(msg.googleMessageId)` を渡すよう変更

## 背景

`downloadUri`（`https://chat.google.com/api/get_attachment_url?...`）は Google Chat の認証付き URL のため、アプリからは直接開けない。  
Cloud Storage への保存は未実装のため、代替として Google Chat メッセージ URL に遷移することで添付ファイルへのアクセス経路を提供する。

## 動作変化

| 変更前 | 変更後 |
|--------|--------|
| ファイル名 → `downloadUri`（認証エラーで開けない） | ファイル名 → Google Chat メッセージ（認証不要でアクセス可能） |

## Test plan

- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス
- [x] `pnpm test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)