### PR TITLE
feat(web): Phase 5 — チャット分析ページ デザイントークン統一 + 類似メッセージ

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -6,8 +6,9 @@ import { ContentWithMentions } from "@/components/chat/rich-content";
 import { ThreadView } from "@/components/chat/thread-view";
 import { ReclassifyForm } from "@/components/reclassify-form";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { getChatMessage } from "@/lib/api";
-import { buildMessageSearchUrl } from "@/lib/utils";
+import { getChatMessage, getChatMessages } from "@/lib/api";
+import { buildMessageSearchUrl, formatDateTimeJST } from "@/lib/utils";
+import { CATEGORY_CONFIG } from "../message-card";
 import { AiPanel } from "./ai-panel";
 import { ChatOpenButton } from "./chat-open-button";
 import { ResponseStatusControl } from "./response-status-control";
@@ -16,41 +17,19 @@ interface Props {
   params: Promise<{ id: string }>;
 }
 
-const CATEGORY_LABELS: Record<string, string> = {
-  salary: "給与・社保",
-  retirement: "退職・休職",
-  hiring: "入社・採用",
-  contract: "契約変更",
-  transfer: "施設・異動",
-  foreigner: "外国人・ビザ",
-  training: "研修・監査",
-  health_check: "健康診断",
-  attendance: "勤怠・休暇",
-  other: "その他",
-};
+function getCategoryLabel(category: string): string {
+  return CATEGORY_CONFIG[category]?.label ?? category;
+}
 
-const CATEGORY_COLORS: Record<string, string> = {
-  salary: "bg-green-100 text-green-800",
-  retirement: "bg-red-100 text-red-800",
-  hiring: "bg-blue-100 text-blue-800",
-  contract: "bg-yellow-100 text-yellow-800",
-  transfer: "bg-purple-100 text-purple-800",
-  foreigner: "bg-orange-100 text-orange-800",
-  training: "bg-indigo-100 text-indigo-800",
-  health_check: "bg-pink-100 text-pink-800",
-  attendance: "bg-teal-100 text-teal-800",
-  other: "bg-gray-100 text-gray-600",
-};
+function getCategoryPill(category: string): string {
+  return CATEGORY_CONFIG[category]?.pill ?? "bg-gray-100 text-gray-600";
+}
 
 const METHOD_LABELS: Record<string, string> = {
   ai: "AI (Gemini)",
   regex: "正規表現",
   manual: "手動修正",
 };
