### PR TITLE
feat: 受信箱に優先度セレクター追加（極高/高/中/低） (#143)

### DIFF
--- a/apps/web/src/__tests__/inbox-3pane.test.tsx
+++ b/apps/web/src/__tests__/inbox-3pane.test.tsx
@@ -90,6 +90,18 @@ vi.mock("@/components/workflow-panel", () => ({
   WorkflowPanel: () => React.createElement("div", { "data-testid": "workflow-panel" }),
 }));
 
+vi.mock("@/components/task-priority-selector", () => ({
+  TaskPrioritySelector: ({ value }: Record<string, unknown>) =>
+    React.createElement("div", { "data-testid": "task-priority-selector", "data-value": value }),
+  TaskPriorityDot: ({ priority }: Record<string, unknown>) =>
+    priority
+      ? React.createElement("span", {
+          "data-testid": "task-priority-dot",
+          "data-priority": priority,
+        })
+      : null,
+}));
+
 vi.mock("../app/(protected)/inbox/handover-form", () => ({
   HandoverForm: ({ taskSummary, assignees, notes }: Record<string, unknown>) =>
     React.createElement(

--- a/apps/web/src/app/(protected)/inbox/actions.ts
+++ b/apps/web/src/app/(protected)/inbox/actions.ts
@@ -1,8 +1,13 @@
 "use server";
 
-import type { ResponseStatus } from "@hr-system/shared";
+import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { revalidatePath } from "next/cache";
-import { updateLineResponseStatus, updateResponseStatus, updateWorkflow } from "@/lib/api";
+import {
+  updateLineResponseStatus,
+  updateLineTaskPriority,
+  updateResponseStatus,
+  updateWorkflow,
+} from "@/lib/api";
 import type { WorkflowUpdateRequest } from "@/lib/types";
 
 export async function updateResponseStatusAction(
@@ -20,10 +25,27 @@ export async function updateWorkflowAction(chatMessageId: string, body: Workflow
   revalidatePath("/chat-messages");
 }
 
+export async function updateTaskPriorityAction(
+  chatMessageId: string,
+  taskPriority: TaskPriority | null,
+) {
+  await updateWorkflow(chatMessageId, { taskPriority });
+  revalidatePath("/inbox");
+  revalidatePath("/chat-messages");
+}
+
 export async function updateLineResponseStatusAction(
   messageId: string,
   responseStatus: ResponseStatus,
 ) {
   await updateLineResponseStatus(messageId, responseStatus);
+  revalidatePath("/inbox");
+}
+
+export async function updateLineTaskPriorityAction(
+  messageId: string,
+  taskPriority: TaskPriority | null,
+) {
+  await updateLineTaskPriority(messageId, taskPriority);
   revalidatePath("/inbox");
 }

--- a/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
@@ -4,6 +4,7 @@ import type { ResponseStatus } from "@hr-system/shared";
 import { ExternalLink, MessageSquare, X } from "lucide-react";
 import Link from "next/link";
 import { ResponseStatusButtons } from "@/components/response-status-buttons";
+import { TaskPriorityDot, TaskPrioritySelector } from "@/components/task-priority-selector";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { WorkflowPanel } from "@/components/workflow-panel";
 import { CATEGORY_LABELS, RESPONSE_STATUS_DOT_COLORS } from "@/lib/constants";
@@ -14,7 +15,11 @@ import type {
   WorkflowSteps,
 } from "@/lib/types";
 import { cn, formatDateTimeJST } from "@/lib/utils";
-import { updateResponseStatusAction, updateWorkflowAction } from "./actions";
+import {
+  updateResponseStatusAction,
+  updateTaskPriorityAction,
+  updateWorkflowAction,
+} from "./actions";
 import { HandoverForm } from "./handover-form";
 import { useSelectMessage } from "./use-select-message";
 
@@ -86,6 +91,7 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
                     {(intent.confidenceScore * 100).toFixed(0)}%
                   </span>
                 )}
+                {intent?.taskPriority && <TaskPriorityDot priority={intent.taskPriority} />}
               </div>
             </button>
           );
@@ -168,6 +174,17 @@ function DetailPane({ message, onClose }: { message: ChatMessageDetail; onClose:
                 onChangeStatus={(s) => updateResponseStatusAction(message.id, s)}
               />
             </div>
+
+            {/* タスク優先度 */}
+            {intent && (
+              <div className="mt-4">
+                <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
+                <TaskPrioritySelector
+                  value={intent.taskPriority ?? null}
+                  onChange={(p) => updateTaskPriorityAction(message.id, p)}
+                />
+              </div>
+            )}
 
             {/* ワークフロー */}
             {intent && (

--- a/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
@@ -2,10 +2,11 @@
 
 import { Image as ImageIcon, MessageSquare, X } from "lucide-react";
 import { ResponseStatusButtons } from "@/components/response-status-buttons";
+import { TaskPriorityDot, TaskPrioritySelector } from "@/components/task-priority-selector";
 import { RESPONSE_STATUS_DOT_COLORS } from "@/lib/constants";
 import type { LineMessageDetail, LineMessageSummary } from "@/lib/types";
 import { cn, formatDateTimeJST } from "@/lib/utils";
-import { updateLineResponseStatusAction } from "./actions";
+import { updateLineResponseStatusAction, updateLineTaskPriorityAction } from "./actions";
 import { useSelectMessage } from "./use-select-message";
 
 interface LineInbox3PaneProps {
@@ -87,6 +88,7 @@ export function LineInbox3Pane({ messages, selectedMessage, selectedId }: LineIn
                     {msg.lineMessageType}
                   </span>
                 )}
+                {msg.taskPriority && <TaskPriorityDot priority={msg.taskPriority} />}
               </div>
             </button>
           );
@@ -155,6 +157,15 @@ function LineDetailPane({ message, onClose }: { message: LineMessageDetail; onCl
           <ResponseStatusButtons
             currentStatus={responseStatus}
             onChangeStatus={(s) => updateLineResponseStatusAction(message.id, s)}
+          />
+        </div>
+
+        {/* タスク優先度 */}
+        <div className="mt-4">
+          <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
+          <TaskPrioritySelector
+            value={message.taskPriority}
+            onChange={(p) => updateLineTaskPriorityAction(message.id, p)}
           />
         </div>
 

--- a/apps/web/src/components/task-priority-selector.tsx
+++ b/apps/web/src/components/task-priority-selector.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import type { TaskPriority } from "@hr-system/shared";
+import { cn } from "@/lib/utils";
+
+const PRIORITY_OPTIONS: Array<{
+  value: TaskPriority;
+  label: string;
+  dotClass: string;
+  activeClass: string;
+}> = [
+  {
+    value: "critical",
+    label: "極高",
+    dotClass: "bg-red-500",
+    activeClass: "bg-red-100 text-red-800 border-red-300 ring-1 ring-red-400 font-bold",
+  },
+  {
+    value: "high",
+    label: "高",
+    dotClass: "bg-orange-400",
+    activeClass: "bg-orange-50 text-orange-700 border-orange-300",
+  },
+  {
+    value: "medium",
+    label: "中",
+    dotClass: "bg-blue-400",
+    activeClass: "bg-blue-50 text-blue-700 border-blue-300",
+  },
+  {
+    value: "low",
+    label: "低",
+    dotClass: "bg-slate-300",
+    activeClass: "bg-slate-50 text-slate-600 border-slate-300",
+  },
+];
+
+interface TaskPrioritySelectorProps {
+  value: TaskPriority | null;
+  onChange: (priority: TaskPriority | null) => void;
+}
+
+export function TaskPrioritySelector({ value, onChange }: TaskPrioritySelectorProps) {
+  return (
+    <div className="flex items-center gap-1.5">
+      {PRIORITY_OPTIONS.map((opt) => {
+        const isActive = value === opt.value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => onChange(isActive ? null : opt.value)}
+            className={cn(
+              "inline-flex items-center gap-1 rounded-md border px-2 py-1 text-[11px] transition-colors",
+              isActive
+                ? opt.activeClass
+                : "border-border/60 text-muted-foreground hover:bg-accent/50",
+            )}
+          >
+            <span className={cn("h-1.5 w-1.5 rounded-full", opt.dotClass)} />
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** 左ペイン用の小さな優先度インジケーター */
+export function TaskPriorityDot({ priority }: { priority: TaskPriority | null }) {
+  if (!priority) return null;
+
+  const opt = PRIORITY_OPTIONS.find((o) => o.value === priority);
+  if (!opt) return null;
+
+  if (priority === "critical") {
+    return (
+      <span className="inline-flex items-center gap-0.5 rounded bg-red-100 px-1 py-0.5 text-[9px] font-bold text-red-700 animate-pulse">
+        <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
+        {opt.label}
+      </span>
+    );
+  }
+
+  return <span className={cn("h-1.5 w-1.5 rounded-full", opt.dotClass)} title={opt.label} />;
+}


### PR DESCRIPTION
## Summary
- `TaskPrioritySelector` コンポーネント: 極高(赤)/高(橙)/中(青)/低(灰) の4段階ボタン、トグルで解除可能
- `TaskPriorityDot` コンポーネント: 左ペイン用の小さなインジケーター。極高は赤パルスバッジで目立たせる
- Google Chat / LINE 両受信箱の詳細ペインに優先度セレクターを組み込み
- 左ペインのメッセージ一覧に優先度インジケーター表示
- Server Action `updateTaskPriorityAction` / `updateLineTaskPriorityAction` 追加

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm lint` — 全パッケージ通過
- [x] `pnpm test` — 全テスト通過（モック追加済み）

Closes #143

🤖 Generated with [Claude Code](https://claude.com/claude-code)