### PR TITLE
fix(web): hydration mismatch を修正 (#114)

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/[id]/response-status-control.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/response-status-control.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { formatDateTimeJST } from "@/lib/utils";
 import { updateResponseStatusAction } from "./actions";
 
 type ResponseStatus = "unresponded" | "in_progress" | "responded" | "not_required";
@@ -64,19 +65,7 @@ export function ResponseStatusControl({ chatMessageId, current, updatedBy, updat
       {updatedBy && !saving && (
         <p className="text-xs text-muted-foreground">
           最終更新: {updatedBy}
-          {updatedAt && (
-            <span>
-              {" "}
-              (
-              {new Date(updatedAt).toLocaleString("ja-JP", {
-                month: "2-digit",
-                day: "2-digit",
-                hour: "2-digit",
-                minute: "2-digit",
-              })}
-              )
-            </span>
-          )}
+          {updatedAt && <span> ({formatDateTimeJST(updatedAt)})</span>}
         </p>
       )}
     </div>

--- a/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { LineMessageSummary } from "@/lib/types";
+import { formatDateTimeJST } from "@/lib/utils";
 
 const AVATAR_PALETTE = [
   "bg-rose-400",
@@ -25,15 +26,7 @@ function getInitials(name: string): string {
   return name.slice(0, 2);
 }
 
-function formatDateTime(iso: string): string {
-  return new Date(iso).toLocaleString("ja-JP", {
-    timeZone: "Asia/Tokyo",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
+const formatDateTime = formatDateTimeJST;
 
 export function LineMessageCard({ msg }: { msg: LineMessageSummary }) {
   const senderDisplay = msg.senderName || "不明";

--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation";
 import { AttachmentList } from "@/components/chat/attachment-list";
 import { ContentWithMentions } from "@/components/chat/rich-content";
 import type { ChatMessageSummary } from "@/lib/types";
-import { buildMessageSearchUrl } from "@/lib/utils";
+import { buildMessageSearchUrl, formatDateTimeJST } from "@/lib/utils";
 
 export const CATEGORY_CONFIG: Record<string, { label: string; accent: string; pill: string }> = {
   salary: {
@@ -105,15 +105,7 @@ function getInitials(name: string): string {
   return name.slice(0, 2);
 }
 
-function formatDateTime(iso: string): string {
-  return new Date(iso).toLocaleString("ja-JP", {
-    timeZone: "Asia/Tokyo",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-  });
-}
+const formatDateTime = formatDateTimeJST;
 
 function ConfidenceMeter({ score }: { score: number }) {
   const pct = Math.round(score * 100);

--- a/apps/web/src/app/(protected)/chat-messages/table-view.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/table-view.tsx
@@ -4,7 +4,7 @@ import { ExternalLink } from "lucide-react";
 import Link from "next/link";
 import { useState, useTransition } from "react";
 import type { ChatMessageSummary, WorkflowStepStatus, WorkflowSteps } from "@/lib/types";
-import { buildMessageSearchUrl } from "@/lib/utils";
+import { buildMessageSearchUrl, formatDateJST } from "@/lib/utils";
 import { updateResponseStatusAction, updateWorkflowAction } from "./[id]/actions";
 
 type ResponseStatus = NonNullable<ChatMessageSummary["intent"]>["responseStatus"];
@@ -43,13 +43,7 @@ function nextInCycle<T>(arr: T[], current: T): T {
   return arr[(idx + 1) % arr.length] ?? arr[0]!;
 }
 
-function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString("ja-JP", {
-    timeZone: "Asia/Tokyo",
-    month: "2-digit",
-    day: "2-digit",
-  });
-}
+const formatDate = formatDateJST;
 
 interface RowState {
   responseStatus: ResponseStatus;

--- a/apps/web/src/components/chat/sync-button.tsx
+++ b/apps/web/src/components/chat/sync-button.tsx
@@ -4,6 +4,7 @@ import { Settings } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import type { SyncConfig, SyncStatus } from "@/lib/types";
+import { formatDateTimeJST } from "@/lib/utils";
 
 const INTERVAL_OPTIONS = [
   { label: "5分", value: 5 },
@@ -106,7 +107,7 @@ export function ChatSyncButton() {
   };
 
   const lastSyncLabel = status?.lastSyncedAt
-    ? `最終同期: ${new Date(status.lastSyncedAt).toLocaleString("ja-JP")}`
+    ? `最終同期: ${formatDateTimeJST(status.lastSyncedAt)}`
     : null;
 
   return (
@@ -181,7 +182,7 @@ export function ChatSyncButton() {
 
           {config.updatedAt && (
             <p className="mt-3 text-[10px] text-slate-400">
-              更新: {new Date(config.updatedAt).toLocaleString("ja-JP")}
+              更新: {formatDateTimeJST(config.updatedAt)}
             </p>
           )}
         </div>

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -5,6 +5,26 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
 
+/** Asia/Tokyo の Date を "MM/DD HH:mm" 形式で返す（SSR/Client で一致する決定的フォーマット） */
+export function formatDateTimeJST(iso: string): string {
+  const d = new Date(iso);
+  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000);
+  const mm = String(jst.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(jst.getUTCDate()).padStart(2, "0");
+  const hh = String(jst.getUTCHours()).padStart(2, "0");
+  const mi = String(jst.getUTCMinutes()).padStart(2, "0");
+  return `${mm}/${dd} ${hh}:${mi}`;
+}
+
+/** Asia/Tokyo の Date を "MM/DD" 形式で返す（SSR/Client で一致する決定的フォーマット） */
+export function formatDateJST(iso: string): string {
+  const d = new Date(iso);
+  const jst = new Date(d.getTime() + 9 * 60 * 60 * 1000);
+  const mm = String(jst.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(jst.getUTCDate()).padStart(2, "0");
+  return `${mm}/${dd}`;
+}
+
 /** メッセージ本文の先頭部分で Google Chat 内検索するURL */
 export function buildMessageSearchUrl(content: string): string {
   const query = content.trim().slice(0, 30);


### PR DESCRIPTION
## Summary
- `toLocaleString("ja-JP")` がSSR(Node.js)とクライアント(ブラウザ)で異なる出力を返し、React error #418 が発生していた
- 決定的な手動フォーマット関数 `formatDateTimeJST` / `formatDateJST` を `utils.ts` に追加
- chat-messages 配下の全クライアントコンポーネント（5ファイル）で統一適用

## Changed files
- `apps/web/src/lib/utils.ts` — `formatDateTimeJST`, `formatDateJST` 追加
- `apps/web/src/app/(protected)/chat-messages/message-card.tsx` — formatDateTime 置換
- `apps/web/src/app/(protected)/chat-messages/line-message-card.tsx` — formatDateTime 置換
- `apps/web/src/app/(protected)/chat-messages/table-view.tsx` — formatDate 置換
- `apps/web/src/components/chat/sync-button.tsx` — toLocaleString 置換
- `apps/web/src/app/(protected)/chat-messages/[id]/response-status-control.tsx` — toLocaleString 置換

## Test plan
- [x] `pnpm typecheck` パス
- [x] `pnpm lint` パス
- [ ] 本番デプロイ後、チャット分析ページで React error #418 が発生しないことを確認

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)