### PR TITLE
fix(web): /admin 404 を修正 — /admin/users へリダイレクト

### DIFF
--- a/apps/web/src/app/(protected)/admin/page.tsx
+++ b/apps/web/src/app/(protected)/admin/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function AdminRedirect() {
+  redirect("/admin/users");
+}


### PR DESCRIPTION
## Summary
- `/admin` にアクセスすると 404 が返る問題を修正
- `apps/web/src/app/(protected)/admin/page.tsx` を追加し、`/admin/users` へリダイレクト
- 旧ルート（`/employees` → `/admin/employees`）と同じパターン

Closes #135

## Test plan
- [ ] `/admin` にアクセスして `/admin/users` にリダイレクトされることを確認
- [ ] `/admin/users`, `/admin/spaces` 等の既存ページが正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)