### PR TITLE
test: Phase 2 Inbox テスト追加

### DIFF
--- a/apps/api/src/__tests__/chat-messages-routes.test.ts
+++ b/apps/api/src/__tests__/chat-messages-routes.test.ts
@@ -2,10 +2,13 @@ import { Timestamp } from "firebase-admin/firestore";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- モック変数（vi.hoisted でホイスト） ---
-const { mockChatMessagesGet, mockIntentRecordsGet } = vi.hoisted(() => ({
-  mockChatMessagesGet: vi.fn(),
-  mockIntentRecordsGet: vi.fn(),
-}));
+const { mockChatMessagesGet, mockIntentRecordsGet, mockIntentRecordsCollectionGet } = vi.hoisted(
+  () => ({
+    mockChatMessagesGet: vi.fn(),
+    mockIntentRecordsGet: vi.fn(),
+    mockIntentRecordsCollectionGet: vi.fn(),
+  }),
+);
 
 vi.mock("@hr-system/db", () => {
   const chatMessagesQuery: Record<string, unknown> = {};
@@ -22,6 +25,7 @@ vi.mock("@hr-system/db", () => {
         orderBy: vi.fn(() => chatMessagesQuery),
       },
       intentRecords: {
+        get: vi.fn(() => mockIntentRecordsCollectionGet()),
         where: vi.fn(() => {
           const q: Record<string, unknown> = {
             get: vi.fn(() => mockIntentRecordsGet()),
@@ -80,7 +84,11 @@ function makeChatDoc(id: string) {
   };
 }
 
-function makeIntentSnap(id: string, confidenceScore: number) {
+function makeIntentSnap(
+  id: string,
+  confidenceScore: number,
+  responseStatus: string = "unresponded",
+) {
   return {
     docs: [
       {
@@ -93,7 +101,7 @@ function makeIntentSnap(id: string, confidenceScore: number) {
           isManualOverride: false,
           originalCategory: null,
           regexPattern: null,
-          responseStatus: "unresponded",
+          responseStatus,
           createdAt: now,
         }),
       },
@@ -158,6 +166,135 @@ describe("chat-messages routes", () => {
       const body = (await res.json()) as { data: Array<{ id: string }> };
       expect(body.data).toHaveLength(1);
       expect(body.data[0]!.id).toBe("msg-2");
+    });
+
+    it("responseStatus=in_progress で対応中のメッセージのみ返す", async () => {
+      mockChatMessagesGet.mockResolvedValueOnce({
+        docs: [makeChatDoc("msg-1"), makeChatDoc("msg-2"), makeChatDoc("msg-3")],
+      });
+      mockIntentRecordsGet.mockResolvedValueOnce({
+        docs: [
+          ...makeIntentSnap("msg-1", 0.8, "unresponded").docs,
+          ...makeIntentSnap("msg-2", 0.8, "in_progress").docs,
+          ...makeIntentSnap("msg-3", 0.8, "responded").docs,
+        ],
+      });
+
+      const res = await app.request("/api/chat-messages?responseStatus=in_progress");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: Array<{ id: string }> };
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]!.id).toBe("msg-2");
+    });
+
+    it("responseStatus フィルタで intent が null のメッセージを除外する", async () => {
+      mockChatMessagesGet.mockResolvedValueOnce({
+        docs: [makeChatDoc("msg-1"), makeChatDoc("msg-2")],
+      });
+      // msg-1 の intent は存在しない
+      mockIntentRecordsGet.mockResolvedValueOnce({
+        docs: [...makeIntentSnap("msg-2", 0.8, "responded").docs],
+      });
+
+      const res = await app.request("/api/chat-messages?responseStatus=responded");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: Array<{ id: string }> };
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]!.id).toBe("msg-2");
+    });
+
+    it("responseStatus=unresponded で intent が null のメッセージも除外する", async () => {
+      // intent が null の場合、responseStatus のデフォルトは "unresponded" だが
+      // 実装上は intent == null のときフィルタ外となる
+      mockChatMessagesGet.mockResolvedValueOnce({
+        docs: [makeChatDoc("msg-1"), makeChatDoc("msg-2")],
+      });
+      mockIntentRecordsGet.mockResolvedValueOnce({
+        docs: [...makeIntentSnap("msg-2", 0.8, "unresponded").docs],
+      });
+
+      const res = await app.request("/api/chat-messages?responseStatus=unresponded");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { data: Array<{ id: string }> };
+      // msg-1 は intent null → 除外, msg-2 は unresponded → 通過
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]!.id).toBe("msg-2");
+    });
+  });
+
+  describe("GET /api/chat-messages/inbox-counts", () => {
+    it("対応状況別の件数を集計して返す", async () => {
+      mockIntentRecordsCollectionGet.mockResolvedValueOnce({
+        docs: [
+          { data: () => ({ responseStatus: "unresponded" }) },
+          { data: () => ({ responseStatus: "unresponded" }) },
+          { data: () => ({ responseStatus: "in_progress" }) },
+          { data: () => ({ responseStatus: "responded" }) },
+          { data: () => ({ responseStatus: "not_required" }) },
+          { data: () => ({ responseStatus: "not_required" }) },
+        ],
+      });
+
+      const res = await app.request("/api/chat-messages/inbox-counts");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        counts: {
+          unresponded: number;
+          in_progress: number;
+          responded: number;
+          not_required: number;
+        };
+      };
+      expect(body.counts).toEqual({
+        unresponded: 2,
+        in_progress: 1,
+        responded: 1,
+        not_required: 2,
+      });
+    });
+
+    it("responseStatus が未設定のドキュメントを unresponded としてカウントする", async () => {
+      mockIntentRecordsCollectionGet.mockResolvedValueOnce({
+        docs: [
+          { data: () => ({ responseStatus: undefined }) },
+          { data: () => ({}) },
+          { data: () => ({ responseStatus: "responded" }) },
+        ],
+      });
+
+      const res = await app.request("/api/chat-messages/inbox-counts");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        counts: {
+          unresponded: number;
+          in_progress: number;
+          responded: number;
+          not_required: number;
+        };
+      };
+      expect(body.counts.unresponded).toBe(2);
+      expect(body.counts.responded).toBe(1);
+    });
+
+    it("ドキュメントが空の場合は全カウント0を返す", async () => {
+      mockIntentRecordsCollectionGet.mockResolvedValueOnce({ docs: [] });
+
+      const res = await app.request("/api/chat-messages/inbox-counts");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        counts: {
+          unresponded: number;
+          in_progress: number;
+          responded: number;
+          not_required: number;
+        };
+      };
+      expect(body.counts).toEqual({
+        unresponded: 0,
+        in_progress: 0,
+        responded: 0,
+        not_required: 0,
+      });
     });
   });
 });

