### PR TITLE
feat(web): Phase 4 — Admin 設定ページのデザインリフレッシュ

### DIFF
--- a/apps/web/src/app/(protected)/admin/admin-tabs.tsx
+++ b/apps/web/src/app/(protected)/admin/admin-tabs.tsx
@@ -1,32 +1,34 @@
 "use client";
 
+import { MessageSquareMore, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
 
 const tabs = [
-  { href: "/admin/users", label: "ユーザー" },
-  { href: "/admin/spaces", label: "スペース" },
+  { href: "/admin/users", label: "ユーザー", icon: Users },
+  { href: "/admin/spaces", label: "スペース", icon: MessageSquareMore },
 ] as const;
 
 export function AdminTabs() {
   const pathname = usePathname();
 
   return (
-    <nav className="flex gap-4 border-b">
-      {tabs.map(({ href, label }) => {
+    <nav className="flex gap-1">
+      {tabs.map(({ href, label, icon: Icon }) => {
         const active = pathname.startsWith(href);
         return (
           <Link
             key={href}
             href={href}
             className={cn(
-              "pb-2 text-sm font-medium border-b-2 -mb-[2px] transition-colors",
+              "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
               active
-                ? "border-primary text-foreground"
-                : "border-transparent text-muted-foreground hover:text-foreground",
+                ? "bg-[var(--gradient-from)]/10 text-[var(--gradient-from)]"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground",
             )}
           >
+            <Icon className="h-3.5 w-3.5" />
             {label}
           </Link>
         );

--- a/apps/web/src/app/(protected)/admin/layout.tsx
+++ b/apps/web/src/app/(protected)/admin/layout.tsx
@@ -1,9 +1,21 @@
+import { Settings } from "lucide-react";
 import type { ReactNode } from "react";
 import { AdminTabs } from "./admin-tabs";
 
 export default function AdminLayout({ children }: { children: ReactNode }) {
   return (
     <div className="space-y-6">
+      {/* ヘッダー */}
+      <div className="flex items-center gap-3">
+        <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-accent shadow-sm">
+          <Settings className="h-5 w-5 text-white" />
+        </div>
+        <div>
+          <h1 className="text-xl font-bold tracking-tight">管理設定</h1>
+          <p className="text-xs text-muted-foreground">ユーザー・スペースの管理</p>
+        </div>
+      </div>
+
       <AdminTabs />
       {children}
     </div>

--- a/apps/web/src/app/(protected)/admin/spaces/page.tsx
+++ b/apps/web/src/app/(protected)/admin/spaces/page.tsx
@@ -20,7 +20,7 @@ export default async function AdminSpacesPage() {
 
   return (
     <div className="space-y-6">
-      <div className="rounded-lg border border-amber-200 bg-amber-50 p-4">
+      <div className="rounded-xl border border-amber-200/60 bg-amber-50 p-4">
         <p className="text-sm text-amber-800">
           ⚠ 追加するスペースには <span className="font-mono font-medium">{syncAccountEmail}</span>{" "}
           が参加している必要があります。
@@ -61,15 +61,13 @@ export default async function AdminSpacesPage() {
 
       <div className="flex items-center justify-between">
         <div>
-          <h2 className="text-lg font-semibold">スペース一覧</h2>
-          <p className="text-sm text-muted-foreground mt-1">
-            チャット同期の対象スペースを管理します
-          </p>
+          <h2 className="text-sm font-semibold">スペース一覧</h2>
+          <p className="text-xs text-muted-foreground">チャット同期の対象スペースを管理します</p>
         </div>
         <AddSpaceForm />
       </div>
 
-      <div className="rounded-md border">
+      <div className="rounded-xl border border-border/60 bg-card overflow-hidden">
         <Table>
           <TableHeader>
             <TableRow>

--- a/apps/web/src/app/(protected)/admin/users/page.tsx
+++ b/apps/web/src/app/(protected)/admin/users/page.tsx
@@ -17,18 +17,18 @@ export default async function AdminUsersPage() {
   const { data: users } = await getAdminUsers();
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">ユーザー管理</h1>
-          <p className="text-sm text-muted-foreground mt-1">
+          <h2 className="text-sm font-semibold">ユーザー一覧</h2>
+          <p className="text-xs text-muted-foreground">
             ダッシュボードへのアクセスを許可するユーザーを管理します
           </p>
         </div>
         <AddUserForm />
       </div>
 
-      <div className="rounded-md border">
+      <div className="rounded-xl border border-border/60 bg-card overflow-hidden">
         <Table>
           <TableHeader>
             <TableRow>


### PR DESCRIPTION
## Summary
- Admin layout に gradient accent ヘッダー追加（ダッシュボードと統一）
- AdminTabs をアイコン付きピル型タブに刷新
- Users / Spaces テーブルカードを `rounded-xl border-border/60 bg-card` に統一
- Spaces 注意バナーの角丸・ボーダーを統一

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm lint` — エラーなし
- [x] `pnpm test` — 全57テスト通過
- [ ] 目視確認: Admin ユーザー/スペースページの表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)