### PR TITLE
perf(web): カード/テーブルビュー切替を即時化（Hydration Error 修正含む）

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/view-container.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/view-container.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { LayoutList, MessageSquare, Table2 } from "lucide-react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import type { ChatMessageSummary } from "@/lib/types";
+import { MessageCard } from "./message-card";
+import { TableView } from "./table-view";
+
+export function ViewContainer({
+  messages,
+  offset,
+  initialView,
+}: {
+  messages: ChatMessageSummary[];
+  offset: number;
+  initialView: "card" | "table";
+}) {
+  const [view, setView] = useState<"card" | "table">(initialView);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const switchView = (newView: "card" | "table") => {
+    setView(newView); // 即座にクライアント側を切り替え
+    // URLを同期（ページ遷移ではなく履歴更新のみ）
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("page");
+    if (newView === "card") {
+      params.delete("view");
+    } else {
+      params.set("view", newView);
+    }
+    const qs = params.toString();
+    router.replace(`/chat-messages${qs ? `?${qs}` : ""}`, { scroll: false });
+  };
+
+  return (
+    <div className="space-y-3">
+      {/* ビュー切替 */}
+      <div className="flex justify-end">
+        <div className="flex rounded-lg border border-slate-200 bg-white p-0.5">
+          <button
+            type="button"
+            onClick={() => switchView("card")}
+            className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+              view === "card" ? "bg-slate-900 text-white" : "text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            <LayoutList size={13} />
+            カード
+          </button>
+          <button
+            type="button"
+            onClick={() => switchView("table")}
+            className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
+              view === "table" ? "bg-slate-900 text-white" : "text-slate-500 hover:text-slate-700"
+            }`}
+          >
+            <Table2 size={13} />
+            テーブル
+          </button>
+        </div>
+      </div>
+
+      {/* コンテンツ */}
+      {messages.length === 0 ? (
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-white py-20 text-center">
+          <MessageSquare className="mb-3 text-slate-300" size={36} />
+          <p className="text-sm font-medium text-slate-500">メッセージがありません</p>
+          <p className="mt-1 text-xs text-slate-400">フィルタ条件を変えてお試しください</p>
+        </div>
+      ) : view === "table" ? (
+        <TableView messages={messages} offset={offset} />
+      ) : (
+        <div className="space-y-3">
+          {messages.map((msg) => (
+            <MessageCard key={msg.id} msg={msg} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 概要

チャット分析ページ（`/chat-messages`）のカード/テーブルビュー切替が遅い問題を改善。  
あわせて Hydration Error #418（`useSearchParams` 起因）を修正。

## 変更内容

### `view-container.tsx`（新規）
- `"use client"` のクライアントコンポーネントとして切り出し
- `useState` でビューを即時切り替え（サーバーリクエストなし）
- `useRouter.replace` で URL をバックグラウンド同期（フィルタ条件を維持）

### `page.tsx`
- `<Link href="...">` ベースのビュー切替 UI を削除
- `<Suspense>` で `ViewContainer` をラップ → `useSearchParams` の Hydration Error (#418) を修正
- ヘッダーには `ChatSyncButton` のみ残す

## 改善効果

| Before | After |
|--------|-------|
| クリック → サーバーリクエスト → 全ページ再レンダリング | クリック → `setState` 即時更新（0ms） |
| ページ切替ごとに体感遅延あり | カード⇄テーブル切替が瞬時 |
| Hydration Error (#418) が発生 | Suspense でラップして解消 |

## テスト計画

- [x] `pnpm typecheck` — 通過
- [x] `pnpm lint` — エラーなし
- [ ] `/chat-messages` でカード⇄テーブル切替が即時であることを確認
- [ ] フィルタ（カテゴリ・スペース等）を選択した状態でビュー切替しても条件が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)