### PR TITLE
feat: LINE 画像メッセージ取得・表示対応 (#117)

### DIFF
--- a/apps/api/src/routes/line-messages.ts
+++ b/apps/api/src/routes/line-messages.ts
@@ -48,6 +48,7 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
       senderUserId: msg.senderUserId as string,
       senderName: msg.senderName as string,
       content: msg.content as string,
+      contentUrl: (msg.contentUrl as string) ?? null,
       lineMessageType: msg.lineMessageType as string,
       createdAt: toISO(msg.createdAt as FirebaseFirestore.Timestamp),
     };
@@ -116,6 +117,7 @@ lineMessageRoutes.get("/:id", async (c) => {
     senderUserId: msg.senderUserId,
     senderName: msg.senderName,
     content: msg.content,
+    contentUrl: msg.contentUrl ?? null,
     lineMessageType: msg.lineMessageType,
     rawPayload: msg.rawPayload,
     createdAt: toISO(msg.createdAt),

--- a/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
@@ -63,9 +63,45 @@ export function LineMessageCard({ msg }: { msg: LineMessageSummary }) {
             </div>
 
             {/* Content */}
-            <p className="mb-2.5 text-sm leading-relaxed text-slate-700 whitespace-pre-wrap">
-              {msg.content}
-            </p>
+            {msg.content && (
+              <p className="mb-2.5 text-sm leading-relaxed text-slate-700 whitespace-pre-wrap">
+                {msg.content}
+              </p>
+            )}
+
+            {/* Media (image) */}
+            {msg.contentUrl && msg.lineMessageType === "image" && (
+              <a
+                href={msg.contentUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mb-2.5 block"
+              >
+                <img
+                  src={msg.contentUrl}
+                  alt="LINE 画像"
+                  className="max-h-64 rounded-lg border border-slate-200 object-contain"
+                  loading="lazy"
+                />
+              </a>
+            )}
+
+            {/* Media (other) */}
+            {msg.contentUrl && msg.lineMessageType !== "image" && (
+              <a
+                href={msg.contentUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="mb-2.5 inline-flex items-center gap-1.5 rounded-md bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-200"
+              >
+                {msg.lineMessageType === "video"
+                  ? "動画"
+                  : msg.lineMessageType === "audio"
+                    ? "音声"
+                    : "ファイル"}
+                を開く
+              </a>
+            )}
 
             {/* Metadata */}
             <div className="flex flex-wrap items-center gap-2">

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -326,6 +326,7 @@ export interface LineMessageSummary {
   senderUserId: string;
   senderName: string;
   content: string;
+  contentUrl: string | null;
   lineMessageType: string;
   createdAt: string;
 }

--- a/apps/worker/src/lib/line-api.ts
+++ b/apps/worker/src/lib/line-api.ts
@@ -1,6 +1,7 @@
 import { messagingApi } from "@line/bot-sdk";
 
 let client: messagingApi.MessagingApiClient | null = null;
+let blobClient: messagingApi.MessagingApiBlobClient | null = null;
 
 function getClient(): messagingApi.MessagingApiClient {
   if (!client) {
@@ -9,6 +10,15 @@ function getClient(): messagingApi.MessagingApiClient {
     });
   }
   return client;
+}
+
+function getBlobClient(): messagingApi.MessagingApiBlobClient {
+  if (!blobClient) {
+    blobClient = new messagingApi.MessagingApiBlobClient({
+      channelAccessToken: process.env.LINE_CHANNEL_ACCESS_TOKEN ?? "",
+    });
+  }
+  return blobClient;
 }
 
 /** グループメンバーのプロフィール取得（displayName） */
@@ -32,6 +42,21 @@ export async function getGroupSummary(groupId: string): Promise<string | null> {
     return summary.groupName;
   } catch (e) {
     console.warn(`[LineApi] getGroupSummary failed: ${String(e)}`);
+    return null;
+  }
+}
+
+/** メッセージコンテンツ（画像・動画・ファイル等）のバイナリを取得 */
+export async function getMessageContent(messageId: string): Promise<Buffer | null> {
+  try {
+    const stream = await getBlobClient().getMessageContent(messageId);
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream as AsyncIterable<Buffer>) {
+      chunks.push(Buffer.from(chunk));
+    }
+    return Buffer.concat(chunks);
+  } catch (e) {
+    console.warn(`[LineApi] getMessageContent failed: ${String(e)}`);
     return null;
   }
 }

--- a/apps/worker/src/lib/storage.ts
+++ b/apps/worker/src/lib/storage.ts
@@ -1,0 +1,38 @@
+import { getStorage } from "firebase-admin/storage";
+
+const BUCKET_NAME = process.env.LINE_MEDIA_BUCKET ?? "hr-system-487809-line-media";
+
+const CONTENT_TYPE_MAP: Record<string, string> = {
+  image: "image/jpeg",
+  video: "video/mp4",
+  audio: "audio/m4a",
+};
+
+const EXT_MAP: Record<string, string> = {
+  image: "jpg",
+  video: "mp4",
+  audio: "m4a",
+};
+
+/**
+ * LINE メッセージのメディアコンテンツを Cloud Storage にアップロードし、
+ * 公開URLを返す。
+ */
+export async function uploadLineMedia(
+  messageId: string,
+  messageType: string,
+  data: Buffer,
+): Promise<string> {
+  const bucket = getStorage().bucket(BUCKET_NAME);
+  const ext = EXT_MAP[messageType] ?? "bin";
+  const contentType = CONTENT_TYPE_MAP[messageType] ?? "application/octet-stream";
+  const filePath = `line/${messageType}/${messageId}.${ext}`;
+
+  const file = bucket.file(filePath);
+  await file.save(data, {
+    metadata: { contentType },
+    public: true,
+  });
+
+  return `https://storage.googleapis.com/${BUCKET_NAME}/${filePath}`;
+}

--- a/apps/worker/src/pipeline/process-line-message.ts
+++ b/apps/worker/src/pipeline/process-line-message.ts
@@ -1,6 +1,7 @@
 import { collections } from "@hr-system/db";
 import { Timestamp } from "firebase-admin/firestore";
-import { getGroupMemberProfile, getGroupSummary } from "../lib/line-api.js";
+import { getGroupMemberProfile, getGroupSummary, getMessageContent } from "../lib/line-api.js";
+import { uploadLineMedia } from "../lib/storage.js";
 
 interface LineWebhookEvent {
   type: string;
@@ -55,6 +56,21 @@ export async function processLineEvent(event: LineWebhookEvent): Promise<void> {
     getGroupSummary(groupId),
   ]);
 
+  // メディアメッセージ（image, video, audio, file）の場合、コンテンツをダウンロードしてGCSに保存
+  const MEDIA_TYPES = new Set(["image", "video", "audio", "file"]);
+  let contentUrl: string | null = null;
+  if (MEDIA_TYPES.has(message.type)) {
+    const binary = await getMessageContent(lineMessageId);
+    if (binary) {
+      try {
+        contentUrl = await uploadLineMedia(lineMessageId, message.type, binary);
+        console.log(`[LineWorker] Uploaded media: ${contentUrl}`);
+      } catch (e) {
+        console.warn(`[LineWorker] Media upload failed: ${String(e)}`);
+      }
+    }
+  }
+
   await collections.lineMessages.add({
     groupId,
     groupName: groupName ?? null,
@@ -62,6 +78,7 @@ export async function processLineEvent(event: LineWebhookEvent): Promise<void> {
     senderUserId: userId,
     senderName: senderName ?? "unknown",
     content: message.text ?? "",
+    contentUrl,
     lineMessageType: message.type,
     rawPayload: event as unknown as Record<string, unknown>,
     createdAt: Timestamp.fromMillis(event.timestamp),

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -288,6 +288,8 @@ export interface LineMessage {
   senderName: string;
   /** プレーンテキスト */
   content: string;
+  /** メディアコンテンツの Cloud Storage URL（image, video, audio, file） */
+  contentUrl: string | null;
   /** LINE メッセージタイプ: text, image, video, audio, file, sticker 等 */
   lineMessageType: string;
   /** 生ペイロード（将来の再解析用） */


### PR DESCRIPTION
## Summary
- LINE で送信された画像メッセージを Worker が自動ダウンロードし、Cloud Storage に保存
- ダッシュボードで画像サムネイル表示（動画/音声/ファイルはリンク表示）

## Architecture
```
LINE User → image送信 → Webhook → Worker
  → LINE Content API (MessagingApiBlobClient) で画像取得
  → gs://hr-system-487809-line-media/ にアップロード
  → Firestore に contentUrl 保存
  → API → Web でサムネイル表示
```

## Changed files (7 files)
| File | Change |
|------|--------|
| `packages/db/src/types.ts` | `LineMessage` に `contentUrl: string \| null` 追加 |
| `apps/worker/src/lib/line-api.ts` | `getMessageContent()` 追加 (BlobClient) |
| `apps/worker/src/lib/storage.ts` | **新規** Cloud Storage アップロード関数 |
| `apps/worker/src/pipeline/process-line-message.ts` | image/video/audio/file 時にメディア取得・保存 |
| `apps/api/src/routes/line-messages.ts` | レスポンスに `contentUrl` 追加 |
| `apps/web/src/lib/types.ts` | `LineMessageSummary` に `contentUrl` 追加 |
| `apps/web/src/app/(protected)/chat-messages/line-message-card.tsx` | 画像サムネイル + メディアリンク表示 |

## GCS bucket
- `gs://hr-system-487809-line-media/` 作成済み (asia-northeast1)
- allUsers に objectViewer 付与済み（公開読み取り）

## Test plan
- [x] `pnpm typecheck` パス (全パッケージ)
- [x] `pnpm lint` パス
- [x] `pnpm test` パス (全 119 テスト)
- [ ] Worker デプロイ後、LINE で画像送信 → GCS に保存されることを確認
- [ ] Web でサムネイル表示されることを確認

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)