### PR TITLE
feat(web): 「作成案」ワークフロー管理テーブルビューを追加

### DIFF
--- a/apps/web/src/__tests__/api-contract.test.ts
+++ b/apps/web/src/__tests__/api-contract.test.ts
@@ -103,6 +103,12 @@ const sampleIntentSummary: IntentSummary = {
   isManualOverride: false,
   originalCategory: null,
   responseStatus: "unresponded",
+  taskSummary: null,
+  assignees: null,
+  notes: null,
+  workflowSteps: null,
+  workflowUpdatedBy: null,
+  workflowUpdatedAt: null,
   createdAt: "2026-02-18T00:00:00.000Z",
 };
 

--- a/apps/web/src/app/(protected)/chat-messages/[id]/actions.ts
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/actions.ts
@@ -1,13 +1,20 @@
 "use server";
 
 import { revalidatePath } from "next/cache";
-import { updateResponseStatus } from "@/lib/api";
+import { updateResponseStatus, updateWorkflow } from "@/lib/api";
+import type { WorkflowUpdateRequest } from "@/lib/types";
 
 export async function updateResponseStatusAction(
   chatMessageId: string,
   responseStatus: "unresponded" | "in_progress" | "responded" | "not_required",
 ) {
   await updateResponseStatus(chatMessageId, responseStatus);
+  revalidatePath(`/chat-messages/${chatMessageId}`);
+  revalidatePath("/chat-messages");
+}
+
+export async function updateWorkflowAction(chatMessageId: string, body: WorkflowUpdateRequest) {
+  await updateWorkflow(chatMessageId, body);
   revalidatePath(`/chat-messages/${chatMessageId}`);
   revalidatePath("/chat-messages");
 }

