### PR TITLE
fix(web): Google Chat リンクを #search/ URL に変更しメッセージへ直接遷移

### DIFF
--- a/apps/web/src/__tests__/utils.test.ts
+++ b/apps/web/src/__tests__/utils.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildMessageSearchUrl } from "../lib/utils";
+
+describe("buildMessageSearchUrl", () => {
+  it("本文の先頭30文字でエンコードした検索URLを生成する", () => {
+    const url = buildMessageSearchUrl("給与変更をお願いします。詳細は添付の通りです。");
+    expect(url).toBe(
+      "https://mail.google.com/chat/u/0/#search/%E7%B5%A6%E4%B8%8E%E5%A4%89%E6%9B%B4%E3%82%92%E3%81%8A%E9%A1%98%E3%81%84%E3%81%97%E3%81%BE%E3%81%99%E3%80%82%E8%A9%B3%E7%B4%B0%E3%81%AF%E6%B7%BB%E4%BB%98%E3%81%AE%E9%80%9A%E3%82%8A%E3%81%A7%E3%81%99%E3%80%82/cmembership=1",
+    );
+  });
+
+  it("30文字を超える場合は先頭30文字のみ使用する", () => {
+    const longContent = "a".repeat(50);
+    const url = buildMessageSearchUrl(longContent);
+    expect(url).toContain(encodeURIComponent("a".repeat(30)));
+    expect(url).not.toContain(encodeURIComponent("a".repeat(31)));
+  });
+
+  it("空文字列の場合は空文字列を返す", () => {
+    expect(buildMessageSearchUrl("")).toBe("");
+  });
+
+  it("空白のみの場合は空文字列を返す", () => {
+    expect(buildMessageSearchUrl("   ")).toBe("");
+  });
+
+  it("cmembership=1 パラメータが末尾に付く", () => {
+    const url = buildMessageSearchUrl("テスト");
+    expect(url).toContain("/cmembership=1");
+  });
+
+  it("u/0 アカウントパスが含まれる", () => {
+    const url = buildMessageSearchUrl("テスト");
+    expect(url).toContain("/chat/u/0/");
+  });
+});

--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -7,6 +7,7 @@ import { ThreadView } from "@/components/chat/thread-view";
 import { ReclassifyForm } from "@/components/reclassify-form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getChatMessage } from "@/lib/api";
+import { buildMessageSearchUrl } from "@/lib/utils";
 import { ChatOpenButton } from "./chat-open-button";
 import { ResponseStatusControl } from "./response-status-control";
 
@@ -50,13 +51,6 @@ function formatDateTime(iso: string) {
   return new Date(iso).toLocaleString("ja-JP");
 }
 
-/** googleMessageId ("spaces/{spaceId}/messages/{messageId}") から Google Chat URL を生成 */
-function buildChatUrl(googleMessageId: string): string {
-  const match = googleMessageId.match(/^spaces\/([^/]+)\/messages\/([^/]+)$/);
-  if (!match) return "";
-  return `https://chat.google.com/room/${match[1]}/${match[2]}`;
-}
-
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
   return (
     <div className="flex justify-between gap-4">
@@ -98,8 +92,8 @@ export default async function ChatMessageDetailPage({ params }: Props) {
             </span>
           )}
         </div>
-        {buildChatUrl(msg.googleMessageId) && (
-          <ChatOpenButton url={buildChatUrl(msg.googleMessageId)} />
+        {buildMessageSearchUrl(msg.content) && (
+          <ChatOpenButton url={buildMessageSearchUrl(msg.content)} />
         )}
       </div>
 

--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { AttachmentList } from "@/components/chat/attachment-list";
 import { ContentWithMentions } from "@/components/chat/rich-content";
 import type { ChatMessageSummary } from "@/lib/types";
+import { buildMessageSearchUrl } from "@/lib/utils";
 
 export const CATEGORY_CONFIG: Record<string, { label: string; accent: string; pill: string }> = {
   salary: {
@@ -104,13 +105,6 @@ function getInitials(name: string): string {
   return name.slice(0, 2);
 }
 
-/** googleMessageId ("spaces/{spaceId}/messages/{messageId}") から Google Chat URL を生成 */
-function buildChatUrl(googleMessageId: string): string {
-  const match = googleMessageId.match(/^spaces\/([^/]+)\/messages\/([^/]+)$/);
-  if (!match) return "";
-  return `https://chat.google.com/room/${match[1]}/${match[2]}`;
-}
-
 function formatDateTime(iso: string): string {
   return new Date(iso).toLocaleString("ja-JP", {
     timeZone: "Asia/Tokyo",
@@ -196,19 +190,19 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
                 <time className="font-mono text-xs text-slate-400 tabular-nums">
                   {formatDateTime(msg.createdAt)}
                 </time>
-                {buildChatUrl(msg.googleMessageId) && (
+                {buildMessageSearchUrl(msg.content) && (
                   <button
                     type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       window.open(
-                        buildChatUrl(msg.googleMessageId),
+                        buildMessageSearchUrl(msg.content),
                         "_blank",
                         "noopener,noreferrer,width=1400,height=900",
                       );
                     }}
                     className="text-slate-400 transition-colors hover:text-slate-600"
-                    title="Google Chat で開く（新しいウィンドウ）"
+                    title="Google Chat でメッセージを検索して開く（新しいウィンドウ）"
                   >
                     <ExternalLink size={12} />
                   </button>

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/** メッセージ本文の先頭部分で Google Chat 内検索するURL */
+export function buildMessageSearchUrl(content: string): string {
+  const query = content.trim().slice(0, 30);
+  if (!query) return "";
+  return `https://mail.google.com/chat/u/0/#search/${encodeURIComponent(query)}/cmembership=1`;
+}


### PR DESCRIPTION
## Summary

`chat.google.com/room/{spaceId}/{messageId}` 形式は特定メッセージへのディープリンクにならず、ルームを開くだけ。添付ファイルリンクと同方針で、メッセージ本文の先頭30文字を使った `#search/` 検索URLに変更する。

**変更内容**

| ファイル | 変更箇所 |
|---------|---------|
| `lib/utils.ts` | `buildMessageSearchUrl()` 追加 |
| `message-card.tsx` | `buildChatUrl` → `buildMessageSearchUrl(msg.content)` |
| `[id]/page.tsx` | `buildChatUrl` → `buildMessageSearchUrl(msg.content)` |
| `__tests__/utils.test.ts` | ユニットテスト6件追加 |

**生成されるURL例**
```
https://mail.google.com/chat/u/0/#search/給与変更をお願いします。詳細/cmembership=1
```
（添付ファイル検索と同じ `mail.google.com/chat/#search/` 形式）

## Test plan

- [ ] メッセージ一覧の ExternalLink アイコン → 本文で検索したポップアップが開く
- [ ] 詳細ページの「Google Chat で開く」→ 本文で検索したポップアップが開く
- [ ] 本文が空のメッセージではボタンが非表示になること
- [ ] `pnpm test` 42件通過 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)