### PR TITLE
fix(web): FE-BE 型アライメント — nullable 修正 + DraftItem 構造統一

### DIFF
--- a/apps/web/src/__tests__/api-contract.test.ts
+++ b/apps/web/src/__tests__/api-contract.test.ts
@@ -26,6 +26,7 @@ import type {
   DraftDetail,
   DraftItem,
   DraftSummary,
+  EmployeeDetail,
   EmployeeSummary,
   IntentDetail,
   IntentSummary,
@@ -58,7 +59,7 @@ const sampleDraftSummary: DraftSummary = {
   effectiveDate: "2026-03-01T00:00:00.000Z",
   aiConfidence: 0.95,
   aiReasoning: "職種変更に伴う給与見直し",
-  appliedRules: [],
+  appliedRules: null,
   reviewedBy: null,
   reviewedAt: null,
   approvedBy: null,
@@ -70,9 +71,11 @@ const sampleDraftSummary: DraftSummary = {
 const sampleDraftItem: DraftItem = {
   id: "item-001",
   draftId: "draft-001",
-  category: "base_salary",
-  beforeValue: 247000,
-  afterValue: 260000,
+  itemType: "base_salary",
+  itemName: "基本給",
+  beforeAmount: 247000,
+  afterAmount: 260000,
+  isChanged: true,
 };
 
 const sampleApprovalLog: ApprovalLogEntry = {
@@ -172,14 +175,37 @@ const sampleEmployee: EmployeeSummary = {
   isActive: true,
 };
 
+const sampleEmployeeNullable: EmployeeSummary = {
+  id: "emp-002",
+  employeeNumber: "E0002",
+  name: "佐藤 次郎",
+  email: null,
+  employmentType: "part_time",
+  department: null,
+  position: null,
+  hireDate: "2021-04-01T00:00:00.000Z",
+  isActive: true,
+};
+
 const sampleAuditLog: AuditLogEntry = {
   id: "audit-001",
-  eventType: "DRAFT_CREATED",
-  entityType: "salary_draft",
+  eventType: "draft_created",
+  entityType: "SalaryDraft",
   entityId: "draft-001",
   actorEmail: "manager@example.com",
   actorRole: "hr_manager",
   details: { draftId: "draft-001" },
+  createdAt: "2026-02-18T00:00:00.000Z",
+};
+
+const sampleAuditLogNullable: AuditLogEntry = {
+  id: "audit-002",
+  eventType: "external_sync",
+  entityType: "ChatMessage",
+  entityId: "msg-001",
+  actorEmail: null,
+  actorRole: null,
+  details: {},
   createdAt: "2026-02-18T00:00:00.000Z",
 };
 
@@ -231,6 +257,17 @@ describe("DraftSummary 契約", () => {
     expect(typeof sampleDraftSummary.updatedAt).toBe("string");
   });
 
+  it("appliedRules が null 許容であること", () => {
+    expect(sampleDraftSummary.appliedRules).toBeNull();
+    const withRules: DraftSummary = { ...sampleDraftSummary, appliedRules: { pitch_up: true } };
+    expect(withRules.appliedRules).not.toBeNull();
+  });
+
+  it("reason が null 許容であること", () => {
+    const withNull: DraftSummary = { ...sampleDraftSummary, reason: null };
+    expect(withNull.reason).toBeNull();
+  });
+
   it("beforeBaseSalary / afterBaseSalary が number であること", () => {
     expect(typeof sampleDraftSummary.beforeBaseSalary).toBe("number");
     expect(typeof sampleDraftSummary.afterBaseSalary).toBe("number");
@@ -276,8 +313,8 @@ describe("ページネーション構造の整合性", () => {
       limit: number;
       offset: number;
     } = {
-      employees: [sampleEmployee],
-      total: 1,
+      employees: [sampleEmployee, sampleEmployeeNullable],
+      total: 2,
       limit: 20,
       offset: 0,
     };
@@ -291,8 +328,8 @@ describe("ページネーション構造の整合性", () => {
       limit: number;
       offset: number;
     } = {
-      logs: [sampleAuditLog],
-      total: 1,
+      logs: [sampleAuditLog, sampleAuditLogNullable],
+      total: 2,
       limit: 20,
       offset: 0,
     };
@@ -394,5 +431,49 @@ describe("AdminUser 契約", () => {
 
   it("isActive が boolean であること", () => {
     expect(typeof sampleAdminUser.isActive).toBe("boolean");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 契約テスト: EmployeeDetail
+// ---------------------------------------------------------------------------
+
+describe("EmployeeDetail 契約", () => {
+  const baseEmployeeDetail: EmployeeDetail = {
+    ...sampleEmployee,
+    googleChatUserId: null,
+    createdAt: "2026-02-18T00:00:00.000Z",
+    updatedAt: "2026-02-18T00:00:00.000Z",
+    currentSalary: null,
+  };
+
+  it("EmployeeSummary を継承し googleChatUserId / currentSalary を持つこと", () => {
+    expect(
+      hasAllKeys(baseEmployeeDetail, [
+        "googleChatUserId",
+        "currentSalary",
+        "createdAt",
+        "updatedAt",
+      ]),
+    ).toBe(true);
+  });
+
+  it("currentSalary が null 許容であること", () => {
+    expect(baseEmployeeDetail.currentSalary).toBeNull();
+
+    const withSalary: EmployeeDetail = {
+      ...baseEmployeeDetail,
+      currentSalary: {
+        id: "sal-001",
+        baseSalary: 250000,
+        positionAllowance: 10000,
+        regionAllowance: 5000,
+        qualificationAllowance: 3000,
+        otherAllowance: 2000,
+        totalSalary: 270000,
+        effectiveFrom: "2026-01-01T00:00:00.000Z",
+      },
+    };
+    expect(withSalary.currentSalary).not.toBeNull();
   });
 });

--- a/apps/web/src/app/(protected)/audit-logs/page.tsx
+++ b/apps/web/src/app/(protected)/audit-logs/page.tsx
@@ -98,8 +98,8 @@ export default async function AuditLogsPage({ searchParams }: Props) {
                       <span className="font-mono text-xs">{log.entityId.slice(0, 8)}...</span>
                     )}
                   </TableCell>
-                  <TableCell>{log.actorEmail}</TableCell>
-                  <TableCell>{log.actorRole}</TableCell>
+                  <TableCell>{log.actorEmail ?? "—"}</TableCell>
+                  <TableCell>{log.actorRole ?? "—"}</TableCell>
                 </TableRow>
               ))
             )}

--- a/apps/web/src/app/(protected)/drafts/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/drafts/[id]/page.tsx
@@ -66,7 +66,7 @@ export default async function DraftDetailPage({ params }: Props) {
           </CardHeader>
           <CardContent className="space-y-3 text-sm">
             <Row label="変更種別" value={draft.changeType === "mechanical" ? "機械的" : "裁量的"} />
-            <Row label="理由" value={draft.reason} />
+            <Row label="理由" value={draft.reason ?? "—"} />
             <Row label="適用日" value={formatDate(draft.effectiveDate)} />
             <Row label="作成日時" value={formatDateTime(draft.createdAt)} />
             <Row label="更新日時" value={formatDateTime(draft.updatedAt)} />
@@ -133,9 +133,12 @@ export default async function DraftDetailPage({ params }: Props) {
               <Row label="信頼度" value={`${(draft.aiConfidence * 100).toFixed(0)}%`} />
             )}
             {draft.aiReasoning && <Row label="推論" value={draft.aiReasoning} />}
-            {draft.appliedRules.length > 0 && (
-              <Row label="適用ルール" value={draft.appliedRules.join(", ")} />
-            )}
+            {(() => {
+              const ruleKeys = draft.appliedRules ? Object.keys(draft.appliedRules) : [];
+              return ruleKeys.length > 0 ? (
+                <Row label="適用ルール" value={ruleKeys.join(", ")} />
+              ) : null;
+            })()}
           </CardContent>
         </Card>
       )}
@@ -170,7 +173,7 @@ export default async function DraftDetailPage({ params }: Props) {
                       <StatusBadge status={log.toStatus} />
                     </TableCell>
                     <TableCell>{log.actorEmail}</TableCell>
-                    <TableCell>{log.comment ?? "-"}</TableCell>
+                    <TableCell>{log.comment ?? "—"}</TableCell>
                   </TableRow>
                 ))}
               </TableBody>

--- a/apps/web/src/app/(protected)/employees/page.tsx
+++ b/apps/web/src/app/(protected)/employees/page.tsx
@@ -68,10 +68,10 @@ export default async function EmployeesPage({ searchParams }: Props) {
                 <TableRow key={e.id}>
                   <TableCell className="font-mono">{e.employeeNumber}</TableCell>
                   <TableCell className="font-medium">{e.name}</TableCell>
-                  <TableCell>{e.email}</TableCell>
+                  <TableCell>{e.email ?? "—"}</TableCell>
                   <TableCell>{EMPLOYMENT_LABELS[e.employmentType] ?? e.employmentType}</TableCell>
-                  <TableCell>{e.department}</TableCell>
-                  <TableCell>{e.position}</TableCell>
+                  <TableCell>{e.department ?? "—"}</TableCell>
+                  <TableCell>{e.position ?? "—"}</TableCell>
                   <TableCell>{formatDate(e.hireDate)}</TableCell>
                   <TableCell>
                     <Badge variant={e.isActive ? "default" : "secondary"}>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   ConfusionMatrixEntry,
   DraftDetail,
   DraftSummary,
+  EmployeeDetail,
   EmployeeSummary,
   IntentStatsSummary,
   LineGroupStat,
@@ -129,9 +130,7 @@ export function getEmployees(params?: EmployeeListParams) {
 }
 
 export function getEmployee(id: string) {
-  return request<EmployeeSummary & { currentSalary: Record<string, unknown> | null }>(
-    `/api/employees/${id}`,
-  );
+  return request<EmployeeDetail>(`/api/employees/${id}`);
 }
 
 // --- Audit Logs ---

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -2,6 +2,7 @@ import type {
   ActorRole,
   ChangeType,
   DraftStatus,
+  SalaryItemType,
   WorkflowStepStatus,
   WorkflowSteps,
 } from "@hr-system/shared";
@@ -13,7 +14,7 @@ export interface DraftSummary {
   chatMessageId: string | null;
   status: DraftStatus;
   changeType: ChangeType;
-  reason: string;
+  reason: string | null;
   beforeBaseSalary: number;
   afterBaseSalary: number;
   beforeTotal: number;
@@ -21,7 +22,7 @@ export interface DraftSummary {
   effectiveDate: string;
   aiConfidence: number | null;
   aiReasoning: string | null;
-  appliedRules: string[];
+  appliedRules: Record<string, unknown> | null;
   reviewedBy: string | null;
   reviewedAt: string | null;
   approvedBy: string | null;
@@ -40,9 +41,11 @@ export interface DraftDetail extends DraftSummary {
 export interface DraftItem {
   id: string;
   draftId: string;
-  category: string;
-  beforeValue: number;
-  afterValue: number;
+  itemType: SalaryItemType;
+  itemName: string;
+  beforeAmount: number;
+  afterAmount: number;
+  isChanged: boolean;
 }
 
 export interface ApprovalLogEntry {
@@ -62,12 +65,29 @@ export interface EmployeeSummary {
   id: string;
   employeeNumber: string;
   name: string;
-  email: string;
+  email: string | null;
   employmentType: string;
-  department: string;
-  position: string;
+  department: string | null;
+  position: string | null;
   hireDate: string;
   isActive: boolean;
+}
+
+/** GET /api/employees/:id レスポンス */
+export interface EmployeeDetail extends EmployeeSummary {
+  googleChatUserId: string | null;
+  createdAt: string;
+  updatedAt: string;
+  currentSalary: {
+    id: string;
+    baseSalary: number;
+    positionAllowance: number;
+    regionAllowance: number;
+    qualificationAllowance: number;
+    otherAllowance: number;
+    totalSalary: number;
+    effectiveFrom: string;
+  } | null;
 }
 
 /** GET /api/audit-logs レスポンスの1件 */
@@ -76,8 +96,8 @@ export interface AuditLogEntry {
   eventType: string;
   entityType: string;
   entityId: string;
-  actorEmail: string;
-  actorRole: ActorRole;
+  actorEmail: string | null;
+  actorRole: ActorRole | null;
   details: Record<string, unknown>;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary
- FE `types.ts` の型定義を BE API レスポンスに合わせて修正（nullable フィールド、DraftItem 構造、EmployeeDetail 追加）
- UI コンポーネントに null 安全なフォールバック表示を追加（drafts/employees/audit-logs）
- 契約テスト 19 件で FE-BE 整合性を保証（eventType/entityType/appliedRules/EmployeeDetail）

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `lib/types.ts` | `reason`, `appliedRules`, `email`, `department`, `position`, `actorEmail`, `actorRole` の nullable 修正 + `DraftItem` 構造統一 + `EmployeeDetail` 追加 |
| `lib/api.ts` | `getEmployee()` 戻り型を `EmployeeDetail` に修正 |
| `drafts/[id]/page.tsx` | `reason ?? "—"`, `appliedRules` null 安全化 |
| `employees/page.tsx` | `email/department/position ?? "—"` |
| `audit-logs/page.tsx` | `actorEmail/actorRole ?? "—"` |
| `api-contract.test.ts` | nullable サンプル追加、EmployeeDetail 契約テスト追加 |

## Quality Gate
- ✅ typecheck 通過
- ✅ テスト 61/61 通過
- ✅ `/simplify` 3 並列レビュー完了
- ✅ `/safe-refactor` 分析完了

## Test plan
- [ ] `pnpm typecheck` 通過確認
- [ ] `pnpm test` 全テスト通過確認
- [ ] ドラフト詳細画面で `reason: null` / `appliedRules: null` のデータ表示確認
- [ ] 従業員一覧で `email/department/position: null` のデータ表示確認
- [ ] 監査ログで `actorEmail/actorRole: null` のデータ表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)