### PR TITLE
受信箱: 詳細ページ遷移削除 + 添付ファイル表示 (#150, #151)

### DIFF
--- a/apps/web/src/__tests__/inbox-3pane.test.tsx
+++ b/apps/web/src/__tests__/inbox-3pane.test.tsx
@@ -61,8 +61,8 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("lucide-react", () => ({
-  ExternalLink: () => React.createElement("span", { "data-testid": "icon-external-link" }),
   MessageSquare: () => React.createElement("span", { "data-testid": "icon-message-square" }),
+  Paperclip: () => React.createElement("span", { "data-testid": "icon-paperclip" }),
   X: () => React.createElement("span", { "data-testid": "icon-x" }),
 }));
 
@@ -118,6 +118,14 @@ vi.mock("../app/(protected)/inbox/use-select-message", () => ({
 vi.mock("../app/(protected)/inbox/actions", () => ({
   updateResponseStatusAction: vi.fn(),
   updateWorkflowAction: vi.fn(),
+}));
+
+vi.mock("@/components/chat/attachment-list", () => ({
+  AttachmentList: ({ attachments }: { attachments: unknown[] }) =>
+    React.createElement("div", {
+      "data-testid": "attachment-list",
+      "data-count": attachments.length,
+    }),
 }));
 
 import type { ChatMessageDetail, ChatMessageSummary } from "../lib/types";
@@ -276,6 +284,21 @@ describe("Inbox3Pane", () => {
       expect(text).toContain("95%");
     });
 
+    it("添付ファイルがある場合にクリップアイコンが表示される", () => {
+      const html = renderToHtml(
+        React.createElement(Inbox3Pane, {
+          messages: [
+            makeSummary({
+              attachments: [{ name: "file.pdf", contentType: "application/pdf" }],
+            }),
+          ],
+          selectedMessage: null,
+          selectedId: null,
+        }),
+      );
+      expect(html).toContain('data-testid="icon-paperclip"');
+    });
+
     it("複数メッセージが一覧に表示される", () => {
       const text = renderToText(
         React.createElement(Inbox3Pane, {
@@ -406,7 +429,7 @@ describe("Inbox3Pane", () => {
       expect(text).toContain("給与・社保");
     });
 
-    it("詳細ページへのリンクが存在する", () => {
+    it("詳細ページへの遷移リンクが存在しない", () => {
       const html = renderToHtml(
         React.createElement(Inbox3Pane, {
           messages: [makeSummary()],
@@ -414,7 +437,35 @@ describe("Inbox3Pane", () => {
           selectedId: "msg-1",
         }),
       );
-      expect(html).toContain('href="/chat-messages/msg-1"');
+      expect(html).not.toContain('href="/chat-messages/');
+    });
+
+    it("添付ファイルがある場合にAttachmentListが表示される", () => {
+      const detail = makeDetail({
+        attachments: [
+          { name: "report.pdf", contentName: "report.pdf", contentType: "application/pdf" },
+        ],
+      });
+      const html = renderToHtml(
+        React.createElement(Inbox3Pane, {
+          messages: [makeSummary()],
+          selectedMessage: detail,
+          selectedId: "msg-1",
+        }),
+      );
+      expect(html).toContain('data-testid="attachment-list"');
+      expect(html).toContain('data-count="1"');
+    });
+
+    it("添付ファイルがない場合にAttachmentListが表示されない", () => {
+      const html = renderToHtml(
+        React.createElement(Inbox3Pane, {
+          messages: [makeSummary()],
+          selectedMessage: makeDetail({ attachments: [] }),
+          selectedId: "msg-1",
+        }),
+      );
+      expect(html).not.toContain('data-testid="attachment-list"');
     });
   });
 

--- a/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import type { ResponseStatus } from "@hr-system/shared";
-import { ExternalLink, MessageSquare, X } from "lucide-react";
-import Link from "next/link";
+import { MessageSquare, Paperclip, X } from "lucide-react";
+import { AttachmentList } from "@/components/chat/attachment-list";
 import { ResponseStatusButtons } from "@/components/response-status-buttons";
 import { TaskPriorityDot, TaskPrioritySelector } from "@/components/task-priority-selector";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -91,6 +91,9 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
                     {(intent.confidenceScore * 100).toFixed(0)}%
                   </span>
                 )}
+                {msg.attachments.length > 0 && (
+                  <Paperclip className="h-3 w-3 text-muted-foreground" />
+                )}
                 {intent?.taskPriority && <TaskPriorityDot priority={intent.taskPriority} />}
               </div>
             </button>
@@ -138,13 +141,6 @@ function DetailPane({ message, onClose }: { message: ChatMessageDetail; onClose:
               {formatDateTimeJST(message.createdAt)}
             </span>
           </div>
-          <Link
-            href={`/chat-messages/${message.id}`}
-            className="rounded p-1 text-muted-foreground hover:bg-accent"
-            title="詳細ページ"
-          >
-            <ExternalLink className="h-4 w-4" />
-          </Link>
         </div>
 
         {/* メッセージ / スレッド タブ */}
@@ -165,6 +161,13 @@ function DetailPane({ message, onClose }: { message: ChatMessageDetail; onClose:
             <div className="rounded-lg bg-muted/50 p-4 text-sm leading-relaxed">
               {message.content}
             </div>
+
+            {/* 添付ファイル */}
+            {message.attachments.length > 0 && (
+              <div className="mt-3">
+                <AttachmentList attachments={message.attachments} />
+              </div>
+            )}
 
             {/* 対応ステータス変更 */}
             <div className="mt-4">


### PR DESCRIPTION
## Summary

- 受信箱 DetailPane の ExternalLink（`/chat-messages/:id` への遷移）を削除
- Google Chat 添付ファイル（PDF等）を Inbox 内に直接表示（既存 `AttachmentList` コンポーネント活用）
- 左ペイン一覧に添付ファイル有無のクリップアイコンを追加

## Test plan

- [x] 添付ファイルありメッセージで AttachmentList が表示される
- [x] 添付ファイルなしメッセージで何も表示されない
- [x] 左ペインにクリップアイコンが表示される
- [x] 詳細ページへのリンクが存在しない
- [x] 全95テスト通過、typecheck / lint 通過

Closes #150
Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)