### PR TITLE
fix(web): 添付ファイルクリックで Google Chat ファイル名検索に遷移

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -156,10 +156,7 @@ export default async function ChatMessageDetailPage({ params }: Props) {
                   <Paperclip className="h-3.5 w-3.5" />
                   添付ファイル ({msg.attachments.length}件)
                 </p>
-                <AttachmentList
-                  attachments={msg.attachments}
-                  chatUrl={buildChatUrl(msg.googleMessageId) || undefined}
-                />
+                <AttachmentList attachments={msg.attachments} />
               </div>
             )}
           </CardContent>

--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -252,10 +252,7 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
                   <Paperclip size={11} />
                   添付ファイル ({msg.attachments.length}件)
                 </p>
-                <AttachmentList
-                  attachments={msg.attachments}
-                  chatUrl={buildChatUrl(msg.googleMessageId) || undefined}
-                />
+                <AttachmentList attachments={msg.attachments} />
               </div>
             )}
           </div>

--- a/apps/web/src/components/chat/attachment-list.tsx
+++ b/apps/web/src/components/chat/attachment-list.tsx
@@ -13,54 +13,48 @@ interface Attachment {
 
 interface AttachmentListProps {
   attachments: Attachment[];
-  /** 添付ファイルクリック時の遷移先 Google Chat メッセージ URL。downloadUri が認証を要求する場合のフォールバック。 */
-  chatUrl?: string;
 }
 
-export function AttachmentList({ attachments, chatUrl }: AttachmentListProps) {
+/** ファイル名で Google Chat 検索するURL。クリックするとファイルが含まれるメッセージが表示される。 */
+function buildSearchUrl(filename: string): string {
+  return `https://mail.google.com/chat/u/0/#search/${encodeURIComponent(filename)}/cmembership=1`;
+}
+
+export function AttachmentList({ attachments }: AttachmentListProps) {
   if (attachments.length === 0) return null;
 
   return (
     <div className="space-y-1">
-      {attachments.map((att) => (
-        <div
-          key={att.name}
-          className="flex items-center gap-2 rounded-md border border-muted bg-muted/40 px-3 py-2 text-sm"
-        >
-          {att.source === "DRIVE_FILE" ? (
-            <HardDrive className="h-4 w-4 shrink-0 text-muted-foreground" />
-          ) : (
-            <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
-          )}
-          {chatUrl ? (
+      {attachments.map((att) => {
+        const displayName = att.contentName ?? att.name;
+        const href = buildSearchUrl(displayName);
+        return (
+          <div
+            key={att.name}
+            className="flex items-center gap-2 rounded-md border border-muted bg-muted/40 px-3 py-2 text-sm"
+          >
+            {att.source === "DRIVE_FILE" ? (
+              <HardDrive className="h-4 w-4 shrink-0 text-muted-foreground" />
+            ) : (
+              <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+            )}
             <a
-              href={chatUrl}
+              href={href}
               target="_blank"
               rel="noopener noreferrer"
               className="flex-1 truncate text-primary hover:underline"
-              title="Google Chat でファイルを開く"
+              title="Google Chat でファイルを検索して開く"
             >
-              {att.contentName ?? att.name}
+              {displayName}
             </a>
-          ) : att.downloadUri ? (
-            <a
-              href={att.downloadUri}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="flex-1 truncate text-primary hover:underline"
-            >
-              {att.contentName ?? att.name}
-            </a>
-          ) : (
-            <span className="flex-1 truncate text-foreground">{att.contentName ?? att.name}</span>
-          )}
-          {att.contentType && (
-            <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
-              {att.contentType.split("/").pop()}
-            </span>
-          )}
-        </div>
-      ))}
+            {att.contentType && (
+              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                {att.contentType.split("/").pop()}
+              </span>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- 添付ファイル名クリック時のリンク先を Google Chat ファイル名検索 URL に変更
- `AttachmentList` コンポーネントを簡略化（`chatUrl` prop 不要に）

## 背景・原因

| 方式 | URL | 結果 |
|------|-----|------|
| ~~downloadUri~~ | `https://chat.google.com/api/get_attachment_url?...` | 認証エラーで開けない |
| ~~メッセージURL~~ | `https://mail.google.com/chat/u/0/#chat/space/AAAA-qf5jX0` | 何も表示されない |
| **ファイル名検索URL** | `https://mail.google.com/chat/u/0/#search/{filename}/cmembership=1` | ✅ ファイルを含むメッセージが表示される |

## 変更内容

`AttachmentList` 内で `buildSearchUrl(filename)` を使いファイル名ごとの検索URLを生成。
ファイル名は `encodeURIComponent` でエンコード。

## Test plan

- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス
- [x] `pnpm test` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)