### PR TITLE
feat(web): カテゴリ別分布を2カラムレイアウトに刷新（空間効率改善）

### DIFF
--- a/apps/web/src/components/dashboard-charts.tsx
+++ b/apps/web/src/components/dashboard-charts.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import {
   Bar,
   BarChart,
@@ -17,7 +16,6 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import type { CategoryStat, TimelinePoint } from "@/lib/types";
 
 const CATEGORY_COLORS: Record<string, string> = {
@@ -57,26 +55,6 @@ function PieTooltip({
   );
 }
 
-function BarTooltip({
-  active,
-  payload,
-}: {
-  active?: boolean;
-  payload?: Array<{ value: number; payload: CategoryStat }>;
-}) {
-  if (!active || !payload?.length) return null;
-  const d = payload[0];
-  if (!d) return null;
-  return (
-    <div className="rounded border bg-background px-3 py-2 shadow-md text-sm">
-      <p className="font-semibold">{d.payload.label}</p>
-      <p className="text-muted-foreground">
-        {d.value.toLocaleString("ja-JP")}件 ({d.payload.percentage}%)
-      </p>
-    </div>
-  );
-}
-
 export function CategoryDistributionChart({
   data,
   total,
@@ -84,98 +62,105 @@ export function CategoryDistributionChart({
   data: CategoryStat[];
   total: number;
 }) {
-  const [view, setView] = useState<"donut" | "bar">("donut");
   const filtered = data.filter((d) => d.count > 0);
   const sorted = [...filtered].sort((a, b) => b.count - a.count);
+  const maxCount = sorted[0]?.count ?? 1;
 
   return (
-    <Tabs value={view} onValueChange={(v) => setView(v as "donut" | "bar")}>
-      <TabsList className="mb-2">
-        <TabsTrigger value="donut">ドーナツ</TabsTrigger>
-        <TabsTrigger value="bar">横棒グラフ</TabsTrigger>
-      </TabsList>
+    <div className="flex flex-col sm:flex-row gap-6 items-center sm:items-start">
+      {/* コンパクトドーナツ（固定200×200px） */}
+      <div className="shrink-0">
+        <PieChart width={200} height={200}>
+          <Pie
+            data={filtered}
+            dataKey="count"
+            nameKey="label"
+            cx={100}
+            cy={100}
+            innerRadius={62}
+            outerRadius={92}
+            animationBegin={0}
+            animationDuration={600}
+            strokeWidth={0}
+          >
+            {filtered.map((entry) => (
+              <Cell
+                key={entry.category}
+                fill={CATEGORY_COLORS[entry.category] ?? "#6b7280"}
+                opacity={entry.category === "other" ? 0.45 : 1}
+              />
+            ))}
+            <Label
+              content={(props) => {
+                const vb = props.viewBox as { cx?: number; cy?: number } | undefined;
+                const cx = vb?.cx ?? 100;
+                const cy = vb?.cy ?? 100;
+                return (
+                  <text x={cx} y={cy} textAnchor="middle">
+                    <tspan
+                      x={cx}
+                      y={cy - 7}
+                      fontSize={22}
+                      fontWeight={700}
+                      className="fill-foreground"
+                    >
+                      {total.toLocaleString("ja-JP")}
+                    </tspan>
+                    <tspan x={cx} y={cy + 13} fontSize={11} fill="#6b7280">
+                      件
+                    </tspan>
+                  </text>
+                );
+              }}
+            />
+          </Pie>
+          <Tooltip content={<PieTooltip />} />
+        </PieChart>
+      </div>
 
-      <TabsContent value="donut">
-        <ResponsiveContainer width="100%" height={420}>
-          <PieChart>
-            <Pie
-              data={filtered}
-              dataKey="count"
-              nameKey="label"
-              cx="50%"
-              cy="42%"
-              innerRadius={75}
-              outerRadius={115}
-              animationBegin={0}
-              animationDuration={600}
-            >
-              {filtered.map((entry) => (
-                <Cell
-                  key={entry.category}
-                  fill={CATEGORY_COLORS[entry.category] ?? "#6b7280"}
-                  opacity={entry.category === "other" ? 0.5 : 1}
-                />
-              ))}
-              <Label
-                content={(props) => {
-                  const vb = props.viewBox as { cx?: number; cy?: number } | undefined;
-                  const cx = vb?.cx ?? 0;
-                  const cy = vb?.cy ?? 0;
-                  return (
-                    <text x={cx} y={cy} textAnchor="middle">
-                      <tspan
-                        x={cx}
-                        y={cy - 8}
-                        fontSize={26}
-                        fontWeight={700}
-                        className="fill-foreground"
-                      >
-                        {total.toLocaleString("ja-JP")}
-                      </tspan>
-                      <tspan x={cx} y={cy + 16} fontSize={12} fill="#6b7280">
-                        件
-                      </tspan>
-                    </text>
-                  );
+      {/* カテゴリランキングリスト */}
+      <div className="flex-1 min-w-0 space-y-2 w-full">
+        {sorted.map((item) => (
+          <div
+            key={item.category}
+            className="flex items-center gap-2.5 px-1 py-0.5 rounded hover:bg-muted/50 transition-colors"
+          >
+            {/* カラードット */}
+            <span
+              className="shrink-0 h-2 w-2 rounded-full"
+              style={{
+                backgroundColor: CATEGORY_COLORS[item.category] ?? "#6b7280",
+                opacity: item.category === "other" ? 0.45 : 1,
+              }}
+            />
+            {/* カテゴリ名 */}
+            <span className="text-xs text-muted-foreground shrink-0 w-48 truncate">
+              {item.label}
+            </span>
+            {/* プログレスバー */}
+            <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden min-w-0">
+              <div
+                className="h-full rounded-full transition-[width] duration-500"
+                style={{
+                  width: `${(item.count / maxCount) * 100}%`,
+                  backgroundColor: CATEGORY_COLORS[item.category] ?? "#6b7280",
+                  opacity: item.category === "other" ? 0.45 : 1,
                 }}
               />
-            </Pie>
-            <Tooltip content={<PieTooltip />} />
-            <Legend
-              // biome-ignore lint/suspicious/noExplicitAny: Recharts LegendPayload does not expose pie data type
-              formatter={(value: string, entry: any) =>
-                `${value} ${(entry?.payload as CategoryStat | undefined)?.percentage ?? ""}%`
-              }
-              wrapperStyle={{ fontSize: 12 }}
-            />
-          </PieChart>
-        </ResponsiveContainer>
-      </TabsContent>
-
-      <TabsContent value="bar">
-        <ResponsiveContainer width="100%" height={360}>
-          <BarChart
-            data={sorted}
-            layout="vertical"
-            margin={{ top: 0, right: 48, bottom: 0, left: 0 }}
-          >
-            <CartesianGrid strokeDasharray="3 3" horizontal={false} />
-            <XAxis type="number" fontSize={11} />
-            <YAxis type="category" dataKey="label" width={168} fontSize={11} />
-            <Tooltip content={<BarTooltip />} />
-            <Bar dataKey="count" radius={[0, 4, 4, 0]}>
-              {sorted.map((entry) => (
-                <Cell
-                  key={entry.category}
-                  fill={CATEGORY_COLORS[entry.category] ?? "#6b7280"}
-                  opacity={entry.category === "other" ? 0.5 : 1}
-                />
-              ))}
-            </Bar>
-          </BarChart>
-        </ResponsiveContainer>
-      </TabsContent>
-    </Tabs>
+            </div>
+            {/* 件数・パーセンテージ */}
+            <div className="shrink-0 flex items-center gap-1.5 w-28 justify-end">
+              <span className="text-xs font-semibold tabular-nums">
+                {item.count.toLocaleString("ja-JP")}
+              </span>
+              <span className="text-xs text-muted-foreground tabular-nums w-10 text-right">
+                {item.percentage}%
+              </span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## 概要

ダッシュボードの「カテゴリ別分布」セクションの空間効率を大幅に改善。

## 変更内容

### Before
- ドーナツ / 横棒グラフ のタブ切り替え UI（高さ ≈ 500px）
- チャートが中央に浮遊し、上下に大きな余白
- 凡例が下部に密集して読みにくい

### After
- 左: コンパクトドーナツ (200×200px 固定) ＋ 右: ランキングリスト
- 高さ ≈ 240px（約50%削減）
- タブ切り替え不要 — 全カテゴリを一覧表示
- 各行: カラードット + カテゴリ名 + プログレスバー + 件数 + %

## 実装の詳細

- `useState` / `Tabs` / `BarTooltip` を削除（不要になったため）
- 「その他」(47.9%) を `opacity: 0.45` で視覚的に弱め
- 行ホバーエフェクト (`hover:bg-muted/50`) で操作感を向上
- プログレスバー幅は最大値カテゴリを 100% として相対比較
- `sm:flex-row` でモバイル縦積み / タブレット以上で横並び

🤖 Generated with [Claude Code](https://claude.com/claude-code)