### PR TITLE
fix(web): LINE メッセージ全文表示 (#116)

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
@@ -63,7 +63,7 @@ export function LineMessageCard({ msg }: { msg: LineMessageSummary }) {
             </div>
 
             {/* Content */}
-            <p className="mb-2.5 line-clamp-3 text-sm leading-relaxed text-slate-700 whitespace-pre-wrap">
+            <p className="mb-2.5 text-sm leading-relaxed text-slate-700 whitespace-pre-wrap">
               {msg.content}
             </p>
 


### PR DESCRIPTION
## Summary
- LINE メッセージカードの `line-clamp-3` を除去し、メッセージ全文を表示

## Changed files
- `apps/web/src/app/(protected)/chat-messages/line-message-card.tsx` — `line-clamp-3` クラス除去

## Test plan
- [x] `pnpm typecheck` パス
- [ ] LINE メッセージが全文表示されることを確認

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)