### PR TITLE
fix(web): 添付ファイルリンクのクリックで詳細ページに遷移する問題を修正

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { CornerDownRight, ExternalLink, Paperclip, Pencil } from "lucide-react";
-import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { AttachmentList } from "@/components/chat/attachment-list";
 import { ContentWithMentions } from "@/components/chat/rich-content";
 import type { ChatMessageSummary } from "@/lib/types";
@@ -136,6 +136,7 @@ function ConfidenceMeter({ score }: { score: number }) {
 }
 
 export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
+  const router = useRouter();
   const catCfg = msg.intent
     ? (CATEGORY_CONFIG[msg.intent.category] ?? CATEGORY_CONFIG.other)
     : null;
@@ -148,7 +149,11 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
   const methCfg = msg.intent ? (METHOD_CONFIG[msg.intent.classificationMethod] ?? null) : null;
 
   return (
-    <Link href={`/chat-messages/${msg.id}`} className="group block">
+    <button
+      type="button"
+      onClick={() => router.push(`/chat-messages/${msg.id}`)}
+      className="group block w-full cursor-pointer text-left"
+    >
       <div
         className={`relative border-l-4 ${accent} rounded-r-xl bg-white px-5 py-4 shadow ring-1 ring-slate-200/80 transition-all duration-150 group-hover:shadow-lg group-hover:ring-slate-300 ${
           isReply ? "ml-8" : ""
@@ -258,6 +263,6 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
           </div>
         </div>
       </div>
-    </Link>
+    </button>
   );
 }


### PR DESCRIPTION
## 問題

一覧ページで添付ファイル名をクリックすると、Google Chat の検索URL に遷移せず、メッセージ詳細ページに遷移してしまっていた。

## 根本原因

Next.js の `<Link>` コンポーネントは `<a>` タグとしてレンダリングされる。`AttachmentList` 内にも `<a>` タグがあるため、**`<a>` の入れ子（HTML 仕様違反）**が発生していた。

ブラウザは `<a>` の入れ子を検出すると DOM を再構成し、内側の `<a>` を外側の `<a>` と同じ階層に移動させる。その結果、`e.stopPropagation()` が機能せず、添付ファイルリンクをクリックしても親の `<Link>` のクリックイベントが発火していた。

## 修正内容

`message-card.tsx` の外側ラッパーを `<Link>` から `<button type="button"> + useRouter` に変更。

```tsx
// Before: <a> の入れ子が発生
<Link href={`/chat-messages/${msg.id}`} className="group block">

// After: <button> + <a> の構造で stopPropagation が正常動作
<button
  type="button"
  onClick={() => router.push(`/chat-messages/${msg.id}`)}
  className="group block w-full cursor-pointer text-left"
>
```

## テスト

- [x] `pnpm typecheck` — 通過
- [x] `pnpm lint` — エラー解消（`<div role="button">` → `<button>` に変更して Biome の `a11y/useSemanticElements` エラーも同時に解消）
- [x] `pnpm test` — 全テスト通過（196 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)