### PR TITLE
fix(worker): spaces.members.get のURL形式を修正（users/プレフィックス除去）

### DIFF
--- a/apps/worker/src/__tests__/enrich-event.test.ts
+++ b/apps/worker/src/__tests__/enrich-event.test.ts
@@ -155,7 +155,7 @@ describe("enrichChatEvent", () => {
       const result = await enrichChatEvent(event, client);
 
       expect(result.mentionedUsers).toEqual([{ userId: "users/99999", displayName: "山田 花子" }]);
-      expect(client.getMember).toHaveBeenCalledWith("spaces/AAAA-qf5jX0/members/users/99999");
+      expect(client.getMember).toHaveBeenCalledWith("spaces/AAAA-qf5jX0/members/99999");
     });
 
     it("displayName が既にある場合 getMember は呼ばれない", async () => {
@@ -234,7 +234,7 @@ describe("enrichChatEvent", () => {
       const result = await enrichChatEvent(event, client);
 
       expect(result.senderName).toBe("田中 太郎");
-      expect(client.getMember).toHaveBeenCalledWith("spaces/AAAA-qf5jX0/members/users/12345");
+      expect(client.getMember).toHaveBeenCalledWith("spaces/AAAA-qf5jX0/members/12345");
     });
 
     it("sender.displayName が空で getMember が null の場合は event.senderName を維持する", async () => {
@@ -247,7 +247,7 @@ describe("enrichChatEvent", () => {
       const result = await enrichChatEvent(event, client);
 
       expect(result.senderName).toBe("田中 太郎");
-      expect(client.getMember).toHaveBeenCalledWith("spaces/AAAA-qf5jX0/members/users/12345");
+      expect(client.getMember).toHaveBeenCalledWith("spaces/AAAA-qf5jX0/members/12345");
     });
   });
 

--- a/apps/worker/src/lib/enrich-event.ts
+++ b/apps/worker/src/lib/enrich-event.ts
@@ -37,7 +37,7 @@ export async function enrichChatEvent(event: ChatEvent, client: ChatApiClient): 
     const mentionedUsers = await Promise.all(
       rawMentionedUsers.map(async (u) => {
         if (u.displayName !== "" || !u.userId) return u;
-        const memberName = `${event.spaceName}/members/${u.userId}`;
+        const memberName = `${event.spaceName}/members/${u.userId.replace(/^users\//, "")}`;
         const membership = await client.getMember(memberName);
         return { ...u, displayName: membership?.member?.displayName ?? "" };
       }),
@@ -69,7 +69,7 @@ export async function enrichChatEvent(event: ChatEvent, client: ChatApiClient): 
     let senderName = message.sender?.displayName || "";
     if (!senderName && message.sender?.name) {
       const senderMembership = await client.getMember(
-        `${event.spaceName}/members/${message.sender.name}`,
+        `${event.spaceName}/members/${message.sender.name.replace(/^users\//, "")}`,
       );
       senderName = senderMembership?.member?.displayName || "";
     }

--- a/packages/db/src/seed/backfill-chat.ts
+++ b/packages/db/src/seed/backfill-chat.ts
@@ -742,7 +742,7 @@ export async function repairChatMessages(limit?: number): Promise<void> {
         continue;
       }
       await new Promise((resolve) => setTimeout(resolve, REQUEST_DELAY_MS));
-      const memberName = `${data.spaceId ? `spaces/${data.spaceId}` : SPACE_NAME}/members/${u.userId}`;
+      const memberName = `${data.spaceId ? `spaces/${data.spaceId}` : SPACE_NAME}/members/${u.userId.replace(/^users\//, "")}`;
       const member = await fetchMember(requestClient, bearerToken, memberName);
       mentionedUsers.push({ ...u, displayName: member?.displayName ?? "" });
     }
@@ -763,7 +763,7 @@ export async function repairChatMessages(limit?: number): Promise<void> {
     let repairedSenderName = apiMsg.sender?.displayName || "";
     if (!repairedSenderName && apiMsg.sender?.name) {
       await new Promise((resolve) => setTimeout(resolve, REQUEST_DELAY_MS));
-      const senderMemberName = `${data.spaceId ? `spaces/${data.spaceId}` : SPACE_NAME}/members/${apiMsg.sender.name}`;
+      const senderMemberName = `${data.spaceId ? `spaces/${data.spaceId}` : SPACE_NAME}/members/${apiMsg.sender.name.replace(/^users\//, "")}`;
       const senderMember = await fetchMember(requestClient, bearerToken, senderMemberName);
       repairedSenderName = senderMember?.displayName ?? "";
     }


### PR DESCRIPTION
## 概要

`spaces.members.get` API のエンドポイントに `users/` プレフィックスが誤って含まれており、
senderName・mentionedUsers の displayName 補完が全件 404 で失敗していた問題を修正する。

## 原因

Chat API の membership リソース名: `spaces/{space}/members/{numericId}`

`sender.name` や `u.userId` は `users/{numericId}` 形式のため、
そのままパスに連結すると `members/users/{numericId}` になり 404 になる。

```
❌ spaces/AAAA-qf5jX0/members/users/114728874051542119658 → 404
✅ spaces/AAAA-qf5jX0/members/114728874051542119658 → 200
```

## 修正内容

`.replace(/^users\//, "")` で `users/` プレフィックスを除去してから membership リソース名を構築。

修正箇所:
- `apps/worker/src/lib/enrich-event.ts` — mentionedUsers の displayName 補完・senderName 補完
- `packages/db/src/seed/backfill-chat.ts` — repairChatMessages の mentionedUsers・senderName 補完

テスト:
- `getMember` の呼び出し引数期待値を正しい URL 形式 (`members/12345`) に更新
- 全57テスト PASS 確認済み

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)