### PR TITLE
fix(web): パイチャートのラベル重なりを Legend 表示に変更

### DIFF
--- a/apps/web/src/components/dashboard-charts.tsx
+++ b/apps/web/src/components/dashboard-charts.tsx
@@ -50,27 +50,21 @@ function formatCount(value: number | undefined): [string, string] {
 export function CategoryPieChart({ data }: { data: CategoryStat[] }) {
   const filtered = data.filter((d) => d.count > 0);
   return (
-    <ResponsiveContainer width="100%" height={300}>
+    <ResponsiveContainer width="100%" height={420}>
       <PieChart>
-        <Pie
-          data={filtered}
-          dataKey="count"
-          nameKey="label"
-          cx="50%"
-          cy="50%"
-          outerRadius={100}
-          label={(props: { payload?: CategoryStat }) => {
-            const d = props.payload;
-            return d ? `${d.label} ${d.percentage}%` : "";
-          }}
-          labelLine={false}
-          fontSize={11}
-        >
+        <Pie data={filtered} dataKey="count" nameKey="label" cx="50%" cy="42%" outerRadius={110}>
           {filtered.map((entry) => (
             <Cell key={entry.category} fill={CATEGORY_COLORS[entry.category] ?? "#6b7280"} />
           ))}
         </Pie>
         <Tooltip formatter={formatCount} />
+        <Legend
+          // biome-ignore lint/suspicious/noExplicitAny: Recharts LegendPayload does not expose pie data type
+          formatter={(value: string, entry: any) =>
+            `${value} ${(entry?.payload as CategoryStat | undefined)?.percentage ?? ""}%`
+          }
+          wrapperStyle={{ fontSize: 12 }}
+        />
       </PieChart>
     </ResponsiveContainer>
   );


### PR DESCRIPTION
## 概要

ダッシュボードの「カテゴリ別分布」パイチャートで、小さいスライスのラベルが重なる問題を修正。

## 原因

Recharts の `Pie` コンポーネントにインラインラベルを配置していたため、スライスが小さいカテゴリ（契約・外国人・研修・健康診断等）のラベルが互いに重なっていた。

## 修正内容

- `label` / `labelLine` プロップを削除（インラインラベルを廃止）
- `<Legend>` コンポーネントを追加し、チャート下部にカテゴリ名 + パーセンテージを一覧表示
- チャート高さを 300 → 420 px に拡張、`cy` を 42% に調整して Legend との余白を確保

🤖 Generated with [Claude Code](https://claude.com/claude-code)