### PR TITLE
fix(web): 添付ファイルリンクのクリック伝播を修正 & URLテスト追加

### DIFF
--- a/apps/web/src/__tests__/attachment-list.test.ts
+++ b/apps/web/src/__tests__/attachment-list.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildSearchUrl } from "../components/chat/attachment-list";
+
+describe("buildSearchUrl", () => {
+  it("日本語ファイル名を正しくエンコードしたURL を生成する", () => {
+    const url = buildSearchUrl("資格証_ツツミ_ヒロタカ_堤_啓貴_.pdf");
+    expect(url).toBe(
+      "https://mail.google.com/chat/u/0/#search/%E8%B3%87%E6%A0%BC%E8%A8%BC_%E3%83%84%E3%83%84%E3%83%9F_%E3%83%92%E3%83%AD%E3%82%BF%E3%82%AB_%E5%A0%A4_%E5%95%93%E8%B2%B4_.pdf/cmembership=1",
+    );
+  });
+
+  it("ASCII ファイル名はそのままURLに含まれる", () => {
+    const url = buildSearchUrl("resume.pdf");
+    expect(url).toBe("https://mail.google.com/chat/u/0/#search/resume.pdf/cmembership=1");
+  });
+
+  it("スペースを含むファイル名をエンコードする", () => {
+    const url = buildSearchUrl("my document.pdf");
+    expect(url).toBe("https://mail.google.com/chat/u/0/#search/my%20document.pdf/cmembership=1");
+  });
+
+  it("cmembership=1 パラメータが末尾に付く", () => {
+    const url = buildSearchUrl("test.xlsx");
+    expect(url).toContain("/cmembership=1");
+  });
+
+  it("u/0 アカウントパスが含まれる", () => {
+    const url = buildSearchUrl("test.pdf");
+    expect(url).toContain("/chat/u/0/");
+  });
+});

--- a/apps/web/src/components/chat/attachment-list.tsx
+++ b/apps/web/src/components/chat/attachment-list.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 /**
  * 添付ファイルリストコンポーネント
  */
@@ -16,7 +18,7 @@ interface AttachmentListProps {
 }
 
 /** ファイル名で Google Chat 検索するURL。クリックするとファイルが含まれるメッセージが表示される。 */
-function buildSearchUrl(filename: string): string {
+export function buildSearchUrl(filename: string): string {
   return `https://mail.google.com/chat/u/0/#search/${encodeURIComponent(filename)}/cmembership=1`;
 }
 
@@ -42,6 +44,7 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
               href={href}
               target="_blank"
               rel="noopener noreferrer"
+              onClick={(e) => e.stopPropagation()}
               className="flex-1 truncate text-primary hover:underline"
               title="Google Chat でファイルを検索して開く"
             >


### PR DESCRIPTION
## 根本原因

カード一覧ページ（`/chat-messages`）では `MessageCard` が `<Link>` でラップされている。
添付ファイルの `<a>` をクリックすると、クリックイベントが親 `<Link>` に伝播して
メッセージ詳細ページ（`/chat-messages/{id}`）に遷移してしまい、
Google Chat 検索タブが開いても気づかないか、ブロックされる問題があった。

## 修正内容

- `AttachmentList` に `"use client"` を追加
- 添付ファイル `<a>` に `onClick={(e) => e.stopPropagation()}` を追加
- `buildSearchUrl` を `export` してユニットテスト5件を追加

## テスト

| テストケース | 内容 |
|------------|------|
| 日本語ファイル名エンコード | `資格証_ツツミ_..._.pdf` → 正しい %HH 形式 |
| ASCII ファイル名 | そのままURLに含まれる |
| スペース含むファイル名 | `%20` にエンコード |
| cmembership=1 | 末尾パラメータが付く |
| u/0 アカウントパス | URLに含まれる |

## Test plan

- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス
- [x] `pnpm test` パス（36テスト、新規5件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)