--- a/apps/web/src/__tests__/utils.test.ts
+++ b/apps/web/src/__tests__/utils.test.ts
@@ -1,5 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { buildMessageSearchUrl } from "../lib/utils";
+
+// sidebar-nav の依存をモック（@/lib/utils の cn 関数）
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+}));
+
+// next/navigation のモック
+vi.mock("next/navigation", () => ({
+  usePathname: vi.fn(() => "/"),
+}));
+
+import { isNavActive } from "../components/sidebar-nav";
 
 describe("buildMessageSearchUrl", () => {
   it("本文の先頭30文字でエンコードした検索URLを生成する", () => {
@@ -32,5 +44,37 @@ describe("buildMessageSearchUrl", () => {
   it("u/0 アカウントパスが含まれる", () => {
     const url = buildMessageSearchUrl("テスト");
     expect(url).toContain("/chat/u/0/");
+  });
+});
+
+describe("isNavActive", () => {
+  it("/ はルートパスのみマッチする", () => {
+    expect(isNavActive("/", "/")).toBe(true);
+    expect(isNavActive("/", "/inbox")).toBe(false);
+    expect(isNavActive("/", "/dashboard")).toBe(false);
+  });
+
+  it("/inbox は /inbox で始まるパスにマッチする", () => {
+    expect(isNavActive("/inbox", "/inbox")).toBe(true);
+    expect(isNavActive("/inbox", "/inbox/detail")).toBe(true);
+    expect(isNavActive("/inbox", "/")).toBe(false);
+  });
+
+  it("/dashboard は /dashboard で始まるパスにマッチする", () => {
+    expect(isNavActive("/dashboard", "/dashboard")).toBe(true);
+    expect(isNavActive("/dashboard", "/dashboard/sub")).toBe(true);
+    expect(isNavActive("/dashboard", "/")).toBe(false);
+  });
+
+  it("/admin/users は /admin で始まるパスにマッチする", () => {
+    expect(isNavActive("/admin/users", "/admin/users")).toBe(true);
+    expect(isNavActive("/admin/users", "/admin/other")).toBe(true);
+    expect(isNavActive("/admin/users", "/")).toBe(false);
+  });
+
+  it("/chat-messages は /chat-messages で始まるパスにマッチする", () => {
+    expect(isNavActive("/chat-messages", "/chat-messages")).toBe(true);
+    expect(isNavActive("/chat-messages", "/chat-messages/msg-123")).toBe(true);
+    expect(isNavActive("/chat-messages", "/")).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Phase 2（Inbox + Task管理）で追加された機能のテストを追加
- `responseStatus` フィルタ、`inbox-counts` エンドポイント、`isNavActive` ナビゲーション判定をカバー

## 変更内容

### BE: `chat-messages-routes.test.ts`
- `responseStatus=in_progress` フィルタで対応中メッセージのみ返す
- `responseStatus` フィルタで intent が null のメッセージを除外する
- `responseStatus=unresponded` で intent null も除外する
- `inbox-counts` エンドポイント: 混合ステータスの集計
- `inbox-counts`: 未設定 responseStatus → unresponded としてカウント
- `inbox-counts`: 空コレクション → 全カウント 0
- `makeIntentSnap` ヘルパーに `responseStatus` パラメータ追加
- Firestore モックに `collections.intentRecords.get()` サポート追加

### FE: `utils.test.ts`
- `isNavActive` の全ナビゲーションパスマッチング検証（`/`, `/inbox`, `/dashboard`, `/admin/users`, `/chat-messages`）

## Test plan
- [x] `pnpm test` 全パッケージ通過（7/7）
- [x] BE: 9テスト全パス
- [x] FE: 11テスト全パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)