### PR TITLE
feat(web): カテゴリ別分布をドーナツ＋横棒グラフ切替タブに変更

### DIFF
--- a/apps/web/src/app/(protected)/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import { MessageSquare, TrendingUp } from "lucide-react";
-import { CategoryBarChart, CategoryPieChart, TimelineChart } from "@/components/dashboard-charts";
+import { CategoryDistributionChart, TimelineChart } from "@/components/dashboard-charts";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { getStatsCategories, getStatsSpaces, getStatsSummary, getStatsTimeline } from "@/lib/api";
 
@@ -40,27 +40,18 @@ export default async function DashboardPage() {
       </div>
 
       {/* カテゴリ別集計 */}
-      <div className="grid gap-6 lg:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <CardTitle>カテゴリ別分布</CardTitle>
-            <CardDescription>全{categoriesData.total}件の分類内訳</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <CategoryPieChart data={categoriesData.categories} />
-          </CardContent>
-        </Card>
-
-        <Card>
-          <CardHeader>
-            <CardTitle>カテゴリ別件数</CardTitle>
-            <CardDescription>件数順の棒グラフ</CardDescription>
-          </CardHeader>
-          <CardContent>
-            <CategoryBarChart data={categoriesData.categories} />
-          </CardContent>
-        </Card>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>カテゴリ別分布</CardTitle>
+          <CardDescription>全{categoriesData.total}件の分類内訳</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <CategoryDistributionChart
+            data={categoriesData.categories}
+            total={categoriesData.total}
+          />
+        </CardContent>
+      </Card>
 
       {/* タイムライン */}
       <Card>

--- a/apps/web/src/components/dashboard-charts.tsx
+++ b/apps/web/src/components/dashboard-charts.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useState } from "react";
 import {
   Bar,
   BarChart,
   CartesianGrid,
   Cell,
+  Label,
   Legend,
   Line,
   LineChart,
@@ -15,6 +17,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { CategoryStat, TimelinePoint } from "@/lib/types";
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -29,19 +32,6 @@ const CATEGORY_COLORS: Record<string, string> = {
   attendance: "#14b8a6",
   other: "#6b7280",
 };
-
-const COLORS = [
-  "#22c55e",
-  "#ef4444",
-  "#3b82f6",
-  "#eab308",
-  "#a855f7",
-  "#f97316",
-  "#6366f1",
-  "#ec4899",
-  "#14b8a6",
-  "#6b7280",
-];
 
 function formatCount(value: number | undefined): [string, string] {
   return [`${value ?? 0}件`, "件数"];
@@ -61,9 +51,131 @@ function PieTooltip({
     <div className="rounded border bg-background px-3 py-2 shadow-md text-sm">
       <p className="font-semibold">{d.name}</p>
       <p className="text-muted-foreground">
-        {d.value}件 ({d.payload.percentage}%)
+        {d.value.toLocaleString("ja-JP")}件 ({d.payload.percentage}%)
       </p>
     </div>
+  );
+}
+
+function BarTooltip({
+  active,
+  payload,
+}: {
+  active?: boolean;
+  payload?: Array<{ value: number; payload: CategoryStat }>;
+}) {
+  if (!active || !payload?.length) return null;
+  const d = payload[0];
+  if (!d) return null;
+  return (
+    <div className="rounded border bg-background px-3 py-2 shadow-md text-sm">
+      <p className="font-semibold">{d.payload.label}</p>
+      <p className="text-muted-foreground">
+        {d.value.toLocaleString("ja-JP")}件 ({d.payload.percentage}%)
+      </p>
+    </div>
+  );
+}
+
+export function CategoryDistributionChart({
+  data,
+  total,
+}: {
+  data: CategoryStat[];
+  total: number;
+}) {
+  const [view, setView] = useState<"donut" | "bar">("donut");
+  const filtered = data.filter((d) => d.count > 0);
+  const sorted = [...filtered].sort((a, b) => b.count - a.count);
+
+  return (
+    <Tabs value={view} onValueChange={(v) => setView(v as "donut" | "bar")}>
+      <TabsList className="mb-2">
+        <TabsTrigger value="donut">ドーナツ</TabsTrigger>
+        <TabsTrigger value="bar">横棒グラフ</TabsTrigger>
+      </TabsList>
+
+      <TabsContent value="donut">
+        <ResponsiveContainer width="100%" height={420}>
+          <PieChart>
+            <Pie
+              data={filtered}
+              dataKey="count"
+              nameKey="label"
+              cx="50%"
+              cy="42%"
+              innerRadius={75}
+              outerRadius={115}
+              animationBegin={0}
+              animationDuration={600}
+            >
+              {filtered.map((entry) => (
+                <Cell
+                  key={entry.category}
+                  fill={CATEGORY_COLORS[entry.category] ?? "#6b7280"}
+                  opacity={entry.category === "other" ? 0.5 : 1}
+                />
+              ))}
+              <Label
+                content={(props) => {
+                  const vb = props.viewBox as { cx?: number; cy?: number } | undefined;
+                  const cx = vb?.cx ?? 0;
+                  const cy = vb?.cy ?? 0;
+                  return (
+                    <text x={cx} y={cy} textAnchor="middle">
+                      <tspan
+                        x={cx}
+                        y={cy - 8}
+                        fontSize={26}
+                        fontWeight={700}
+                        className="fill-foreground"
+                      >
+                        {total.toLocaleString("ja-JP")}
+                      </tspan>
+                      <tspan x={cx} y={cy + 16} fontSize={12} fill="#6b7280">
+                        件
+                      </tspan>
+                    </text>
+                  );
+                }}
+              />
+            </Pie>
+            <Tooltip content={<PieTooltip />} />
+            <Legend
+              // biome-ignore lint/suspicious/noExplicitAny: Recharts LegendPayload does not expose pie data type
+              formatter={(value: string, entry: any) =>
+                `${value} ${(entry?.payload as CategoryStat | undefined)?.percentage ?? ""}%`
+              }
+              wrapperStyle={{ fontSize: 12 }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+      </TabsContent>
+
+      <TabsContent value="bar">
+        <ResponsiveContainer width="100%" height={360}>
+          <BarChart
+            data={sorted}
+            layout="vertical"
+            margin={{ top: 0, right: 48, bottom: 0, left: 0 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+            <XAxis type="number" fontSize={11} />
+            <YAxis type="category" dataKey="label" width={168} fontSize={11} />
+            <Tooltip content={<BarTooltip />} />
+            <Bar dataKey="count" radius={[0, 4, 4, 0]}>
+              {sorted.map((entry) => (
+                <Cell
+                  key={entry.category}
+                  fill={CATEGORY_COLORS[entry.category] ?? "#6b7280"}
+                  opacity={entry.category === "other" ? 0.5 : 1}
+                />
+              ))}
+            </Bar>
+          </BarChart>
+        </ResponsiveContainer>
+      </TabsContent>
+    </Tabs>
   );
 }
 
@@ -99,8 +211,8 @@ export function CategoryBarChart({ data }: { data: CategoryStat[] }) {
         <YAxis type="category" dataKey="label" width={100} fontSize={12} />
         <Tooltip formatter={formatCount} />
         <Bar dataKey="count" radius={[0, 4, 4, 0]}>
-          {data.map((entry, index) => (
-            <Cell key={entry.category} fill={COLORS[index % COLORS.length]} />
+          {data.map((entry) => (
+            <Cell key={entry.category} fill={CATEGORY_COLORS[entry.category] ?? "#6b7280"} />
           ))}
         </Bar>
       </BarChart>


### PR DESCRIPTION
## 概要

ダッシュボードの「カテゴリ別分布」を、ドーナツチャートと横棒グラフをタブで切り替えられる形に刷新。

## 変更内容

### `CategoryDistributionChart`（新規）
- **ドーナツタブ**: `innerRadius=75` でドーナツ化、中央に総件数（例: 5,574件）を表示
- **横棒グラフタブ**: 件数降順ソート、カテゴリ固有色、カスタム Tooltip
- 「その他」スライス/バーを `opacity:0.5` で視覚的に後退
- 両タブでホバー時にカテゴリ名・件数・パーセンテージを表示

### `dashboard/page.tsx`
- 「カテゴリ別分布」と「カテゴリ別件数」の 2 枚カードを 1 枚の `CategoryDistributionChart` に統合

### 既存コンポーネント
- `CategoryPieChart` / `CategoryBarChart` は後方互換のため残置

🤖 Generated with [Claude Code](https://claude.com/claude-code)