### PR TITLE
fix: Google Chat で Intent なしでもタスク優先度を設定可能に (#148)

### DIFF
--- a/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
@@ -176,15 +176,13 @@ function DetailPane({ message, onClose }: { message: ChatMessageDetail; onClose:
             </div>
 
             {/* タスク優先度 */}
-            {intent && (
-              <div className="mt-4">
-                <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
-                <TaskPrioritySelector
-                  value={intent.taskPriority ?? null}
-                  onChange={(p) => updateTaskPriorityAction(message.id, p)}
-                />
-              </div>
-            )}
+            <div className="mt-4">
+              <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
+              <TaskPrioritySelector
+                value={intent?.taskPriority ?? null}
+                onChange={(p) => updateTaskPriorityAction(message.id, p)}
+              />
+            </div>
 
             {/* ワークフロー */}
             {intent && (


### PR DESCRIPTION
## Summary
- Google Chat メッセージで IntentRecord が存在しない場合でもタスク優先度セレクターを表示
- `intent &&` の条件を `intent?.taskPriority ?? null` に変更（1ファイル1箇所のみ）
- API側は既に IntentRecord 自動作成に対応済み（`PATCH /workflow` L528-554）

## 変更内容
`inbox-3pane.tsx` の TaskPrioritySelector 表示条件を緩和。LINE との機能パリティを実現。

## Test plan
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint` 通過
- [x] `pnpm test` 全92テスト通過

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)