### PR TITLE
feat: タスクビューページ追加 — 優先度付きメッセージの一覧・フィルタ (#144)

### DIFF
--- a/apps/web/src/__tests__/sidebar-nav.test.tsx
+++ b/apps/web/src/__tests__/sidebar-nav.test.tsx
@@ -1,8 +1,8 @@
 /**
  * サイドバーナビゲーション テスト
  *
- * App Shell 再設計: 8項目→4項目のナビゲーション構造変更を検証
- * - 新ナビ項目: 受信箱, タスク, ダッシュボード, 管理
+ * App Shell 再設計: 5項目のナビゲーション構造を検証
+ * - ナビ項目: 受信箱, タスク, 承認, ダッシュボード, 管理
  * - isNavActive のルーティング判定
  */
 import { describe, expect, it, vi } from "vitest";
@@ -17,8 +17,8 @@ vi.mock("next/navigation", () => ({ usePathname: () => "/" }));
 import { isNavActive, navItems } from "../components/sidebar-nav";
 
 describe("sidebar-nav 構造", () => {
-  it("ナビゲーション項目が4つであること", () => {
-    expect(navItems).toHaveLength(4);
+  it("ナビゲーション項目が5つであること", () => {
+    expect(navItems).toHaveLength(5);
   });
 
   it("受信箱が /inbox であること", () => {
@@ -27,10 +27,16 @@ describe("sidebar-nav 構造", () => {
     expect(inbox!.href).toBe("/inbox");
   });
 
-  it("タスクが /tasks であること", () => {
+  it("タスクが /task-board であること", () => {
     const tasks = navItems.find((item) => item.label === "タスク");
     expect(tasks).toBeDefined();
-    expect(tasks!.href).toBe("/tasks");
+    expect(tasks!.href).toBe("/task-board");
+  });
+
+  it("承認が /tasks であること", () => {
+    const approval = navItems.find((item) => item.label === "承認");
+    expect(approval).toBeDefined();
+    expect(approval!.href).toBe("/tasks");
   });
 
   it("ダッシュボードが /dashboard であること", () => {
@@ -49,6 +55,14 @@ describe("sidebar-nav 構造", () => {
 describe("isNavActive ルーティング判定", () => {
   it("/inbox が /inbox でアクティブ", () => {
     expect(isNavActive("/inbox", "/inbox")).toBe(true);
+  });
+
+  it("/task-board が /task-board でアクティブ", () => {
+    expect(isNavActive("/task-board", "/task-board")).toBe(true);
+  });
+
+  it("/task-board が /task-board?priority=high でもアクティブ", () => {
+    expect(isNavActive("/task-board", "/task-board?priority=high")).toBe(true);
   });
 
   it("/tasks が /tasks でアクティブ", () => {

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -1,0 +1,204 @@
+import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
+import Link from "next/link";
+import { getChatMessages, getLineMessages } from "@/lib/api";
+import type { TaskItem } from "./task-list";
+import { TaskList } from "./task-list";
+
+type Source = "all" | "gchat" | "line";
+
+const PRIORITY_TABS: { value: TaskPriority | "all"; label: string }[] = [
+  { value: "all", label: "すべて" },
+  { value: "critical", label: "極高" },
+  { value: "high", label: "高" },
+  { value: "medium", label: "中" },
+  { value: "low", label: "低" },
+];
+
+const SOURCE_TABS: { value: Source; label: string }[] = [
+  { value: "all", label: "すべて" },
+  { value: "gchat", label: "Google Chat" },
+  { value: "line", label: "LINE" },
+];
+
+const STATUS_TABS: { value: ResponseStatus | "all"; label: string }[] = [
+  { value: "all", label: "すべて" },
+  { value: "unresponded", label: "未対応" },
+  { value: "in_progress", label: "対応中" },
+  { value: "responded", label: "対応済" },
+];
+
+const PRIORITY_ORDER: Record<TaskPriority, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+};
+
+interface Props {
+  searchParams: Promise<{
+    priority?: string;
+    source?: string;
+    status?: string;
+  }>;
+}
+
+export default async function TaskBoardPage({ searchParams }: Props) {
+  const params = await searchParams;
+  const priorityFilter = (params.priority as TaskPriority | undefined) ?? undefined;
+  const sourceFilter: Source = (params.source as Source) ?? "all";
+  const statusFilter = (params.status as ResponseStatus | undefined) ?? undefined;
+
+  // 両ソースを並列取得
+  const [chatResult, lineResult] = await Promise.all([
+    sourceFilter !== "line" ? getChatMessages({ limit: 200 }) : null,
+    sourceFilter !== "gchat" ? getLineMessages({ limit: 200 }) : null,
+  ]);
+
+  // タスク優先度付きメッセージを抽出・統合
+  const tasks: TaskItem[] = [];
+
+  if (chatResult) {
+    for (const msg of chatResult.data) {
+      const priority = msg.intent?.taskPriority;
+      if (!priority) continue;
+      tasks.push({
+        id: msg.id,
+        source: "gchat",
+        senderName: msg.senderName,
+        content: msg.content,
+        taskPriority: priority,
+        responseStatus: (msg.intent?.responseStatus ?? "unresponded") as ResponseStatus,
+        taskSummary: msg.intent?.taskSummary ?? null,
+        assignees: msg.intent?.assignees ?? null,
+        groupName: null,
+        createdAt: msg.createdAt,
+      });
+    }
+  }
+
+  if (lineResult) {
+    for (const msg of lineResult.data) {
+      if (!msg.taskPriority) continue;
+      tasks.push({
+        id: msg.id,
+        source: "line",
+        senderName: msg.senderName,
+        content: msg.content,
+        taskPriority: msg.taskPriority,
+        responseStatus: msg.responseStatus,
+        taskSummary: null,
+        assignees: null,
+        groupName: msg.groupName,
+        createdAt: msg.createdAt,
+      });
+    }
+  }
+
+  // フィルタリング
+  let filtered = tasks;
+  if (priorityFilter) {
+    filtered = filtered.filter((t) => t.taskPriority === priorityFilter);
+  }
+  if (statusFilter) {
+    filtered = filtered.filter((t) => t.responseStatus === statusFilter);
+  }
+
+  // 優先度順 → 日時降順でソート
+  filtered.sort((a, b) => {
+    const pDiff = PRIORITY_ORDER[a.taskPriority] - PRIORITY_ORDER[b.taskPriority];
+    if (pDiff !== 0) return pDiff;
+    return b.createdAt.localeCompare(a.createdAt);
+  });
+
+  const criticalCount = filtered.filter((t) => t.taskPriority === "critical").length;
+
+  function buildUrl(overrides: { priority?: string; source?: string; status?: string }) {
+    const sp = new URLSearchParams();
+    const p = "priority" in overrides ? overrides.priority : params.priority;
+    const src = "source" in overrides ? overrides.source : params.source;
+    const s = "status" in overrides ? overrides.status : params.status;
+    if (p && p !== "all") sp.set("priority", p);
+    if (src && src !== "all") sp.set("source", src);
+    if (s && s !== "all") sp.set("status", s);
+    const qs = sp.toString();
+    return `/task-board${qs ? `?${qs}` : ""}`;
+  }
+
+  return (
+    <div className="-m-6 flex h-[calc(100vh-52px)] flex-col">
+      {/* ヘッダー */}
+      <div className="flex-shrink-0 border-b border-border/60 bg-white px-5 py-3">
+        <div className="mb-2 flex items-center justify-between">
+          <h1 className="text-lg font-bold tracking-tight">タスク</h1>
+          <span className="text-xs text-muted-foreground">
+            {filtered.length}件{criticalCount > 0 && ` (極高 ${criticalCount}件)`}
+          </span>
+        </div>
+
+        {/* フィルター: 優先度 */}
+        <div className="mb-2 flex flex-wrap gap-1.5">
+          {PRIORITY_TABS.map((tab) => {
+            const isActive = tab.value === "all" ? !priorityFilter : priorityFilter === tab.value;
+            return (
+              <Link
+                key={tab.value}
+                href={buildUrl({ priority: tab.value === "all" ? undefined : tab.value })}
+                className={`inline-flex items-center rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                  isActive
+                    ? tab.value === "critical"
+                      ? "bg-red-600 text-white"
+                      : "bg-slate-900 text-white"
+                    : "border border-slate-200 bg-white text-slate-600 hover:bg-slate-100"
+                }`}
+              >
+                {tab.label}
+              </Link>
+            );
+          })}
+        </div>
+
+        {/* フィルター: ソース + ステータス */}
+        <div className="flex flex-wrap items-center gap-3">
+          <div className="flex gap-1">
+            {SOURCE_TABS.map((tab) => {
+              const isActive = sourceFilter === tab.value;
+              return (
+                <Link
+                  key={tab.value}
+                  href={buildUrl({ source: tab.value === "all" ? undefined : tab.value })}
+                  className={`inline-flex items-center rounded-lg px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                    isActive ? "bg-slate-800 text-white" : "text-slate-500 hover:bg-slate-100"
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </div>
+          <span className="text-slate-300">|</span>
+          <div className="flex gap-1">
+            {STATUS_TABS.map((tab) => {
+              const isActive = tab.value === "all" ? !statusFilter : statusFilter === tab.value;
+              return (
+                <Link
+                  key={tab.value}
+                  href={buildUrl({ status: tab.value === "all" ? undefined : tab.value })}
+                  className={`inline-flex items-center rounded-lg px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                    isActive ? "bg-slate-700 text-white" : "text-slate-500 hover:bg-slate-100"
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      {/* タスク一覧 */}
+      <div className="flex-1 overflow-y-auto">
+        <TaskList tasks={filtered} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
+import { MessageCircle, MessageSquareText } from "lucide-react";
+import Link from "next/link";
+import { TaskPriorityDot } from "@/components/task-priority-selector";
+import { RESPONSE_STATUS_DOT_COLORS } from "@/lib/constants";
+import { cn, formatDateTimeJST } from "@/lib/utils";
+
+export interface TaskItem {
+  id: string;
+  source: "gchat" | "line";
+  senderName: string;
+  content: string;
+  taskPriority: TaskPriority;
+  responseStatus: ResponseStatus;
+  taskSummary: string | null;
+  assignees: string | null;
+  groupName: string | null;
+  createdAt: string;
+}
+
+const RESPONSE_STATUS_LABELS: Record<ResponseStatus, string> = {
+  unresponded: "未対応",
+  in_progress: "対応中",
+  responded: "対応済",
+  not_required: "対応不要",
+};
+
+export function TaskList({ tasks }: { tasks: TaskItem[] }) {
+  if (tasks.length === 0) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <p className="text-sm text-muted-foreground">タスクはありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="divide-y divide-border/40">
+      {tasks.map((task) => {
+        const isCritical = task.taskPriority === "critical";
+        const inboxUrl =
+          task.source === "gchat" ? `/inbox?id=${task.id}` : `/inbox?source=line&id=${task.id}`;
+
+        return (
+          <Link
+            key={`${task.source}-${task.id}`}
+            href={inboxUrl}
+            className={cn(
+              "block px-5 py-3 transition-colors hover:bg-accent/50",
+              isCritical && "border-l-4 border-l-red-500 bg-red-50/50 hover:bg-red-50",
+            )}
+          >
+            <div className="flex items-center gap-2">
+              {/* 対応状況ドット */}
+              <span
+                className={cn(
+                  "h-2 w-2 flex-shrink-0 rounded-full",
+                  RESPONSE_STATUS_DOT_COLORS[task.responseStatus],
+                )}
+              />
+              {/* 優先度 */}
+              <TaskPriorityDot priority={task.taskPriority} />
+              {/* 送信者名 */}
+              <span className={cn("text-xs font-medium", isCritical && "text-red-800")}>
+                {task.senderName}
+              </span>
+              {/* ソースアイコン */}
+              {task.source === "gchat" ? (
+                <MessageSquareText size={12} className="text-muted-foreground" />
+              ) : (
+                <MessageCircle size={12} className="text-emerald-500" />
+              )}
+              {task.groupName && (
+                <span className="text-[10px] text-muted-foreground">@ {task.groupName}</span>
+              )}
+              {/* 対応状況 */}
+              <span className="ml-auto text-[10px] text-muted-foreground">
+                {RESPONSE_STATUS_LABELS[task.responseStatus]}
+              </span>
+              <span className="text-[10px] text-muted-foreground">
+                {formatDateTimeJST(task.createdAt)}
+              </span>
+            </div>
+
+            {/* タスク概要 or メッセージ */}
+            <p
+              className={cn(
+                "mt-1 line-clamp-2 text-xs",
+                isCritical ? "text-red-700" : "text-muted-foreground",
+              )}
+            >
+              {task.taskSummary || task.content}
+            </p>
+
+            {/* 担当者 */}
+            {task.assignees && (
+              <p className="mt-1 text-[10px] text-muted-foreground">担当: {task.assignees}</p>
+            )}
+          </Link>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/sidebar-nav.tsx
+++ b/apps/web/src/components/sidebar-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { BarChart3, ClipboardList, Inbox, Settings } from "lucide-react";
+import { BarChart3, ClipboardList, Inbox, ListTodo, Settings } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -15,7 +15,8 @@ export interface NavItem {
 
 export const navItems: NavItem[] = [
   { href: "/inbox", label: "受信箱", icon: Inbox },
-  { href: "/tasks", label: "タスク", icon: ClipboardList },
+  { href: "/task-board", label: "タスク", icon: ListTodo },
+  { href: "/tasks", label: "承認", icon: ClipboardList },
   { href: "/dashboard", label: "ダッシュボード", icon: BarChart3 },
   { href: "/admin", label: "管理", icon: Settings },
 ];


### PR DESCRIPTION
## Summary
- `/task-board` ルートにタスクビューページを新設。Google Chat / LINE 両ソースの優先度付きメッセージを統合表示
- 優先度(極高/高/中/低)・ソース(Google Chat/LINE)・対応状況(未対応/対応中/対応済)でフィルタリング可能
- 極高タスクは赤背景+左ボーダーで視覚的に強調表示
- サイドバーナビを4→5項目に拡張（「タスク」→`/task-board`、「承認」→`/tasks`）

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `task-board/page.tsx` | 新規: サーバーコンポーネント、両ソース取得・フィルタ・ソート |
| `task-board/task-list.tsx` | 新規: クライアントコンポーネント、タスクカード表示 |
| `sidebar-nav.tsx` | ナビ項目を5つに変更 |
| `sidebar-nav.test.tsx` | テストを5項目構成に更新 |

## Dependencies
- #142 (DB/API/型定義) ✅ merged
- #143 (優先度セレクター) ✅ merged

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 全92テスト通過（sidebar-nav 15テスト含む）
- [ ] ブラウザで `/task-board` にアクセスし、フィルタ動作を確認
- [ ] 極高タスクの赤背景表示を確認
- [ ] タスクカードクリックで受信箱詳細に遷移することを確認

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)