--- a/apps/web/src/app/(protected)/chat-messages/table-view.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/table-view.tsx
@@ -1,0 +1,285 @@
+"use client";
+
+import { ExternalLink } from "lucide-react";
+import Link from "next/link";
+import { useState, useTransition } from "react";
+import type { ChatMessageSummary, WorkflowStepStatus, WorkflowSteps } from "@/lib/types";
+import { buildMessageSearchUrl } from "@/lib/utils";
+import { updateResponseStatusAction, updateWorkflowAction } from "./[id]/actions";
+
+type ResponseStatus = NonNullable<ChatMessageSummary["intent"]>["responseStatus"];
+
+const RS_CYCLE: ResponseStatus[] = ["unresponded", "in_progress", "responded", "not_required"];
+const STEP_CYCLE: WorkflowStepStatus[] = ["undetermined", "completed", "not_required"];
+
+const DEFAULT_STEPS: WorkflowSteps = {
+  salaryListReflection: "undetermined",
+  noticeExecution: "undetermined",
+  laborLawyerShare: "undetermined",
+  smartHRReflection: "undetermined",
+};
+
+const RS_CONFIG: Record<ResponseStatus, { label: string; cls: string }> = {
+  unresponded: { label: "未対応", cls: "bg-rose-50 text-rose-700 border border-rose-200" },
+  in_progress: { label: "対応中", cls: "bg-amber-50 text-amber-700 border border-amber-200" },
+  responded: { label: "対応済", cls: "bg-emerald-50 text-emerald-700 border border-emerald-200" },
+  not_required: { label: "不要", cls: "bg-slate-100 text-slate-500 border border-slate-200" },
+};
+
+const STEP_CONFIG: Record<WorkflowStepStatus, { label: string; cls: string }> = {
+  undetermined: { label: "ー", cls: "text-slate-400 bg-slate-50 border border-slate-200" },
+  completed: {
+    label: "✓",
+    cls: "text-emerald-700 bg-emerald-50 border border-emerald-200 font-bold",
+  },
+  not_required: {
+    label: "✗",
+    cls: "text-slate-400 bg-slate-100 border border-slate-200 line-through",
+  },
+};
+
+function nextInCycle<T>(arr: T[], current: T): T {
+  const idx = arr.indexOf(current);
+  return arr[(idx + 1) % arr.length] ?? arr[0]!;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("ja-JP", {
+    timeZone: "Asia/Tokyo",
+    month: "2-digit",
+    day: "2-digit",
+  });
+}
+
+interface RowState {
+  responseStatus: ResponseStatus;
+  taskSummary: string;
+  assignees: string;
+  notes: string;
+  workflowSteps: WorkflowSteps;
+}
+
+function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
+  const intent = msg.intent;
+  const [isPending, startTransition] = useTransition();
+
+  const [state, setState] = useState<RowState>({
+    responseStatus: intent?.responseStatus ?? "unresponded",
+    taskSummary: intent?.taskSummary ?? "",
+    assignees: intent?.assignees ?? "",
+    notes: intent?.notes ?? "",
+    workflowSteps: intent?.workflowSteps ?? { ...DEFAULT_STEPS },
+  });
+  const [savedText, setSavedText] = useState({
+    taskSummary: intent?.taskSummary ?? "",
+    assignees: intent?.assignees ?? "",
+    notes: intent?.notes ?? "",
+  });
+
+  const handleResponseStatus = () => {
+    if (!intent) return;
+    const next = nextInCycle(RS_CYCLE, state.responseStatus);
+    setState((s) => ({ ...s, responseStatus: next }));
+    startTransition(async () => {
+      await updateResponseStatusAction(msg.id, next);
+    });
+  };
+
+  const handleStep = (key: keyof WorkflowSteps) => {
+    if (!intent) return;
+    const next = nextInCycle(STEP_CYCLE, state.workflowSteps[key]);
+    const newSteps = { ...state.workflowSteps, [key]: next };
+    setState((s) => ({ ...s, workflowSteps: newSteps }));
+    startTransition(async () => {
+      await updateWorkflowAction(msg.id, { workflowSteps: newSteps });
+    });
+  };
+
+  const handleTextBlur = (field: "taskSummary" | "assignees" | "notes") => {
+    const current = state[field];
+    if (current === savedText[field]) return;
+    setSavedText((s) => ({ ...s, [field]: current }));
+    startTransition(async () => {
+      await updateWorkflowAction(msg.id, { [field]: current || null });
+    });
+  };
+
+  const chatUrl = buildMessageSearchUrl(msg.content);
+
+  return (
+    <tr
+      className={`group border-b border-slate-100 transition-colors hover:bg-blue-50/30 ${isPending ? "opacity-60" : ""}`}
+    >
+      {/* No */}
+      <td className="w-8 px-2 py-2 text-center text-xs tabular-nums text-slate-400">{rowNo}</td>
+
+      {/* 発生日 */}
+      <td className="w-16 whitespace-nowrap px-2 py-2 text-xs tabular-nums text-slate-500">
+        {formatDate(msg.createdAt)}
+      </td>
+
+      {/* 記事のコピー */}
+      <td className="max-w-[240px] px-2 py-2">
+        <div className="flex items-start gap-1">
+          <Link
+            href={`/chat-messages/${msg.id}`}
+            className="line-clamp-2 text-xs text-slate-700 hover:text-blue-600 hover:underline"
+          >
+            {msg.content}
+          </Link>
+          {chatUrl && (
+            <a
+              href={chatUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-0.5 shrink-0 text-slate-300 hover:text-slate-500"
+            >
+              <ExternalLink size={10} />
+            </a>
+          )}
+        </div>
+      </td>
+
+      {/* タスク */}
+      <td className="min-w-[120px] px-2 py-1">
+        <textarea
+          rows={2}
+          value={state.taskSummary}
+          onChange={(e) => setState((s) => ({ ...s, taskSummary: e.target.value }))}
+          onBlur={() => handleTextBlur("taskSummary")}
+          disabled={!intent}
+          placeholder={intent ? "タスク" : "ー"}
+          className="w-full resize-none rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-slate-700 placeholder:text-slate-300 focus:border-blue-300 focus:bg-white focus:outline-none disabled:cursor-default"
+        />
+      </td>
+
+      {/* 割り振り */}
+      <td className="min-w-[80px] px-2 py-2">
+        <input
+          type="text"
+          value={state.assignees}
+          onChange={(e) => setState((s) => ({ ...s, assignees: e.target.value }))}
+          onBlur={() => handleTextBlur("assignees")}
+          disabled={!intent}
+          placeholder={intent ? "担当者" : "ー"}
+          className="w-full rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-slate-700 placeholder:text-slate-300 focus:border-blue-300 focus:bg-white focus:outline-none disabled:cursor-default"
+        />
+      </td>
+
+      {/* 対応状況 */}
+      <td className="w-16 px-2 py-2 text-center">
+        {intent ? (
+          <button
+            type="button"
+            onClick={handleResponseStatus}
+            disabled={isPending}
+            className={`cursor-pointer rounded px-1.5 py-0.5 text-xs font-medium transition-opacity hover:opacity-80 ${RS_CONFIG[state.responseStatus].cls}`}
+          >
+            {RS_CONFIG[state.responseStatus].label}
+          </button>
+        ) : (
+          <span className="text-xs text-slate-300">ー</span>
+        )}
+      </td>
+
+      {/* ❶〜❹ */}
+      {(
+        [
+          "salaryListReflection",
+          "noticeExecution",
+          "laborLawyerShare",
+          "smartHRReflection",
+        ] as const
+      ).map((key) => (
+        <td key={key} className="w-10 px-1 py-2 text-center">
+          {intent ? (
+            <button
+              type="button"
+              onClick={() => handleStep(key)}
+              disabled={isPending}
+              className={`w-8 cursor-pointer rounded px-1 py-0.5 text-xs transition-opacity hover:opacity-80 ${STEP_CONFIG[state.workflowSteps[key]].cls}`}
+            >
+              {STEP_CONFIG[state.workflowSteps[key]].label}
+            </button>
+          ) : (
+            <span className="text-xs text-slate-300">ー</span>
+          )}
+        </td>
+      ))}
+
+      {/* メモ */}
+      <td className="min-w-[120px] px-2 py-1">
+        <textarea
+          rows={2}
+          value={state.notes}
+          onChange={(e) => setState((s) => ({ ...s, notes: e.target.value }))}
+          onBlur={() => handleTextBlur("notes")}
+          disabled={!intent}
+          placeholder={intent ? "メモ" : "ー"}
+          className="w-full resize-none rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-slate-700 placeholder:text-slate-300 focus:border-blue-300 focus:bg-white focus:outline-none disabled:cursor-default"
+        />
+      </td>
+    </tr>
+  );
+}
+
+export function TableView({
+  messages,
+  offset = 0,
+}: {
+  messages: ChatMessageSummary[];
+  offset?: number;
+}) {
+  return (
+    <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+      <table className="min-w-full border-collapse">
+        <thead>
+          <tr className="border-b border-slate-200 bg-slate-50">
+            <th className="px-2 py-2 text-center text-xs font-semibold text-slate-500">No</th>
+            <th className="whitespace-nowrap px-2 py-2 text-left text-xs font-semibold text-slate-500">
+              発生日
+            </th>
+            <th className="px-2 py-2 text-left text-xs font-semibold text-slate-500">
+              記事のコピー
+            </th>
+            <th className="px-2 py-2 text-left text-xs font-semibold text-slate-500">タスク</th>
+            <th className="px-2 py-2 text-left text-xs font-semibold text-slate-500">割り振り</th>
+            <th className="whitespace-nowrap px-2 py-2 text-center text-xs font-semibold text-slate-500">
+              対応状況
+            </th>
+            <th
+              className="w-10 px-1 py-2 text-center text-xs font-semibold text-slate-500"
+              title="❶条件通知書SS反映"
+            >
+              ❶
+            </th>
+            <th
+              className="w-10 px-1 py-2 text-center text-xs font-semibold text-slate-500"
+              title="❷通知・締結"
+            >
+              ❷
+            </th>
+            <th
+              className="w-10 px-1 py-2 text-center text-xs font-semibold text-slate-500"
+              title="❸社労士共有"
+            >
+              ❸
+            </th>
+            <th
+              className="w-10 px-1 py-2 text-center text-xs font-semibold text-slate-500"
+              title="❹SmartHR反映"
+            >
+              ❹
+            </th>
+            <th className="px-2 py-2 text-left text-xs font-semibold text-slate-500">メモ</th>
+          </tr>
+        </thead>
+        <tbody>
+          {messages.map((msg, i) => (
+            <TableRow key={msg.id} msg={msg} rowNo={offset + i + 1} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/apps/web/src/app/api/chat-messages/[id]/workflow/route.ts
+++ b/apps/web/src/app/api/chat-messages/[id]/workflow/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server";
+import { ApiError, updateWorkflow } from "@/lib/api";
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { id } = await params;
+    const body = await request.json();
+    const result = await updateWorkflow(id, body);
+    return NextResponse.json(result);
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return NextResponse.json({ error: e.message }, { status: e.status });
+    }
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -22,6 +22,7 @@ import type {
   SyncStatus,
   TestClassificationResult,
   TimelinePoint,
+  WorkflowUpdateRequest,
 } from "@/lib/types";
 
 const API_BASE_URL = process.env.API_BASE_URL ?? "http://localhost:3001";
@@ -201,6 +202,13 @@ export function updateResponseStatus(
     `/api/chat-messages/${id}/response-status`,
     { method: "PATCH", body: JSON.stringify({ responseStatus }) },
   );
+}
+
+export function updateWorkflow(id: string, body: WorkflowUpdateRequest) {
+  return request<{ success: boolean; chatMessageId: string }>(`/api/chat-messages/${id}/workflow`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
 }
 
 // --- Stats ---

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,4 +1,10 @@
-import type { ActorRole, ChangeType, DraftStatus } from "@hr-system/shared";
+import type {
+  ActorRole,
+  ChangeType,
+  DraftStatus,
+  WorkflowStepStatus,
+  WorkflowSteps,
+} from "@hr-system/shared";
 
 /** GET /api/salary-drafts レスポンスの1件 */
 export interface DraftSummary {
@@ -168,6 +174,12 @@ export interface IntentSummary {
   isManualOverride: boolean;
   originalCategory: string | null;
   responseStatus: "unresponded" | "in_progress" | "responded" | "not_required";
+  taskSummary: string | null;
+  assignees: string | null;
+  notes: string | null;
+  workflowSteps: WorkflowSteps | null;
+  workflowUpdatedBy: string | null;
+  workflowUpdatedAt: string | null;
   createdAt: string;
 }
 
@@ -179,6 +191,16 @@ export interface IntentDetail extends IntentSummary {
   responseStatusUpdatedBy: string | null;
   responseStatusUpdatedAt: string | null;
 }
+
+/** PATCH /api/chat-messages/:id/workflow リクエスト */
+export interface WorkflowUpdateRequest {
+  taskSummary?: string | null;
+  assignees?: string | null;
+  notes?: string | null;
+  workflowSteps?: WorkflowSteps;
+}
+
+export type { WorkflowStepStatus, WorkflowSteps };
 
 export interface ChatAnnotation {
   type: "USER_MENTION" | "SLASH_COMMAND" | "RICH_LINK" | "UNKNOWN";

--- a/apps/worker/src/pipeline/process-message.ts
+++ b/apps/worker/src/pipeline/process-message.ts
@@ -113,6 +113,12 @@ export async function processMessage(event: ChatEvent): Promise<void> {
       responseStatus: "unresponded",
       responseStatusUpdatedBy: null,
       responseStatusUpdatedAt: null,
+      taskSummary: null,
+      assignees: null,
+      notes: null,
+      workflowSteps: null,
+      workflowUpdatedBy: null,
+      workflowUpdatedAt: null,
       createdAt: FieldValue.serverTimestamp() as never,
     });
   } catch (e) {

--- a/packages/db/src/seed/backfill-chat.ts
+++ b/packages/db/src/seed/backfill-chat.ts
@@ -504,6 +504,12 @@ async function writeMessages(messages: ChatApiMessage[]): Promise<void> {
         responseStatus: "unresponded" as const,
         responseStatusUpdatedBy: null,
         responseStatusUpdatedAt: null,
+        taskSummary: null,
+        assignees: null,
+        notes: null,
+        workflowSteps: null,
+        workflowUpdatedBy: null,
+        workflowUpdatedAt: null,
         createdAt,
       });
 

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -10,6 +10,7 @@ import type {
   ResponseStatus,
   SalaryItemType,
   UserRole,
+  WorkflowSteps,
 } from "@hr-system/shared";
 import type { Timestamp } from "firebase-admin/firestore";
 
@@ -161,6 +162,13 @@ export interface IntentRecord {
   /** 対応状況を更新した人の email */
   responseStatusUpdatedBy: string | null;
   responseStatusUpdatedAt: Timestamp | null;
+  /** 「作成案」タスク管理フィールド */
+  taskSummary: string | null;
+  assignees: string | null;
+  notes: string | null;
+  workflowSteps: WorkflowSteps | null;
+  workflowUpdatedBy: string | null;
+  workflowUpdatedAt: Timestamp | null;
   createdAt: Timestamp;
 }
 

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -11,6 +11,8 @@ export type {
   ResponseStatus,
   SalaryItemType,
   UserRole,
+  WorkflowStepStatus,
+  WorkflowSteps,
 } from "./types.js";
 export {
   ACTOR_ROLES,
@@ -26,4 +28,5 @@ export {
   TERMINAL_STATUSES,
   USER_ROLES,
   VALID_TRANSITIONS,
+  WORKFLOW_STEP_STATUSES,
 } from "./types.js";

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -108,3 +108,19 @@ export const RESPONSE_STATUSES = [
   "not_required",
 ] as const;
 export type ResponseStatus = (typeof RESPONSE_STATUSES)[number];
+
+/** ワークフローステップの進捗状況 */
+export const WORKFLOW_STEP_STATUSES = ["undetermined", "completed", "not_required"] as const;
+export type WorkflowStepStatus = (typeof WORKFLOW_STEP_STATUSES)[number];
+
+/** 「作成案」ワークフロー管理（スプレッドシート互換） */
+export interface WorkflowSteps {
+  /** ❶条件通知書（変更）の職員給与一覧SSへの反映 */
+  salaryListReflection: WorkflowStepStatus;
+  /** ❷条件通知書（変更）の通知、締結 */
+  noticeExecution: WorkflowStepStatus;
+  /** ❸条件通知書（変更）の社労士共有 */
+  laborLawyerShare: WorkflowStepStatus;
+  /** ❹SmartHRへの反映 */
+  smartHRReflection: WorkflowStepStatus;
+}


### PR DESCRIPTION
## 概要

Google Sheets「作成案」スプレッドシートと同じレイアウトのテーブルビューをチャット分析ページに追加する。

## 変更内容

### データモデル拡張 (packages/shared, packages/db)
- `WorkflowStepStatus` (`undetermined` / `completed` / `not_required`) と `WorkflowSteps` 型を追加
- `IntentRecord` に対応管理フィールドを追加:
  - `taskSummary` / `assignees` / `notes`（テキスト）
  - `workflowSteps`（❶条件通知書SS反映 / ❷通知・締結 / ❸社労士共有 / ❹SmartHR反映）
  - `workflowUpdatedBy` / `workflowUpdatedAt`

### API拡張 (apps/api)
- GET `/api/chat-messages` / `/:id` レスポンスにワークフローフィールドを追加
- **新規**: `PATCH /api/chat-messages/:id/workflow` エンドポイント

### Web (apps/web)
- `updateWorkflow` API クライアント関数を追加
- `updateWorkflowAction` Server Action を追加
- `PATCH /api/chat-messages/[id]/workflow` Next.js プロキシルートを追加
- チャット分析ページ (`/chat-messages`) にカード/テーブルビュー切替タブを追加
- **新規** `table-view.tsx`: スプレッドシート風テーブルビュー
  - インライン編集（タスク / 割り振り / メモ、blur で保存）
  - クリックサイクル（対応状況・❶〜❹、クリックごとに状態を循環）

### その他
- `apps/worker` / `packages/db/seed`: `IntentRecord` 新規作成時に新フィールドを `null` で初期化

## テーブルビューの列構成

| No | 発生日 | 記事のコピー | タスク | 割り振り | 対応状況 | ❶ | ❷ | ❸ | ❹ | メモ |

## テスト計画

- [ ] `pnpm typecheck` — 全パッケージ型チェック通過
- [ ] `pnpm lint` — エラーなし
- [ ] `pnpm test` — 55テスト全件通過
- [ ] `/chat-messages?view=table` でテーブルビューが表示される
- [ ] タスク・割り振り・メモのインライン編集が保存される
- [ ] 対応状況・❶〜❹のクリックで状態が循環する

🤖 Generated with [Claude Code](https://claude.com/claude-code)