### PR TITLE
fix(worker): GCS Uniform Bucket-Level Access 互換性修正 + バックフィルスクリプト

### DIFF
--- a/apps/worker/src/lib/storage.ts
+++ b/apps/worker/src/lib/storage.ts
@@ -31,7 +31,6 @@ export async function uploadLineMedia(
   const file = bucket.file(filePath);
   await file.save(data, {
     metadata: { contentType },
-    public: true,
   });
 
   return `https://storage.googleapis.com/${BUCKET_NAME}/${filePath}`;

--- a/apps/worker/src/scripts/backfill-line-media.ts
+++ b/apps/worker/src/scripts/backfill-line-media.ts
@@ -1,0 +1,71 @@
+/**
+ * LINE メディアメッセージのバックフィルスクリプト
+ *
+ * contentUrl が未設定の画像/動画/音声/ファイルメッセージに対して
+ * LINE Content API からバイナリを再取得し、Cloud Storage に保存する。
+ *
+ * 実行:
+ *   LINE_CHANNEL_ACCESS_TOKEN=xxx pnpm --filter @hr-system/worker tsx src/scripts/backfill-line-media.ts
+ *
+ * NOTE: LINE Content API のコンテンツ保持期間は送信後約30日。
+ *       それを過ぎたメッセージは取得不可（スキップされる）。
+ */
+import "@hr-system/db/client"; // Firebase 初期化
+import { collections } from "@hr-system/db";
+import { getMessageContent } from "../lib/line-api.js";
+import { uploadLineMedia } from "../lib/storage.js";
+
+const MEDIA_TYPES = new Set(["image", "video", "audio", "file"]);
+
+async function main() {
+  console.log("[Backfill] Fetching LINE messages without contentUrl...");
+
+  const snapshot = await collections.lineMessages.get();
+  const targets = snapshot.docs.filter((doc) => {
+    const d = doc.data();
+    return MEDIA_TYPES.has(d.lineMessageType) && !d.contentUrl;
+  });
+
+  console.log(`[Backfill] Found ${targets.length} media messages to backfill`);
+
+  let success = 0;
+  let failed = 0;
+  let expired = 0;
+
+  for (const doc of targets) {
+    const msg = doc.data();
+    const messageId = msg.lineMessageId;
+    const type = msg.lineMessageType;
+
+    process.stdout.write(`  ${messageId} (${type})... `);
+
+    const binary = await getMessageContent(messageId);
+    if (!binary) {
+      console.log("SKIP (content expired or unavailable)");
+      expired++;
+      continue;
+    }
+
+    try {
+      const url = await uploadLineMedia(messageId, type, binary);
+      await doc.ref.update({ contentUrl: url });
+      console.log(`OK → ${url}`);
+      success++;
+    } catch (e) {
+      console.log(`FAIL: ${e instanceof Error ? e.message : JSON.stringify(e)}`);
+      failed++;
+    }
+  }
+
+  console.log("\n[Backfill] Complete!");
+  console.log(`  Success: ${success}`);
+  console.log(`  Expired: ${expired}`);
+  console.log(`  Failed:  ${failed}`);
+
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("[Backfill] Fatal error:", e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- `uploadLineMedia` の `public: true` を削除。Uniform Bucket-Level Access 有効バケットではオブジェクトレベル ACL が使えないため 400 エラーになっていた
- 公開アクセスはバケットレベルの `allUsers → roles/storage.objectViewer` ポリシーで担保済み
- `backfill-line-media.ts` スクリプトを追加（`contentUrl` 未設定のメディアメッセージを LINE Content API から再取得して Cloud Storage に保存）

Closes #117

## Test plan
- [x] バックフィルスクリプト実行済み: 2件の画像メッセージが成功
- [x] アップロード済み画像の公開アクセス確認済み（HTTP 200）
- [ ] ダッシュボードで LINE 画像サムネイルの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)