### PR TITLE
feat(web): Phase 3 — ダッシュボード刷新 + 引き継ぎメモ + AI提案パネル

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/[id]/ai-panel.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/ai-panel.tsx
@@ -1,0 +1,114 @@
+import { Bot, Lightbulb } from "lucide-react";
+import type { IntentDetail } from "@/lib/types";
+import { cn } from "@/lib/utils";
+
+const CATEGORY_ACTIONS: Record<string, string[]> = {
+  salary: [
+    "給与変更ドラフトの確認・作成",
+    "職員給与一覧SSへの反映",
+    "SmartHRへの反映",
+    "社労士への共有",
+  ],
+  retirement: [
+    "退職届の確認",
+    "最終給与計算",
+    "退職手続きチェックリスト確認",
+    "社会保険資格喪失届の準備",
+  ],
+  hiring: ["入社書類の送付", "SmartHRへの登録", "給与設定", "社会保険取得届の準備"],
+  contract: ["契約書の作成・更新", "労働条件通知書の発行", "SmartHRの契約情報更新"],
+  transfer: ["異動辞令の発行", "勤務先変更手続き", "通勤手当の再計算"],
+  foreigner: ["在留資格の確認", "ビザ更新手続きの案内", "就労制限の確認"],
+  training: ["研修スケジュールの調整", "受講者リストの更新", "修了証の発行"],
+  health_check: ["健康診断の日程調整", "受診案内の送付", "結果のフォローアップ"],
+  attendance: ["勤怠データの確認", "有給残日数の確認", "勤怠修正の対応"],
+  other: ["内容の確認・対応方針の検討"],
+};
+
+const CONFIDENCE_LABELS: { min: number; label: string; color: string }[] = [
+  { min: 0.8, label: "高信頼度", color: "text-[var(--status-ok)]" },
+  { min: 0.5, label: "中信頼度", color: "text-[var(--status-warn)]" },
+  { min: 0, label: "低信頼度", color: "text-[var(--status-danger)]" },
+];
+
+function getConfidenceLabel(score: number) {
+  return CONFIDENCE_LABELS.find((l) => score >= l.min) ?? CONFIDENCE_LABELS[2]!;
+}
+
+interface AiPanelProps {
+  intent: IntentDetail;
+}
+
+export function AiPanel({ intent }: AiPanelProps) {
+  const conf = getConfidenceLabel(intent.confidenceScore);
+  const actions = CATEGORY_ACTIONS[intent.category] ?? CATEGORY_ACTIONS.other!;
+
+  return (
+    <div className="space-y-4">
+      {/* AI 信頼度 */}
+      <div className="flex items-center gap-3">
+        <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-gradient-accent shadow-sm">
+          <Bot className="h-4 w-4 text-white" />
+        </div>
+        <div>
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold">AI 分類</span>
+            <span className={cn("text-xs font-medium", conf.color)}>
+              {conf.label} ({(intent.confidenceScore * 100).toFixed(0)}%)
+            </span>
+          </div>
+          <p className="text-[10px] text-muted-foreground">
+            {intent.classificationMethod === "ai"
+              ? "Gemini による自動分類"
+              : intent.classificationMethod === "regex"
+                ? "正規表現ルールによる分類"
+                : "手動分類"}
+          </p>
+        </div>
+      </div>
+
+      {/* 信頼度バー */}
+      <div>
+        <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+          <div
+            className={cn(
+              "h-full rounded-full transition-[width] duration-500",
+              intent.confidenceScore >= 0.8
+                ? "bg-[var(--status-ok)]"
+                : intent.confidenceScore >= 0.5
+                  ? "bg-[var(--status-warn)]"
+                  : "bg-[var(--status-danger)]",
+            )}
+            style={{ width: `${intent.confidenceScore * 100}%` }}
+          />
+        </div>
+      </div>
+
+      {/* AI 推論 */}
+      {intent.reasoning && (
+        <div className="rounded-lg border border-border/60 bg-muted/40 p-3">
+          <p className="mb-1 text-[10px] font-semibold text-muted-foreground uppercase tracking-wider">
+            AI の判断理由
+          </p>
+          <p className="text-xs leading-relaxed text-foreground/80">{intent.reasoning}</p>
+        </div>
+      )}
+
+      {/* 推奨アクション */}
+      <div>
+        <div className="mb-2 flex items-center gap-1.5">
+          <Lightbulb className="h-3.5 w-3.5 text-[var(--status-warn)]" />
+          <p className="text-xs font-semibold text-muted-foreground">推奨アクション</p>
+        </div>
+        <ul className="space-y-1">
+          {actions.map((action) => (
+            <li key={action} className="flex items-start gap-2 text-xs text-foreground/80">
+              <span className="mt-1.5 h-1 w-1 rounded-full bg-[var(--gradient-from)] flex-shrink-0" />
+              {action}
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -8,6 +8,7 @@ import { ReclassifyForm } from "@/components/reclassify-form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { getChatMessage } from "@/lib/api";
 import { buildMessageSearchUrl } from "@/lib/utils";
+import { AiPanel } from "./ai-panel";
 import { ChatOpenButton } from "./chat-open-button";
 import { ResponseStatusControl } from "./response-status-control";
 
@@ -149,10 +150,10 @@ export default async function ChatMessageDetailPage({ params }: Props) {
           </CardContent>
         </Card>
 
-        {/* AI 分類結果 */}
+        {/* AI 分類 + 推奨アクション */}
         <Card>
           <CardHeader>
-            <CardTitle className="text-lg">分類結果</CardTitle>
+            <CardTitle className="text-lg">AI 分析</CardTitle>
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             {intent ? (
@@ -171,27 +172,6 @@ export default async function ChatMessageDetailPage({ params }: Props) {
                     </span>
                   )}
                 </div>
-                <Row
-                  label="分類方法"
-                  value={METHOD_LABELS[intent.classificationMethod] ?? intent.classificationMethod}
-                />
-                <Row label="信頼度" value={`${(intent.confidenceScore * 100).toFixed(1)}%`} />
-                {intent.regexPattern && (
-                  <Row
-                    label="マッチパターン"
-                    value={
-                      <code className="rounded bg-muted px-1 text-xs">{intent.regexPattern}</code>
-                    }
-                  />
-                )}
-                {intent.reasoning && (
-                  <div>
-                    <p className="text-muted-foreground">AI 推論</p>
-                    <p className="mt-1 rounded-md bg-muted p-2 text-xs leading-relaxed">
-                      {intent.reasoning}
-                    </p>
-                  </div>
-                )}
                 {intent.isManualOverride && intent.originalCategory && (
                   <Row
                     label="元のカテゴリ"
@@ -202,6 +182,17 @@ export default async function ChatMessageDetailPage({ params }: Props) {
                 {intent.overriddenAt && (
                   <Row label="修正日時" value={formatDateTime(intent.overriddenAt)} />
                 )}
+                {intent.regexPattern && (
+                  <Row
+                    label="マッチパターン"
+                    value={
+                      <code className="rounded bg-muted px-1 text-xs">{intent.regexPattern}</code>
+                    }
+                  />
+                )}
+                <div className="border-t border-border/60 pt-3">
+                  <AiPanel intent={intent} />
+                </div>
               </>
             ) : (
               <p className="text-muted-foreground">分類結果がありません</p>

--- a/apps/web/src/app/(protected)/dashboard/inbox-status-bar.tsx
+++ b/apps/web/src/app/(protected)/dashboard/inbox-status-bar.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import type { InboxCounts } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+export function InboxStatusBar({ counts }: { counts: InboxCounts }) {
+  const total = Object.values(counts).reduce((a, b) => a + b, 0);
+
+  const segments: { label: string; count: number; color: string }[] = [
+    { label: "未対応", count: counts.unresponded, color: "bg-[var(--status-danger)]" },
+    { label: "対応中", count: counts.in_progress, color: "bg-[var(--status-warn)]" },
+    { label: "対応済", count: counts.responded, color: "bg-[var(--status-ok)]" },
+    { label: "対応不要", count: counts.not_required, color: "bg-muted-foreground/30" },
+  ];
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-card p-4">
+      <p className="mb-3 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        対応状況
+      </p>
+      <div className="flex gap-2">
+        {segments.map((seg) => {
+          const pct = total > 0 ? (seg.count / total) * 100 : 0;
+          return (
+            <div key={seg.label} className="flex-1 min-w-0">
+              <div className="flex items-center justify-between mb-1.5">
+                <span className="text-[10px] text-muted-foreground">{seg.label}</span>
+                <span className="text-xs font-semibold tabular-nums">{seg.count}</span>
+              </div>
+              <div className="h-2 rounded-full bg-muted overflow-hidden">
+                <div
+                  className={cn("h-full rounded-full transition-[width] duration-700", seg.color)}
+                  style={{ width: `${Math.max(pct, seg.count > 0 ? 4 : 0)}%` }}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(protected)/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/dashboard/page.tsx
@@ -1,129 +1,159 @@
-import { MessageSquare, TrendingUp } from "lucide-react";
+import { BarChart3, Calendar, MessageSquare, TrendingUp } from "lucide-react";
 import { AutoRefresh } from "@/components/auto-refresh";
 import { CategoryDistributionChart, TimelineChart } from "@/components/dashboard-charts";
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { getStatsCategories, getStatsSpaces, getStatsSummary, getStatsTimeline } from "@/lib/api";
+import {
+  getInboxCounts,
+  getStatsCategories,
+  getStatsSpaces,
+  getStatsSummary,
+  getStatsTimeline,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { InboxStatusBar } from "./inbox-status-bar";
 
 export default async function DashboardPage() {
-  const [summary, categoriesData, timelineData, spacesData] = await Promise.all([
+  const [summary, categoriesData, timelineData, spacesData, inboxData] = await Promise.all([
     getStatsSummary(),
     getStatsCategories(),
     getStatsTimeline({ granularity: "day" }),
     getStatsSpaces(),
+    getInboxCounts(),
   ]);
+
+  const counts = inboxData.counts;
 
   return (
     <div className="space-y-6">
       <AutoRefresh />
-      <h1 className="text-2xl font-bold">ダッシュボード</h1>
+
+      {/* ヘッダー */}
+      <div className="flex items-center gap-3">
+        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-accent shadow-sm">
+          <BarChart3 className="h-5 w-5 text-white" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold tracking-tight">ダッシュボード</h1>
+          <p className="text-xs text-muted-foreground">メッセージ分析・対応状況の概要</p>
+        </div>
+      </div>
 
       {/* サマリーカード */}
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
         <SummaryCard
-          title="総メッセージ数"
+          label="総メッセージ"
           value={summary.total}
-          icon={<MessageSquare className="h-4 w-4 text-muted-foreground" />}
+          icon={<MessageSquare className="h-4 w-4" />}
+          iconBg="bg-blue-100"
+          iconColor="text-blue-600"
         />
         <SummaryCard
-          title="今日"
+          label="今日"
           value={summary.today}
-          icon={<TrendingUp className="h-4 w-4 text-muted-foreground" />}
+          icon={<Calendar className="h-4 w-4" />}
+          iconBg="bg-emerald-100"
+          iconColor="text-emerald-600"
         />
         <SummaryCard
-          title="今週"
+          label="今週"
           value={summary.thisWeek}
-          icon={<TrendingUp className="h-4 w-4 text-muted-foreground" />}
+          icon={<TrendingUp className="h-4 w-4" />}
+          iconBg="bg-purple-100"
+          iconColor="text-purple-600"
         />
         <SummaryCard
-          title="今月"
-          value={summary.thisMonth}
-          icon={<TrendingUp className="h-4 w-4 text-muted-foreground" />}
+          label="未対応"
+          value={counts.unresponded}
+          icon={<MessageSquare className="h-4 w-4" />}
+          iconBg={counts.unresponded > 0 ? "bg-red-100" : "bg-muted"}
+          iconColor={counts.unresponded > 0 ? "text-red-600" : "text-muted-foreground"}
         />
       </div>
 
-      {/* カテゴリ別集計 */}
-      <Card>
-        <CardHeader>
-          <CardTitle>カテゴリ別分布</CardTitle>
-          <CardDescription>全{categoriesData.total}件の分類内訳</CardDescription>
-        </CardHeader>
-        <CardContent>
+      {/* Inbox 対応状況バー */}
+      <InboxStatusBar counts={counts} />
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        {/* カテゴリ別分布 */}
+        <div className="rounded-xl border border-border/60 bg-card p-5">
+          <div className="mb-4">
+            <h2 className="text-sm font-semibold">カテゴリ別分布</h2>
+            <p className="text-xs text-muted-foreground">全{categoriesData.total}件の分類内訳</p>
+          </div>
           <CategoryDistributionChart
             data={categoriesData.categories}
             total={categoriesData.total}
           />
-        </CardContent>
-      </Card>
+        </div>
 
-      {/* タイムライン */}
-      <Card>
-        <CardHeader>
-          <CardTitle>メッセージ推移（直近30日）</CardTitle>
-          <CardDescription>
-            {timelineData.from.slice(0, 10)} 〜 {timelineData.to.slice(0, 10)}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <TimelineChart data={timelineData.timeline} />
-        </CardContent>
-      </Card>
-
-      {/* スペース別 */}
-      <Card>
-        <CardHeader>
-          <CardTitle>スペース別メッセージ数</CardTitle>
-          <CardDescription>全{spacesData.total}件</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <div className="space-y-3">
-            {spacesData.spaces.map((space) => (
-              <div key={space.spaceId} className="flex items-center justify-between">
-                <span className="text-sm font-medium truncate max-w-[300px]">
-                  {space.displayName}
-                </span>
-                <div className="flex items-center gap-3">
-                  <div className="h-2 rounded-full bg-primary/20 w-[200px]">
+        {/* スペース別 */}
+        <div className="rounded-xl border border-border/60 bg-card p-5">
+          <div className="mb-4">
+            <h2 className="text-sm font-semibold">スペース別メッセージ</h2>
+            <p className="text-xs text-muted-foreground">全{spacesData.total}件</p>
+          </div>
+          <div className="space-y-2.5">
+            {spacesData.spaces.map((space) => {
+              const pct = spacesData.total > 0 ? (space.count / spacesData.total) * 100 : 0;
+              return (
+                <div key={space.spaceId} className="flex items-center gap-3">
+                  <span className="text-xs text-muted-foreground truncate min-w-0 flex-1">
+                    {space.displayName}
+                  </span>
+                  <div className="h-1.5 w-32 rounded-full bg-muted overflow-hidden flex-shrink-0">
                     <div
-                      className="h-2 rounded-full bg-primary"
-                      style={{
-                        width: `${spacesData.total > 0 ? (space.count / spacesData.total) * 100 : 0}%`,
-                      }}
+                      className="h-full rounded-full bg-[var(--gradient-from)] transition-[width] duration-500"
+                      style={{ width: `${pct}%` }}
                     />
                   </div>
-                  <span className="text-sm text-muted-foreground tabular-nums w-12 text-right">
-                    {space.count}件
+                  <span className="text-xs font-medium tabular-nums w-10 text-right flex-shrink-0">
+                    {space.count}
                   </span>
                 </div>
-              </div>
-            ))}
+              );
+            })}
             {spacesData.spaces.length === 0 && (
-              <p className="text-sm text-muted-foreground text-center py-4">データがありません</p>
+              <p className="text-xs text-muted-foreground text-center py-6">データがありません</p>
             )}
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
+
+      {/* タイムライン */}
+      <div className="rounded-xl border border-border/60 bg-card p-5">
+        <div className="mb-4">
+          <h2 className="text-sm font-semibold">メッセージ推移（直近30日）</h2>
+          <p className="text-xs text-muted-foreground">
+            {timelineData.from.slice(0, 10)} 〜 {timelineData.to.slice(0, 10)}
+          </p>
+        </div>
+        <TimelineChart data={timelineData.timeline} />
+      </div>
     </div>
   );
 }
 
 function SummaryCard({
-  title,
+  label,
   value,
   icon,
+  iconBg,
+  iconColor,
 }: {
-  title: string;
+  label: string;
   value: number;
   icon: React.ReactNode;
+  iconBg: string;
+  iconColor: string;
 }) {
   return (
-    <Card>
-      <CardHeader className="flex flex-row items-center justify-between pb-2">
-        <CardTitle className="text-sm font-medium">{title}</CardTitle>
-        {icon}
-      </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-bold">{value.toLocaleString("ja-JP")}</div>
-      </CardContent>
-    </Card>
+    <div className="rounded-xl border border-border/60 bg-card p-4 transition-shadow hover:shadow-sm">
+      <div className="flex items-center justify-between mb-3">
+        <span className="text-xs font-medium text-muted-foreground">{label}</span>
+        <div className={cn("flex h-7 w-7 items-center justify-center rounded-lg", iconBg)}>
+          <span className={iconColor}>{icon}</span>
+        </div>
+      </div>
+      <span className="text-2xl font-bold tabular-nums">{value.toLocaleString("ja-JP")}</span>
+    </div>
   );
 }

--- a/apps/web/src/app/(protected)/inbox/handover-form.tsx
+++ b/apps/web/src/app/(protected)/inbox/handover-form.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { Check, Loader2, Pencil } from "lucide-react";
+import { useRef, useState } from "react";
+import type { WorkflowUpdateRequest } from "@/lib/types";
+import { cn } from "@/lib/utils";
+import { updateWorkflowAction } from "./actions";
+
+interface HandoverFormProps {
+  chatMessageId: string;
+  taskSummary: string | null;
+  assignees: string | null;
+  notes: string | null;
+}
+
+export function HandoverForm({ chatMessageId, taskSummary, assignees, notes }: HandoverFormProps) {
+  const [editing, setEditing] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+  const [localTask, setLocalTask] = useState(taskSummary ?? "");
+  const [localAssignees, setLocalAssignees] = useState(assignees ?? "");
+  const [localNotes, setLocalNotes] = useState(notes ?? "");
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  const hasContent = !!(taskSummary || assignees || notes);
+
+  async function handleSave() {
+    setSaving(true);
+    const body: WorkflowUpdateRequest = {
+      taskSummary: localTask || null,
+      assignees: localAssignees || null,
+      notes: localNotes || null,
+    };
+    await updateWorkflowAction(chatMessageId, body);
+    setSaving(false);
+    setSaved(true);
+    setEditing(false);
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(() => setSaved(false), 2000);
+  }
+
+  if (!editing) {
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <p className="text-xs font-semibold text-muted-foreground">引き継ぎメモ</p>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[10px] text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+          >
+            <Pencil className="h-3 w-3" />
+            {hasContent ? "編集" : "追加"}
+          </button>
+        </div>
+        {hasContent ? (
+          <div className="space-y-1.5 text-xs">
+            {taskSummary && (
+              <div>
+                <span className="text-muted-foreground">タスク:</span>{" "}
+                <span className="text-foreground">{taskSummary}</span>
+              </div>
+            )}
+            {assignees && (
+              <div>
+                <span className="text-muted-foreground">担当者:</span>{" "}
+                <span className="text-foreground">{assignees}</span>
+              </div>
+            )}
+            {notes && (
+              <div>
+                <span className="text-muted-foreground">メモ:</span>{" "}
+                <span className="text-foreground">{notes}</span>
+              </div>
+            )}
+          </div>
+        ) : (
+          <p className="text-[10px] text-muted-foreground/60 italic">メモなし</p>
+        )}
+        {saved && (
+          <p className="flex items-center gap-1 text-[10px] text-[var(--status-ok)]">
+            <Check className="h-3 w-3" />
+            保存しました
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs font-semibold text-muted-foreground">引き継ぎメモ</p>
+      <div className="space-y-1.5">
+        <input
+          type="text"
+          placeholder="タスク概要"
+          value={localTask}
+          onChange={(e) => setLocalTask(e.target.value)}
+          className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-[var(--gradient-from)]"
+        />
+        <input
+          type="text"
+          placeholder="担当者"
+          value={localAssignees}
+          onChange={(e) => setLocalAssignees(e.target.value)}
+          className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-[var(--gradient-from)]"
+        />
+        <textarea
+          placeholder="引き継ぎメモ"
+          value={localNotes}
+          onChange={(e) => setLocalNotes(e.target.value)}
+          rows={2}
+          className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-[var(--gradient-from)] resize-none"
+        />
+      </div>
+      <div className="flex gap-1.5">
+        <button
+          type="button"
+          disabled={saving}
+          onClick={handleSave}
+          className={cn(
+            "flex items-center gap-1 rounded-md bg-[var(--gradient-from)] px-3 py-1 text-xs font-medium text-white transition-opacity hover:opacity-90",
+            saving && "opacity-50 pointer-events-none",
+          )}
+        >
+          {saving ? <Loader2 className="h-3 w-3 animate-spin" /> : <Check className="h-3 w-3" />}
+          保存
+        </button>
+        <button
+          type="button"
+          onClick={() => {
+            setEditing(false);
+            setLocalTask(taskSummary ?? "");
+            setLocalAssignees(assignees ?? "");
+            setLocalNotes(notes ?? "");
+          }}
+          className="rounded-md border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-accent transition-colors"
+        >
+          キャンセル
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(protected)/inbox/inbox-list.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-list.tsx
@@ -7,6 +7,7 @@ import { WorkflowPanel } from "@/components/workflow-panel";
 import type { ChatMessageSummary, WorkflowSteps } from "@/lib/types";
 import { cn, formatDateTimeJST } from "@/lib/utils";
 import { updateResponseStatusAction, updateWorkflowAction } from "./actions";
+import { HandoverForm } from "./handover-form";
 
 type ResponseStatus = "unresponded" | "in_progress" | "responded" | "not_required";
 
@@ -159,7 +160,7 @@ function InboxCard({
       {/* Expanded panel */}
       {isExpanded && (
         <div className="border-t border-border/60 bg-muted/30 px-4 py-4 animate-fade-up">
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 md:grid-cols-3">
             {/* Status control */}
             <div>
               <p className="mb-2 text-xs font-semibold text-muted-foreground">対応状況</p>
@@ -192,6 +193,16 @@ function InboxCard({
               <WorkflowPanel
                 steps={intent?.workflowSteps ?? null}
                 onUpdate={handleWorkflowUpdate}
+              />
+            </div>
+
+            {/* Handover notes */}
+            <div>
+              <HandoverForm
+                chatMessageId={message.id}
+                taskSummary={intent?.taskSummary ?? null}
+                assignees={intent?.assignees ?? null}
+                notes={intent?.notes ?? null}
               />
             </div>
           </div>


### PR DESCRIPTION
## Summary
- Phase 3 FE刷新: ダッシュボード、引き継ぎメモ、AI提案パネルの3機能を一括実装
- BE変更なし — 既存API（`PATCH /workflow`, `GET /inbox-counts`）を活用

## 変更内容

### A: ダッシュボード刷新 (`dashboard/page.tsx`, `inbox-status-bar.tsx`)
- グラデーションアクセントアイコン付きヘッダー
- SummaryCard 4枚（総メッセージ/今日/今週/未対応）
- InboxStatusBar: 対応状況別プログレスバー（未対応・対応中・対応済・対応不要）
- カテゴリ分布/スペース別を2カラムレイアウトに変更
- shadcn Card → 軽量なカスタムカードに統一

### B: 引き継ぎメモ (`inbox/handover-form.tsx`, `inbox-list.tsx`)
- Inbox展開パネルにHandoverForm追加（3カラムレイアウト）
- タスク概要 / 担当者 / 引き継ぎメモの表示・編集
- 保存後フィードバック表示（2秒で自動消去）
- 既存 `PATCH /api/chat-messages/:id/workflow` を使用

### C: AI提案パネル (`chat-messages/[id]/ai-panel.tsx`, `page.tsx`)
- AI信頼度バー（高/中/低の3段階カラー）
- AI判断理由の表示
- カテゴリ別推奨アクション一覧（10カテゴリ全対応）
- 既存の「分類結果」カードを「AI分析」カードに統合

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm lint` — エラーなし
- [x] `pnpm test` — 全テスト通過（7パッケージ）
- [ ] ダッシュボードページの表示確認
- [ ] Inbox展開パネルで引き継ぎメモの追加・編集・保存確認
- [ ] チャット詳細ページでAI分析パネルの表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)