### PR TITLE
fix(web): 添付ファイルリンクを新しいウィンドウで開き Chrome タブインターセプトを回避

### DIFF
--- a/apps/web/src/components/chat/attachment-list.tsx
+++ b/apps/web/src/components/chat/attachment-list.tsx
@@ -40,16 +40,17 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
             ) : (
               <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
             )}
-            <a
-              href={href}
-              target="_blank"
-              rel="noopener noreferrer"
-              onClick={(e) => e.stopPropagation()}
-              className="flex-1 truncate text-primary hover:underline"
-              title="Google Chat でファイルを検索して開く"
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                window.open(href, "_blank", "noopener,noreferrer,width=1400,height=900");
+              }}
+              className="flex-1 truncate text-left text-primary hover:underline"
+              title="Google Chat でファイルを検索して開く（新しいウィンドウ）"
             >
               {displayName}
-            </a>
+            </button>
             {att.contentType && (
               <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
                 {att.contentType.split("/").pop()}


### PR DESCRIPTION
## Summary

- 添付ファイル名をクリックすると既存の Google Chat タブが強制遷移してしまう問題を修正
- 根本原因: Chrome は `mail.google.com` タブが開いていると `target=\"_blank\"` のリンクをインターセプトし、既存タブに URL を送る。Google Chat がその `#search/...` URL を処理してスペース表示に遷移する
- 対策: `<a target="_blank">` から `<button>` + `window.open(href, "_blank", "noopener,noreferrer,width=1400,height=900")` に変更。幅・高さを指定することで Chrome がポップアップウィンドウとして扱い、タブインターセプトを回避する

## Test plan

- [ ] 添付ファイル名をクリックすると新しいポップアップウィンドウが開くこと
- [ ] 既存の Google Chat タブが強制遷移しないこと
- [ ] ポップアップ内でファイル名での検索結果が表示されること
- [ ] カードをクリックすると引き続き詳細ページへ遷移すること（`stopPropagation` が機能していること）
- [ ] `pnpm test` が通過すること ✅

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)