-
-function formatDateTime(iso: string) {
-  return new Date(iso).toLocaleString("ja-JP");
-}
 
 function Row({ label, value }: { label: string; value: React.ReactNode }) {
   return (
@@ -66,6 +45,13 @@ export default async function ChatMessageDetailPage({ params }: Props) {
   const msg = await getChatMessage(id);
 
   const intent = msg.intent;
+
+  // 同カテゴリの類似メッセージ取得
+  const similarMessages = intent
+    ? await getChatMessages({ category: intent.category, limit: 6 }).then((res) =>
+        res.data.filter((m) => m.id !== id).slice(0, 5),
+      )
+    : [];
 
   return (
     <div className="space-y-6">
@@ -109,10 +95,10 @@ export default async function ChatMessageDetailPage({ params }: Props) {
             <div className="grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
               <Row label="送信者" value={msg.senderName} />
               <Row label="種別" value={msg.senderType === "HUMAN" ? "ユーザー" : "Bot"} />
-              <Row label="日時" value={formatDateTime(msg.createdAt)} />
+              <Row label="日時" value={formatDateTimeJST(msg.createdAt)} />
               <Row
                 label="処理日時"
-                value={msg.processedAt ? formatDateTime(msg.processedAt) : "未処理"}
+                value={msg.processedAt ? formatDateTimeJST(msg.processedAt) : "未処理"}
               />
             </div>
 
@@ -160,11 +146,11 @@ export default async function ChatMessageDetailPage({ params }: Props) {
               <>
                 <div className="flex items-center gap-2">
                   <span
-                    className={`rounded-full px-3 py-1 text-sm font-medium ${
-                      CATEGORY_COLORS[intent.category] ?? "bg-gray-100 text-gray-600"
-                    }`}
+                    className={`rounded-full px-3 py-1 text-sm font-medium ${getCategoryPill(
+                      intent.category,
+                    )}`}
                   >
-                    {CATEGORY_LABELS[intent.category] ?? intent.category}
+                    {getCategoryLabel(intent.category)}
                   </span>
                   {intent.isManualOverride && (
                     <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800">
@@ -173,14 +159,11 @@ export default async function ChatMessageDetailPage({ params }: Props) {
                   )}
                 </div>
                 {intent.isManualOverride && intent.originalCategory && (
-                  <Row
-                    label="元のカテゴリ"
-                    value={CATEGORY_LABELS[intent.originalCategory] ?? intent.originalCategory}
-                  />
+                  <Row label="元のカテゴリ" value={getCategoryLabel(intent.originalCategory)} />
                 )}
                 {intent.overriddenBy && <Row label="修正者" value={intent.overriddenBy} />}
                 {intent.overriddenAt && (
-                  <Row label="修正日時" value={formatDateTime(intent.overriddenAt)} />
+                  <Row label="修正日時" value={formatDateTimeJST(intent.overriddenAt)} />
                 )}
                 {intent.regexPattern && (
                   <Row
@@ -239,6 +222,43 @@ export default async function ChatMessageDetailPage({ params }: Props) {
           </CardHeader>
           <CardContent>
             <ThreadView messages={msg.threadMessages} />
+          </CardContent>
+        </Card>
+      )}
+
+      {/* 同カテゴリの類似メッセージ */}
+      {similarMessages.length > 0 && intent && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-lg">
+              同カテゴリの最近のメッセージ
+              <span className="ml-2 text-sm font-normal text-muted-foreground">
+                {getCategoryLabel(intent.category)}
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              {similarMessages.map((sm) => (
+                <Link
+                  key={sm.id}
+                  href={`/chat-messages/${sm.id}`}
+                  className="block rounded-lg border border-border/60 px-4 py-3 transition-colors hover:bg-accent"
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="line-clamp-1 min-w-0 flex-1 text-sm text-foreground/80">
+                      {sm.content}
+                    </p>
+                    <time className="shrink-0 font-mono text-xs text-muted-foreground tabular-nums">
+                      {formatDateTimeJST(sm.createdAt)}
+                    </time>
+                  </div>
+                  {sm.senderName && (
+                    <p className="mt-1 text-xs text-muted-foreground">{sm.senderName}</p>
+                  )}
+                </Link>
+              ))}
+            </div>
           </CardContent>
         </Card>
       )}

--- a/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
@@ -17,7 +17,7 @@ const AVATAR_PALETTE = [
 function getAvatarColor(name: string): string {
   let h = 0;
   for (const c of name) h = ((h << 5) - h + c.charCodeAt(0)) | 0;
-  return AVATAR_PALETTE[Math.abs(h) % AVATAR_PALETTE.length] ?? "bg-slate-500";
+  return AVATAR_PALETTE[Math.abs(h) % AVATAR_PALETTE.length] ?? "bg-muted-foreground";
 }
 
 function getInitials(name: string): string {
@@ -35,7 +35,7 @@ export function LineMessageCard({ msg }: { msg: LineMessageSummary }) {
 
   return (
     <div className="group block w-full text-left">
-      <div className="relative border-l-4 border-l-[#06C755] rounded-r-xl bg-white px-5 py-4 shadow ring-1 ring-slate-200/80">
+      <div className="relative border-l-4 border-l-[#06C755] rounded-r-xl bg-card px-5 py-4 shadow ring-1 ring-border/80">
         <div className="flex gap-3">
           {/* Avatar */}
           <div
@@ -52,19 +52,19 @@ export function LineMessageCard({ msg }: { msg: LineMessageSummary }) {
             <div className="mb-1.5 flex items-center justify-between gap-2">
               <div className="flex min-w-0 items-center gap-2">
                 <span
-                  className={`truncate text-sm font-bold ${senderDisplay === "不明" ? "italic text-slate-400" : "text-slate-800"}`}
+                  className={`truncate text-sm font-bold ${senderDisplay === "不明" ? "italic text-muted-foreground" : "text-foreground"}`}
                 >
                   {senderDisplay}
                 </span>
               </div>
-              <time className="shrink-0 font-mono text-xs text-slate-400 tabular-nums">
+              <time className="shrink-0 font-mono text-xs text-muted-foreground tabular-nums">
                 {formatDateTime(msg.createdAt)}
               </time>
             </div>
 
             {/* Content */}
             {msg.content && (
-              <p className="mb-2.5 text-sm leading-relaxed text-slate-700 whitespace-pre-wrap">
+              <p className="mb-2.5 text-sm leading-relaxed text-foreground/80 whitespace-pre-wrap">
                 {msg.content}
               </p>
             )}
@@ -80,7 +80,7 @@ export function LineMessageCard({ msg }: { msg: LineMessageSummary }) {
                 <img
                   src={msg.contentUrl}
                   alt="LINE 画像"
-                  className="max-h-64 rounded-lg border border-slate-200 object-contain"
+                  className="max-h-64 rounded-lg border border-border object-contain"
                   loading="lazy"
                 />
               </a>
@@ -92,7 +92,7 @@ export function LineMessageCard({ msg }: { msg: LineMessageSummary }) {
                 href={msg.contentUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="mb-2.5 inline-flex items-center gap-1.5 rounded-md bg-slate-100 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-200"
+                className="mb-2.5 inline-flex items-center gap-1.5 rounded-md bg-muted px-3 py-1.5 text-xs font-medium text-muted-foreground hover:bg-accent"
               >
                 {msg.lineMessageType === "video"
                   ? "動画"
@@ -108,9 +108,11 @@ export function LineMessageCard({ msg }: { msg: LineMessageSummary }) {
               <span className="inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium bg-[#06C755]/10 text-[#06C755] ring-1 ring-inset ring-[#06C755]/20">
                 LINE
               </span>
-              {msg.groupName && <span className="text-xs text-slate-400">{msg.groupName}</span>}
+              {msg.groupName && (
+                <span className="text-xs text-muted-foreground">{msg.groupName}</span>
+              )}
               {msg.lineMessageType !== "text" && (
-                <span className="inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium bg-slate-100 text-slate-500 ring-1 ring-inset ring-slate-200">
+                <span className="inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium bg-muted text-muted-foreground ring-1 ring-inset ring-border">
                   {msg.lineMessageType}
                 </span>
               )}

--- a/apps/web/src/app/(protected)/chat-messages/line-view-container.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/line-view-container.tsx
@@ -10,10 +10,10 @@ export function LineViewContainer({ messages }: { messages: LineMessageSummary[]
     <div className="space-y-3">
       <AutoRefresh />
       {messages.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-white py-20 text-center">
-          <MessageSquare className="mb-3 text-slate-300" size={36} />
-          <p className="text-sm font-medium text-slate-500">LINE メッセージがありません</p>
-          <p className="mt-1 text-xs text-slate-400">
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border bg-card py-20 text-center">
+          <MessageSquare className="mb-3 text-muted-foreground/40" size={36} />
+          <p className="text-sm font-medium text-muted-foreground">LINE メッセージがありません</p>
+          <p className="mt-1 text-xs text-muted-foreground/60">
             Botをグループに招待してメッセージを送信してください
           </p>
         </div>

--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -96,7 +96,7 @@ const AVATAR_PALETTE = [
 function getAvatarColor(name: string): string {
   let h = 0;
   for (const c of name) h = ((h << 5) - h + c.charCodeAt(0)) | 0;
-  return AVATAR_PALETTE[Math.abs(h) % AVATAR_PALETTE.length] ?? "bg-slate-500";
+  return AVATAR_PALETTE[Math.abs(h) % AVATAR_PALETTE.length] ?? "bg-muted-foreground";
 }
 
 function getInitials(name: string): string {
@@ -113,7 +113,7 @@ function ConfidenceMeter({ score }: { score: number }) {
   const txt = pct >= 80 ? "text-emerald-700" : pct >= 60 ? "text-amber-600" : "text-rose-600";
   return (
     <div className="flex items-center gap-1.5">
-      <div className="h-1.5 w-12 overflow-hidden rounded-full bg-slate-200">
+      <div className="h-1.5 w-12 overflow-hidden rounded-full bg-muted">
         <div className={`h-full rounded-full ${bar}`} style={{ width: `${pct}%` }} />
       </div>
       <span className={`font-mono text-xs tabular-nums ${txt}`}>{pct}%</span>
@@ -141,12 +141,12 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
       className="group block w-full cursor-pointer text-left"
     >
       <div
-        className={`relative border-l-4 ${accent} rounded-r-xl bg-white px-5 py-4 shadow ring-1 ring-slate-200/80 transition-all duration-150 group-hover:shadow-lg group-hover:ring-slate-300 ${
+        className={`relative border-l-4 ${accent} rounded-r-xl bg-card px-5 py-4 shadow ring-1 ring-border/80 transition-all duration-150 group-hover:shadow-lg group-hover:ring-border ${
           isReply ? "ml-8" : ""
         }`}
       >
         {isReply && (
-          <div className="absolute -left-[30px] top-4 text-slate-400">
+          <div className="absolute -left-[30px] top-4 text-muted-foreground">
             <CornerDownRight size={15} />
           </div>
         )}
@@ -167,19 +167,19 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
             <div className="mb-1.5 flex items-center justify-between gap-2">
               <div className="flex min-w-0 items-center gap-2">
                 <span
-                  className={`truncate text-sm font-bold ${senderDisplay === "不明" ? "italic text-slate-400" : "text-slate-800"}`}
+                  className={`truncate text-sm font-bold ${senderDisplay === "不明" ? "italic text-muted-foreground" : "text-foreground"}`}
                 >
                   {senderDisplay}
                 </span>
                 {msg.isEdited && (
-                  <span className="flex shrink-0 items-center gap-0.5 text-[11px] text-slate-400">
+                  <span className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground">
                     <Pencil size={9} />
                     編集済
                   </span>
                 )}
               </div>
               <div className="flex shrink-0 items-center gap-2">
-                <time className="font-mono text-xs text-slate-400 tabular-nums">
+                <time className="font-mono text-xs text-muted-foreground tabular-nums">
                   {formatDateTime(msg.createdAt)}
                 </time>
                 {buildMessageSearchUrl(msg.content) && (
@@ -193,7 +193,7 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
                         "noopener,noreferrer,width=1400,height=900",
                       );
                     }}
-                    className="text-slate-400 transition-colors hover:text-slate-600"
+                    className="text-muted-foreground transition-colors hover:text-foreground"
                     title="Google Chat でメッセージを検索して開く（新しいウィンドウ）"
                   >
                     <ExternalLink size={12} />
@@ -207,7 +207,7 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
               content={msg.content}
               formattedContent={msg.formattedContent}
               mentionedUsers={msg.mentionedUsers}
-              className="mb-2.5 line-clamp-2 text-sm leading-relaxed text-slate-700"
+              className="mb-2.5 line-clamp-2 text-sm leading-relaxed text-foreground/80"
             />
 
             {/* Metadata */}
@@ -219,7 +219,7 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
                   {catCfg.label}
                 </span>
               ) : (
-                <span className="text-xs text-slate-400">未分類</span>
+                <span className="text-xs text-muted-foreground">未分類</span>
               )}
               {methCfg && (
                 <span
@@ -244,7 +244,7 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
             {/* Attachments */}
             {msg.attachments.length > 0 && (
               <div className="mt-2">
-                <p className="mb-1 flex items-center gap-1 text-xs font-medium text-slate-400">
+                <p className="mb-1 flex items-center gap-1 text-xs font-medium text-muted-foreground">
                   <Paperclip size={11} />
                   添付ファイル ({msg.attachments.length}件)
                 </p>

--- a/apps/web/src/app/(protected)/chat-messages/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/page.tsx
@@ -1,4 +1,4 @@
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, MessageSquare } from "lucide-react";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { Suspense } from "react";
@@ -10,6 +10,7 @@ import {
   getLineMessages,
   getStatsSpaces,
 } from "@/lib/api";
+import { cn } from "@/lib/utils";
 import { LineViewContainer } from "./line-view-container";
 import { CATEGORY_CONFIG } from "./message-card";
 import { ViewContainer } from "./view-container";
@@ -33,9 +34,12 @@ function FilterPill({ href, label, active }: { href: string; label: string; acti
   return (
     <Link
       href={href}
-      className={`inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors ${
-        active ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-      }`}
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors",
+        active
+          ? "bg-[var(--gradient-from)] text-white"
+          : "bg-muted text-muted-foreground hover:bg-accent",
+      )}
     >
       {label}
     </Link>
@@ -45,7 +49,7 @@ function FilterPill({ href, label, active }: { href: string; label: string; acti
 function FilterRow({ label, children }: { label: string; children: ReactNode }) {
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <span className="w-14 shrink-0 text-[11px] font-semibold uppercase tracking-wider text-slate-400">
+      <span className="w-14 shrink-0 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
         {label}
       </span>
       {children}
@@ -95,7 +99,7 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
 
   // Source tabs (shared between both views)
   const sourceTabsHtml = (
-    <div className="flex rounded-lg border border-slate-200 bg-white p-0.5">
+    <div className="flex rounded-lg border border-border/60 bg-card p-0.5">
       <Link
         href={buildUrl({
           source: undefined,
@@ -106,9 +110,12 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
           groupId: undefined,
           lowConfidence: undefined,
         })}
-        className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-          source === "gchat" ? "bg-slate-900 text-white" : "text-slate-500 hover:text-slate-700"
-        }`}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+          source === "gchat"
+            ? "bg-[var(--gradient-from)] text-white"
+            : "text-muted-foreground hover:text-foreground",
+        )}
       >
         Google Chat
       </Link>
@@ -122,9 +129,12 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
           groupId: undefined,
           lowConfidence: undefined,
         })}
-        className={`inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors ${
-          source === "line" ? "bg-[#06C755] text-white" : "text-slate-500 hover:text-slate-700"
-        }`}
+        className={cn(
+          "inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs font-medium transition-colors",
+          source === "line"
+            ? "bg-[#06C755] text-white"
+            : "text-muted-foreground hover:text-foreground",
+        )}
       >
         LINE
       </Link>
@@ -140,76 +150,51 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
     const totalCount = offset + lineMessages.length;
 
     return (
-      <div className="-mx-4 -mt-4 min-h-screen bg-slate-50/80 px-4 pt-4">
-        <div className="mx-auto max-w-4xl space-y-5">
-          {/* Page header */}
-          <div className="flex items-center justify-between">
+      <div className="mx-auto max-w-4xl space-y-5">
+        {/* Page header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-accent shadow-sm">
+              <MessageSquare className="h-5 w-5 text-white" />
+            </div>
             <div>
-              <h1 className="text-xl font-bold tracking-tight text-slate-900">チャット分析</h1>
-              <p className="mt-0.5 text-xs text-slate-500">
+              <h1 className="text-xl font-bold tracking-tight">チャット分析</h1>
+              <p className="text-xs text-muted-foreground">
                 {pagination.hasMore ? `${totalCount}件以上表示中` : `全${totalCount}件`}
               </p>
             </div>
-            {sourceTabsHtml}
           </div>
-
-          {/* LINE Filter panel */}
-          {statsData.groups.length > 0 && (
-            <div className="rounded-xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
-              <FilterRow label="グループ">
-                <FilterPill
-                  href={buildUrl({ groupId: undefined, page: "1" })}
-                  label="すべて"
-                  active={!params.groupId}
-                />
-                {statsData.groups.map(({ groupId, groupName, count }) => (
-                  <FilterPill
-                    key={groupId}
-                    href={buildUrl({ groupId, page: "1" })}
-                    label={`${groupName ?? groupId.slice(0, 8)} (${count})`}
-                    active={params.groupId === groupId}
-                  />
-                ))}
-              </FilterRow>
-            </div>
-          )}
-
-          {/* LINE Message feed */}
-          <Suspense fallback={null}>
-            <LineViewContainer messages={lineMessages} />
-          </Suspense>
-
-          {/* Pagination */}
-          <div className="flex items-center justify-center gap-2 pt-2">
-            <Link
-              href={page > 1 ? buildUrl({ page: String(page - 1) }) : "#"}
-              aria-disabled={page <= 1}
-              className={`inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-                page <= 1
-                  ? "pointer-events-none text-slate-300"
-                  : "text-slate-600 hover:bg-slate-100"
-              }`}
-            >
-              <ChevronLeft size={16} />
-              前へ
-            </Link>
-            <span className="rounded-lg bg-slate-100 px-3 py-1.5 text-xs font-semibold tabular-nums text-slate-700">
-              ページ {page}
-            </span>
-            <Link
-              href={pagination.hasMore ? buildUrl({ page: String(page + 1) }) : "#"}
-              aria-disabled={!pagination.hasMore}
-              className={`inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-                !pagination.hasMore
-                  ? "pointer-events-none text-slate-300"
-                  : "text-slate-600 hover:bg-slate-100"
-              }`}
-            >
-              次へ
-              <ChevronRight size={16} />
-            </Link>
-          </div>
+          {sourceTabsHtml}
         </div>
+
+        {/* LINE Filter panel */}
+        {statsData.groups.length > 0 && (
+          <div className="rounded-xl border border-border/60 bg-card px-5 py-4">
+            <FilterRow label="グループ">
+              <FilterPill
+                href={buildUrl({ groupId: undefined, page: "1" })}
+                label="すべて"
+                active={!params.groupId}
+              />
+              {statsData.groups.map(({ groupId, groupName, count }) => (
+                <FilterPill
+                  key={groupId}
+                  href={buildUrl({ groupId, page: "1" })}
+                  label={`${groupName ?? groupId.slice(0, 8)} (${count})`}
+                  active={params.groupId === groupId}
+                />
+              ))}
+            </FilterRow>
+          </div>
+        )}
+
+        {/* LINE Message feed */}
+        <Suspense fallback={null}>
+          <LineViewContainer messages={lineMessages} />
+        </Suspense>
+
+        {/* Pagination */}
+        <Pagination page={page} hasMore={pagination.hasMore} buildUrl={buildUrl} />
       </div>
     );
   }
@@ -232,123 +217,144 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
   const totalCount = offset + messages.length;
 
   return (
-    <div className="-mx-4 -mt-4 min-h-screen bg-slate-50/80 px-4 pt-4">
-      <div className="mx-auto max-w-4xl space-y-5">
-        {/* Page header */}
-        <div className="flex items-center justify-between">
+    <div className="mx-auto max-w-4xl space-y-5">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-accent shadow-sm">
+            <MessageSquare className="h-5 w-5 text-white" />
+          </div>
           <div>
-            <h1 className="text-xl font-bold tracking-tight text-slate-900">チャット分析</h1>
-            <p className="mt-0.5 text-xs text-slate-500">
+            <h1 className="text-xl font-bold tracking-tight">チャット分析</h1>
+            <p className="text-xs text-muted-foreground">
               {pagination.hasMore ? `${totalCount}件以上表示中` : `全${totalCount}件`}
             </p>
           </div>
-          <div className="flex items-center gap-2">
-            {sourceTabsHtml}
-            <ChatSyncButton />
-          </div>
         </div>
+        <div className="flex items-center gap-2">
+          {sourceTabsHtml}
+          <ChatSyncButton />
+        </div>
+      </div>
 
-        {/* Filter panel */}
-        <div className="rounded-xl border border-slate-200 bg-white px-5 py-4 shadow-sm">
-          <div className="space-y-2.5">
-            {spacesData.spaces.length > 0 && (
-              <FilterRow label="スペース">
-                <FilterPill
-                  href={buildUrl({ spaceId: undefined, page: "1" })}
-                  label="すべて"
-                  active={!params.spaceId}
-                />
-                {spacesData.spaces.map(({ spaceId, count }) => (
-                  <FilterPill
-                    key={spaceId}
-                    href={buildUrl({ spaceId, page: "1" })}
-                    label={`${spaceNameMap[spaceId] ?? spaceId} (${count})`}
-                    active={params.spaceId === spaceId}
-                  />
-                ))}
-              </FilterRow>
-            )}
-            <FilterRow label="カテゴリ">
+      {/* Filter panel */}
+      <div className="rounded-xl border border-border/60 bg-card px-5 py-4">
+        <div className="space-y-2.5">
+          {spacesData.spaces.length > 0 && (
+            <FilterRow label="スペース">
               <FilterPill
-                href={buildUrl({ category: undefined, page: "1" })}
+                href={buildUrl({ spaceId: undefined, page: "1" })}
                 label="すべて"
-                active={!params.category}
+                active={!params.spaceId}
               />
-              {Object.entries(CATEGORY_CONFIG).map(([value, cfg]) => (
+              {spacesData.spaces.map(({ spaceId, count }) => (
                 <FilterPill
-                  key={value}
-                  href={buildUrl({ category: value, page: "1" })}
-                  label={cfg.label}
-                  active={params.category === value}
+                  key={spaceId}
+                  href={buildUrl({ spaceId, page: "1" })}
+                  label={`${spaceNameMap[spaceId] ?? spaceId} (${count})`}
+                  active={params.spaceId === spaceId}
                 />
               ))}
             </FilterRow>
-            <FilterRow label="種別">
+          )}
+          <FilterRow label="カテゴリ">
+            <FilterPill
+              href={buildUrl({ category: undefined, page: "1" })}
+              label="すべて"
+              active={!params.category}
+            />
+            {Object.entries(CATEGORY_CONFIG).map(([value, cfg]) => (
               <FilterPill
-                href={buildUrl({ messageType: undefined, page: "1" })}
-                label="全投稿"
-                active={!params.messageType}
+                key={value}
+                href={buildUrl({ category: value, page: "1" })}
+                label={cfg.label}
+                active={params.category === value}
               />
-              <FilterPill
-                href={buildUrl({ messageType: "MESSAGE", page: "1" })}
-                label="通常投稿"
-                active={params.messageType === "MESSAGE"}
-              />
-              <FilterPill
-                href={buildUrl({ messageType: "THREAD_REPLY", page: "1" })}
-                label="スレッド返信"
-                active={params.messageType === "THREAD_REPLY"}
-              />
-            </FilterRow>
-            <FilterRow label="信頼度">
-              <FilterPill
-                href={buildUrl({ lowConfidence: undefined, page: "1" })}
-                label="すべて"
-                active={!isLowConfidence}
-              />
-              <FilterPill
-                href={buildUrl({ lowConfidence: "1", page: "1" })}
-                label="⚠ 要確認 (< 70%)"
-                active={isLowConfidence}
-              />
-            </FilterRow>
-          </div>
-        </div>
-
-        {/* Message feed */}
-        <Suspense fallback={null}>
-          <ViewContainer messages={messages} offset={offset} initialView={initialView} />
-        </Suspense>
-
-        {/* Pagination */}
-        <div className="flex items-center justify-center gap-2 pt-2">
-          <Link
-            href={page > 1 ? buildUrl({ page: String(page - 1) }) : "#"}
-            aria-disabled={page <= 1}
-            className={`inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-              page <= 1 ? "pointer-events-none text-slate-300" : "text-slate-600 hover:bg-slate-100"
-            }`}
-          >
-            <ChevronLeft size={16} />
-            前へ
-          </Link>
-          <span className="rounded-lg bg-slate-100 px-3 py-1.5 text-xs font-semibold tabular-nums text-slate-700">
-            ページ {page}
-          </span>
-          <Link
-            href={pagination.hasMore ? buildUrl({ page: String(page + 1) }) : "#"}
-            aria-disabled={!pagination.hasMore}
-            className={`inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-              !pagination.hasMore
-                ? "pointer-events-none text-slate-300"
-                : "text-slate-600 hover:bg-slate-100"
-            }`}
-          >
-            次へ
-            <ChevronRight size={16} />
-          </Link>
+            ))}
+          </FilterRow>
+          <FilterRow label="種別">
+            <FilterPill
+              href={buildUrl({ messageType: undefined, page: "1" })}
+              label="全投稿"
+              active={!params.messageType}
+            />
+            <FilterPill
+              href={buildUrl({ messageType: "MESSAGE", page: "1" })}
+              label="通常投稿"
+              active={params.messageType === "MESSAGE"}
+            />
+            <FilterPill
+              href={buildUrl({ messageType: "THREAD_REPLY", page: "1" })}
+              label="スレッド返信"
+              active={params.messageType === "THREAD_REPLY"}
+            />
+          </FilterRow>
+          <FilterRow label="信頼度">
+            <FilterPill
+              href={buildUrl({ lowConfidence: undefined, page: "1" })}
+              label="すべて"
+              active={!isLowConfidence}
+            />
+            <FilterPill
+              href={buildUrl({ lowConfidence: "1", page: "1" })}
+              label="⚠ 要確認 (< 70%)"
+              active={isLowConfidence}
+            />
+          </FilterRow>
         </div>
       </div>
+
+      {/* Message feed */}
+      <Suspense fallback={null}>
+        <ViewContainer messages={messages} offset={offset} initialView={initialView} />
+      </Suspense>
+
+      {/* Pagination */}
+      <Pagination page={page} hasMore={pagination.hasMore} buildUrl={buildUrl} />
+    </div>
+  );
+}
+
+function Pagination({
+  page,
+  hasMore,
+  buildUrl,
+}: {
+  page: number;
+  hasMore: boolean;
+  buildUrl: (overrides: { page?: string }) => string;
+}) {
+  return (
+    <div className="flex items-center justify-center gap-2 pt-2">
+      <Link
+        href={page > 1 ? buildUrl({ page: String(page - 1) }) : "#"}
+        aria-disabled={page <= 1}
+        className={cn(
+          "inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+          page <= 1
+            ? "pointer-events-none text-muted-foreground/30"
+            : "text-muted-foreground hover:bg-accent",
+        )}
+      >
+        <ChevronLeft size={16} />
+        前へ
+      </Link>
+      <span className="rounded-lg bg-muted px-3 py-1.5 text-xs font-semibold tabular-nums">
+        ページ {page}
+      </span>
+      <Link
+        href={hasMore ? buildUrl({ page: String(page + 1) }) : "#"}
+        aria-disabled={!hasMore}
+        className={cn(
+          "inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors",
+          !hasMore
+            ? "pointer-events-none text-muted-foreground/30"
+            : "text-muted-foreground hover:bg-accent",
+        )}
+      >
+        次へ
+        <ChevronRight size={16} />
+      </Link>
     </div>
   );
 }

--- a/apps/web/src/app/(protected)/chat-messages/table-view.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/table-view.tsx
@@ -23,18 +23,18 @@ const RS_CONFIG: Record<ResponseStatus, { label: string; cls: string }> = {
   unresponded: { label: "未対応", cls: "bg-rose-50 text-rose-700 border border-rose-200" },
   in_progress: { label: "対応中", cls: "bg-amber-50 text-amber-700 border border-amber-200" },
   responded: { label: "対応済", cls: "bg-emerald-50 text-emerald-700 border border-emerald-200" },
-  not_required: { label: "不要", cls: "bg-slate-100 text-slate-500 border border-slate-200" },
+  not_required: { label: "不要", cls: "bg-muted text-muted-foreground border border-border" },
 };
 
 const STEP_CONFIG: Record<WorkflowStepStatus, { label: string; cls: string }> = {
-  undetermined: { label: "ー", cls: "text-slate-400 bg-slate-50 border border-slate-200" },
+  undetermined: { label: "ー", cls: "text-muted-foreground bg-muted/50 border border-border" },
   completed: {
     label: "✓",
     cls: "text-emerald-700 bg-emerald-50 border border-emerald-200 font-bold",
   },
   not_required: {
     label: "✗",
-    cls: "text-slate-400 bg-slate-100 border border-slate-200 line-through",
+    cls: "text-muted-foreground bg-muted border border-border line-through",
   },
 };
 
@@ -100,13 +100,15 @@ function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
 
   return (
     <tr
-      className={`group border-b border-slate-100 transition-colors hover:bg-blue-50/30 ${isPending ? "opacity-60" : ""}`}
+      className={`group border-b border-border/60 transition-colors hover:bg-accent/30 ${isPending ? "opacity-60" : ""}`}
     >
       {/* No */}
-      <td className="w-8 px-2 py-2 text-center text-xs tabular-nums text-slate-400">{rowNo}</td>
+      <td className="w-8 px-2 py-2 text-center text-xs tabular-nums text-muted-foreground">
+        {rowNo}
+      </td>
 
       {/* 発生日 */}
-      <td className="w-16 whitespace-nowrap px-2 py-2 text-xs tabular-nums text-slate-500">
+      <td className="w-16 whitespace-nowrap px-2 py-2 text-xs tabular-nums text-muted-foreground">
         {formatDate(msg.createdAt)}
       </td>
 
@@ -115,7 +117,7 @@ function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
         <div className="flex items-start gap-1">
           <Link
             href={`/chat-messages/${msg.id}`}
-            className="line-clamp-2 text-xs text-slate-700 hover:text-blue-600 hover:underline"
+            className="line-clamp-2 text-xs text-foreground/80 hover:text-foreground hover:underline"
           >
             {msg.content}
           </Link>
@@ -124,7 +126,7 @@ function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
               href={chatUrl}
               target="_blank"
               rel="noopener noreferrer"
-              className="mt-0.5 shrink-0 text-slate-300 hover:text-slate-500"
+              className="mt-0.5 shrink-0 text-muted-foreground/40 hover:text-muted-foreground"
             >
               <ExternalLink size={10} />
             </a>
@@ -140,7 +142,7 @@ function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
           onChange={(e) => setState((s) => ({ ...s, taskSummary: e.target.value }))}
           onBlur={() => handleTextBlur("taskSummary")}
           placeholder="タスク"
-          className="w-full resize-none rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-slate-700 placeholder:text-slate-300 focus:border-blue-300 focus:bg-white focus:outline-none"
+          className="w-full resize-none rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-foreground/80 placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
         />
       </td>
 
@@ -152,7 +154,7 @@ function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
           onChange={(e) => setState((s) => ({ ...s, assignees: e.target.value }))}
           onBlur={() => handleTextBlur("assignees")}
           placeholder="担当者"
-          className="w-full rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-slate-700 placeholder:text-slate-300 focus:border-blue-300 focus:bg-white focus:outline-none"
+          className="w-full rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-foreground/80 placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
         />
       </td>
 
@@ -197,7 +199,7 @@ function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
           onChange={(e) => setState((s) => ({ ...s, notes: e.target.value }))}
           onBlur={() => handleTextBlur("notes")}
           placeholder="メモ"
-          className="w-full resize-none rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-slate-700 placeholder:text-slate-300 focus:border-blue-300 focus:bg-white focus:outline-none"
+          className="w-full resize-none rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-foreground/80 placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
         />
       </td>
     </tr>
@@ -212,47 +214,55 @@ export function TableView({
   offset?: number;
 }) {
   return (
-    <div className="overflow-x-auto rounded-xl border border-slate-200 bg-white shadow-sm">
+    <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-sm">
       <table className="min-w-full border-collapse">
         <thead>
-          <tr className="border-b border-slate-200 bg-slate-50">
-            <th className="px-2 py-2 text-center text-xs font-semibold text-slate-500">No</th>
-            <th className="whitespace-nowrap px-2 py-2 text-left text-xs font-semibold text-slate-500">
+          <tr className="border-b border-border/60 bg-muted/50">
+            <th className="px-2 py-2 text-center text-xs font-semibold text-muted-foreground">
+              No
+            </th>
+            <th className="whitespace-nowrap px-2 py-2 text-left text-xs font-semibold text-muted-foreground">
               発生日
             </th>
-            <th className="px-2 py-2 text-left text-xs font-semibold text-slate-500">
+            <th className="px-2 py-2 text-left text-xs font-semibold text-muted-foreground">
               記事のコピー
             </th>
-            <th className="px-2 py-2 text-left text-xs font-semibold text-slate-500">タスク</th>
-            <th className="px-2 py-2 text-left text-xs font-semibold text-slate-500">割り振り</th>
-            <th className="whitespace-nowrap px-2 py-2 text-center text-xs font-semibold text-slate-500">
+            <th className="px-2 py-2 text-left text-xs font-semibold text-muted-foreground">
+              タスク
+            </th>
+            <th className="px-2 py-2 text-left text-xs font-semibold text-muted-foreground">
+              割り振り
+            </th>
+            <th className="whitespace-nowrap px-2 py-2 text-center text-xs font-semibold text-muted-foreground">
               対応状況
             </th>
             <th
-              className="w-10 px-1 py-2 text-center text-xs font-semibold text-slate-500"
+              className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
               title="❶条件通知書SS反映"
             >
               ❶
             </th>
             <th
-              className="w-10 px-1 py-2 text-center text-xs font-semibold text-slate-500"
+              className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
               title="❷通知・締結"
             >
               ❷
             </th>
             <th
-              className="w-10 px-1 py-2 text-center text-xs font-semibold text-slate-500"
+              className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
               title="❸社労士共有"
             >
               ❸
             </th>
             <th
-              className="w-10 px-1 py-2 text-center text-xs font-semibold text-slate-500"
+              className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
               title="❹SmartHR反映"
             >
               ❹
             </th>
-            <th className="px-2 py-2 text-left text-xs font-semibold text-slate-500">メモ</th>
+            <th className="px-2 py-2 text-left text-xs font-semibold text-muted-foreground">
+              メモ
+            </th>
           </tr>
         </thead>
         <tbody>

--- a/apps/web/src/app/(protected)/chat-messages/view-container.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/view-container.tsx
@@ -40,12 +40,14 @@ export function ViewContainer({
       <AutoRefresh />
       {/* ビュー切替 */}
       <div className="flex justify-end">
-        <div className="flex rounded-lg border border-slate-200 bg-white p-0.5">
+        <div className="flex rounded-lg border border-border/60 bg-card p-0.5">
           <button
             type="button"
             onClick={() => switchView("card")}
             className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-              view === "card" ? "bg-slate-900 text-white" : "text-slate-500 hover:text-slate-700"
+              view === "card"
+                ? "bg-[var(--gradient-from)] text-white"
+                : "text-muted-foreground hover:text-foreground"
             }`}
           >
             <LayoutList size={13} />
@@ -55,7 +57,9 @@ export function ViewContainer({
             type="button"
             onClick={() => switchView("table")}
             className={`inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-colors ${
-              view === "table" ? "bg-slate-900 text-white" : "text-slate-500 hover:text-slate-700"
+              view === "table"
+                ? "bg-[var(--gradient-from)] text-white"
+                : "text-muted-foreground hover:text-foreground"
             }`}
           >
             <Table2 size={13} />
@@ -66,10 +70,12 @@ export function ViewContainer({
 
       {/* コンテンツ */}
       {messages.length === 0 ? (
-        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-slate-300 bg-white py-20 text-center">
-          <MessageSquare className="mb-3 text-slate-300" size={36} />
-          <p className="text-sm font-medium text-slate-500">メッセージがありません</p>
-          <p className="mt-1 text-xs text-slate-400">フィルタ条件を変えてお試しください</p>
+        <div className="flex flex-col items-center justify-center rounded-xl border border-dashed border-border bg-card py-20 text-center">
+          <MessageSquare className="mb-3 text-muted-foreground/40" size={36} />
+          <p className="text-sm font-medium text-muted-foreground">メッセージがありません</p>
+          <p className="mt-1 text-xs text-muted-foreground/60">
+            フィルタ条件を変えてお試しください
+          </p>
         </div>
       ) : view === "table" ? (
         <TableView messages={messages} offset={offset} />


### PR DESCRIPTION
## Summary
- チャット分析セクション全体（7ファイル）の `slate-*` ハードコードカラーをデザイントークンに統一
- メッセージ詳細ページに「同カテゴリの類似メッセージ」セクションを追加
- LINE/GChat の Pagination コンポーネントを共通化し重複排除
- `CATEGORY_LABELS` / `CATEGORY_COLORS` の重複定義を `CATEGORY_CONFIG` からの導出に統一
- `formatDateTime` 独自定義を `formatDateTimeJST` に統一

## Changed files
| ファイル | 変更内容 |
|---------|---------|
| `page.tsx` | ヘッダーアイコン追加、フィルタ/ソースタブ/Pagination のトークン統一 |
| `message-card.tsx` | カード背景・テキスト・リングのトークン統一 |
| `line-message-card.tsx` | 同上（LINE版） |
| `view-container.tsx` | ビュー切替ボタン・空状態のトークン統一 |
| `line-view-container.tsx` | 空状態のトークン統一 |
| `table-view.tsx` | テーブルヘッダ・行・入力フィールドのトークン統一 |
| `[id]/page.tsx` | 類似メッセージセクション追加、CATEGORY重複排除、formatDateTime統一 |

## Quality checks
- ✅ `pnpm typecheck` 通過
- ✅ `pnpm lint` 通過
- ✅ `pnpm test` 通過（57 tests）
- ✅ `/simplify` レビュー済み
- ✅ `/safe-refactor` 検証済み

## Test plan
- [ ] チャット分析ページ（GChat/LINE切替）の表示確認
- [ ] カード/テーブルビュー切替の動作確認
- [ ] メッセージ詳細ページの類似メッセージ表示確認
- [ ] フィルタ（カテゴリ/スペース/種別/信頼度）の動作確認
- [ ] ダークモード互換性の目視確認

Closes #

🤖 Generated with [Claude Code](https://claude.com/claude-code)