### PR TITLE
fix(api): Chat同期 403エラーを修正（ADC 開発者 OAuth クレデンシャル利用）

### DIFF
--- a/apps/api/src/__tests__/chat-sync.test.ts
+++ b/apps/api/src/__tests__/chat-sync.test.ts
@@ -9,17 +9,13 @@ const { mockGetAccessToken, mockGet, mockSet, mockAdd } = vi.hoisted(() => ({
   mockAdd: vi.fn().mockResolvedValue({ id: "audit-1" }),
 }));
 
-// GoogleAuth / Impersonated をクラスベースでモック（vi.clearAllMocks() 耐性）
+// GoogleAuth をクラスベースでモック（vi.clearAllMocks() 耐性）
 vi.mock("google-auth-library", () => ({
   GoogleAuth: class MockGoogleAuth {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(_opts?: unknown) {}
     async getClient() {
-      return {};
-    }
-  },
-  Impersonated: class MockImpersonated {
-    constructor(_opts: unknown) {}
-    async getAccessToken() {
-      return mockGetAccessToken();
+      return { getAccessToken: mockGetAccessToken };
     }
   },
 }));


### PR DESCRIPTION
## 概要

Chat同期ボタンを押すと「Chat API エラー: 403」が発生する問題を修正する。

## 原因

hr-api SA はChatスペースのメンバーでないため、そのままでは `spaces.messages.list` で403が返る。
スペースは外部アカウント追加不可のため、hr-worker SAボット方式も使えない。

## 修正内容

### 認証方式の変更

開発者 OAuth クレデンシャル（`gcloud auth application-default login` で生成）を  
Secret Manager に保存し、Cloud Run の `GOOGLE_APPLICATION_CREDENTIALS` として  
ファイルマウントする方式を採用。

**既実施のインフラ変更:**
- Secret Manager に `CHAT_USER_CREDENTIALS` シークレット作成
- hr-api SA に `roles/secretmanager.secretAccessor` を付与
- Cloud Run hr-api サービスに `/run/secrets/chat-credentials` でマウント済み

### `apps/api/src/services/chat-sync.ts`
- `Impersonated`・`CHAT_WORKER_SA` を削除
- `getAccessToken()` を ADC（`GoogleAuth` + `chat.messages.readonly`）に変更

### `apps/api/src/__tests__/chat-sync.test.ts`
- `google-auth-library` モックを ADC 方式（`getClient → {getAccessToken}`）に修正
- `Impersonated` モッククラスを削除

## 動作確認

- 全52テスト PASS
- TypeScript 型チェック PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)