### PR TITLE
fix(web): モバイルナビ overflow 修正 + カテゴリチャートクリック連動

### DIFF
--- a/apps/web/src/components/dashboard-charts.tsx
+++ b/apps/web/src/components/dashboard-charts.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import {
   Bar,
   BarChart,
@@ -12,6 +13,7 @@ import {
   Pie,
   PieChart,
   ResponsiveContainer,
+  Sector,
   Tooltip,
   XAxis,
   YAxis,
@@ -62,9 +64,17 @@ export function CategoryDistributionChart({
   data: CategoryStat[];
   total: number;
 }) {
+  const [activeCategory, setActiveCategory] = useState<string | null>(null);
   const filtered = data.filter((d) => d.count > 0);
   const sorted = [...filtered].sort((a, b) => b.count - a.count);
   const maxCount = sorted[0]?.count ?? 1;
+  const activeIndex =
+    activeCategory !== null ? filtered.findIndex((d) => d.category === activeCategory) : undefined;
+  const activeStat = activeCategory ? sorted.find((d) => d.category === activeCategory) : null;
+
+  const handleToggle = (category: string) => {
+    setActiveCategory((prev) => (prev === category ? null : category));
+  };
 
   return (
     <div className="flex flex-col sm:flex-row gap-6 items-center sm:items-start">
@@ -82,12 +92,35 @@ export function CategoryDistributionChart({
             animationBegin={0}
             animationDuration={600}
             strokeWidth={0}
+            // @ts-expect-error recharts v3 型定義に activeIndex が未公開
+            activeIndex={activeIndex}
+            // biome-ignore lint/suspicious/noExplicitAny: Recharts activeShape props are untyped
+            activeShape={(props: any) => (
+              <Sector
+                cx={props.cx}
+                cy={props.cy}
+                innerRadius={props.innerRadius - 4}
+                outerRadius={props.outerRadius + 8}
+                startAngle={props.startAngle}
+                endAngle={props.endAngle}
+                fill={props.fill}
+              />
+            )}
+            // biome-ignore lint/suspicious/noExplicitAny: Recharts onClick data is untyped
+            onClick={(entry: any) => handleToggle(entry.category)}
+            style={{ cursor: "pointer" }}
           >
             {filtered.map((entry) => (
               <Cell
                 key={entry.category}
                 fill={CATEGORY_COLORS[entry.category] ?? "#6b7280"}
-                opacity={entry.category === "other" ? 0.45 : 1}
+                opacity={
+                  activeCategory !== null && activeCategory !== entry.category
+                    ? 0.25
+                    : entry.category === "other"
+                      ? 0.45
+                      : 1
+                }
               />
             ))}
             <Label
@@ -95,6 +128,24 @@ export function CategoryDistributionChart({
                 const vb = props.viewBox as { cx?: number; cy?: number } | undefined;
                 const cx = vb?.cx ?? 100;
                 const cy = vb?.cy ?? 100;
+                if (activeStat) {
+                  return (
+                    <text x={cx} y={cy} textAnchor="middle">
+                      <tspan
+                        x={cx}
+                        y={cy - 7}
+                        fontSize={20}
+                        fontWeight={700}
+                        className="fill-foreground"
+                      >
+                        {activeStat.count.toLocaleString("ja-JP")}
+                      </tspan>
+                      <tspan x={cx} y={cy + 13} fontSize={11} fill="#6b7280">
+                        {activeStat.percentage}%
+                      </tspan>
+                    </text>
+                  );
+                }
                 return (
                   <text x={cx} y={cy} textAnchor="middle">
                     <tspan
@@ -119,46 +170,52 @@ export function CategoryDistributionChart({
       </div>
 
       {/* カテゴリランキングリスト */}
-      <div className="flex-1 min-w-0 space-y-2 w-full">
-        {sorted.map((item) => (
-          <div
-            key={item.category}
-            className="flex items-center gap-2.5 px-1 py-0.5 rounded hover:bg-muted/50 transition-colors"
-          >
-            {/* カラードット */}
-            <span
-              className="shrink-0 h-2 w-2 rounded-full"
-              style={{
-                backgroundColor: CATEGORY_COLORS[item.category] ?? "#6b7280",
-                opacity: item.category === "other" ? 0.45 : 1,
-              }}
-            />
-            {/* カテゴリ名 */}
-            <span className="text-xs text-muted-foreground shrink-0 w-48 truncate">
-              {item.label}
-            </span>
-            {/* プログレスバー */}
-            <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden min-w-0">
-              <div
-                className="h-full rounded-full transition-[width] duration-500"
+      <div className="flex-1 min-w-0 space-y-1.5 w-full">
+        {sorted.map((item) => {
+          const isActive = activeCategory === item.category;
+          const isDimmed = activeCategory !== null && !isActive;
+          return (
+            <button
+              key={item.category}
+              type="button"
+              className={`flex w-full items-center gap-2 px-1 py-0.5 rounded cursor-pointer transition-all duration-150 ${isActive ? "bg-muted" : "hover:bg-muted/50"} ${isDimmed ? "opacity-30" : ""}`}
+              onClick={() => handleToggle(item.category)}
+            >
+              {/* カラードット */}
+              <span
+                className="shrink-0 h-2 w-2 rounded-full"
                 style={{
-                  width: `${(item.count / maxCount) * 100}%`,
                   backgroundColor: CATEGORY_COLORS[item.category] ?? "#6b7280",
                   opacity: item.category === "other" ? 0.45 : 1,
                 }}
               />
-            </div>
-            {/* 件数・パーセンテージ */}
-            <div className="shrink-0 flex items-center gap-1.5 w-28 justify-end">
-              <span className="text-xs font-semibold tabular-nums">
-                {item.count.toLocaleString("ja-JP")}
+              {/* カテゴリ名 */}
+              <span className="text-xs text-muted-foreground shrink-0 w-28 md:w-44 truncate">
+                {item.label}
               </span>
-              <span className="text-xs text-muted-foreground tabular-nums w-10 text-right">
-                {item.percentage}%
-              </span>
-            </div>
-          </div>
-        ))}
+              {/* プログレスバー */}
+              <div className="flex-1 h-1.5 rounded-full bg-muted overflow-hidden min-w-0">
+                <div
+                  className="h-full rounded-full transition-[width] duration-500"
+                  style={{
+                    width: `${(item.count / maxCount) * 100}%`,
+                    backgroundColor: CATEGORY_COLORS[item.category] ?? "#6b7280",
+                    opacity: item.category === "other" ? 0.45 : 1,
+                  }}
+                />
+              </div>
+              {/* 件数・パーセンテージ */}
+              <div className="shrink-0 flex items-center gap-1 w-[88px] justify-end">
+                <span className="text-xs font-semibold tabular-nums">
+                  {item.count.toLocaleString("ja-JP")}
+                </span>
+                <span className="text-xs text-muted-foreground tabular-nums w-9 text-right">
+                  {item.percentage}%
+                </span>
+              </div>
+            </button>
+          );
+        })}
       </div>
     </div>
   );

--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -8,7 +8,7 @@ export function Header() {
       <div className="h-[3px] w-full bg-gradient-to-r from-[oklch(0.3_0.1_252)] via-[oklch(0.73_0.18_55)] to-[oklch(0.3_0.1_252)]" />
       <div className="mx-auto flex h-13 max-w-7xl items-center justify-between px-4">
         {/* ロゴ */}
-        <div className="flex items-center gap-5">
+        <div className="flex items-center gap-2 md:gap-5">
           <a href="/" className="flex items-center gap-2 group">
             <span className="flex h-7 w-7 items-center justify-center rounded-md bg-primary text-xs font-bold text-primary-foreground shadow-sm group-hover:shadow-md transition-shadow">
               HR

--- a/apps/web/src/components/nav.tsx
+++ b/apps/web/src/components/nav.tsx
@@ -34,8 +34,9 @@ export function Nav() {
           <Link
             key={href}
             href={href}
+            title={label}
             className={cn(
-              "relative flex items-center gap-1.5 rounded-md px-2.5 py-1.5 text-sm font-medium transition-all duration-150",
+              "relative flex items-center gap-1.5 rounded-md px-1.5 py-1.5 md:px-2.5 text-sm font-medium transition-all duration-150",
               active
                 ? "text-primary nav-active-indicator"
                 : "text-muted-foreground hover:text-foreground hover:bg-accent",
@@ -47,7 +48,7 @@ export function Nav() {
                 active ? "text-[oklch(0.73_0.18_55)]" : "",
               )}
             />
-            {label}
+            <span className="hidden md:inline">{label}</span>
           </Link>
         );
       })}


### PR DESCRIPTION
## 概要

- モバイルでナビゲーションバーが溢れる問題を修正
- カテゴリ分布チャートにクリック連動インタラクションを追加

## 変更内容

### `components/nav.tsx`
- モバイルでラベルテキストを非表示（`hidden md:inline`）
- リンクの padding を `px-1.5 md:px-2.5` でモバイルに最適化
- `title` 属性でアクセシビリティ確保

### `components/header.tsx`
- ロゴ＋ナビ左セクションの gap を `gap-2 md:gap-5` に変更

### `components/dashboard-charts.tsx`
- リスト行クリック → ドーナツの対応セグメントが拡大ハイライト（Sector activeShape）
- ドーナツセグメントクリック → リスト行との双方向トグル
- 非選択項目は opacity 0.25 に減光（フォーカス効果）
- 中央ラベル: 選択時はカテゴリ件数・%に切り替え、解除で合計に戻る
- モバイル幅修正: ラベル `w-48` → `w-28 md:w-44`、数値列 `w-28` → `w-[88px]`

## テスト

- lint: ✅ エラーなし（warning のみ）
- typecheck: ✅ 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)