### PR TITLE
fix: chat-sync 分類漏れ修正 + salary-drafts PATCH から金額フィールド除去

### DIFF
--- a/apps/api/src/__tests__/chat-sync.test.ts
+++ b/apps/api/src/__tests__/chat-sync.test.ts
@@ -2,11 +2,22 @@ import { Timestamp } from "firebase-admin/firestore";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- モック変数（vi.hoisted で vi.mock と同時にホイスト） ---
-const { mockGetRequestHeaders, mockGet, mockSet, mockAdd } = vi.hoisted(() => ({
+const {
+  mockGetRequestHeaders,
+  mockGet,
+  mockSet,
+  mockAdd,
+  mockBatchUpdate,
+  mockBatchSet,
+  mockBatchCommit,
+} = vi.hoisted(() => ({
   mockGetRequestHeaders: vi.fn().mockResolvedValue({ Authorization: "Bearer test-token" }),
   mockGet: vi.fn(),
   mockSet: vi.fn().mockResolvedValue(undefined),
   mockAdd: vi.fn().mockResolvedValue({ id: "audit-1" }),
+  mockBatchUpdate: vi.fn(),
+  mockBatchSet: vi.fn(),
+  mockBatchCommit: vi.fn().mockResolvedValue(undefined),
 }));
 
 // GoogleAuth をクラスベースでモック（vi.clearAllMocks() 耐性）
@@ -18,15 +29,35 @@ vi.mock("google-auth-library", () => ({
   },
 }));
 
+// @hr-system/ai モック
+vi.mock("@hr-system/ai", () => ({
+  classifyIntent: vi.fn().mockResolvedValue({
+    category: "salary",
+    confidence: 0.9,
+    classificationMethod: "regex",
+    regexPattern: "給与",
+    reasoning: null,
+  }),
+}));
+
 // Firestore モック
 vi.mock("@hr-system/db", () => ({
-  db: {},
+  db: {
+    batch: vi.fn(() => ({
+      update: mockBatchUpdate,
+      set: mockBatchSet,
+      commit: mockBatchCommit,
+    })),
+  },
   collections: {
     syncMetadata: {
       doc: vi.fn(() => ({ get: mockGet, set: mockSet })),
     },
     chatMessages: {
       doc: vi.fn(() => ({ get: mockGet, set: mockSet })),
+    },
+    intentRecords: {
+      doc: vi.fn(() => ({ id: "intent-new" })),
     },
     auditLogs: {
       add: mockAdd,
@@ -37,6 +68,11 @@ vi.mock("@hr-system/db", () => ({
       })),
     },
   },
+  loadClassificationConfig: vi.fn().mockResolvedValue({
+    regexRules: [],
+    systemPrompt: "",
+    fewShotExamples: [],
+  }),
 }));
 
 import {
@@ -145,8 +181,11 @@ describe("chat-sync service", () => {
         ),
       );
 
-      // chatMessages.doc(docId).get() → 存在する
-      mockGet.mockResolvedValueOnce({ exists: true });
+      // chatMessages.doc(docId).get() → 存在する（分類済み）
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ content: "既存メッセージ", processedAt: Timestamp.now() }),
+      });
 
       const result = await syncChatMessages("AAAA-qf5jX0");
       expect(result.newMessages).toBe(0);

--- a/apps/api/src/__tests__/salary-drafts.test.ts
+++ b/apps/api/src/__tests__/salary-drafts.test.ts
@@ -370,7 +370,7 @@ describe("PATCH /api/salary-drafts/:id", () => {
   afterEach(() => vi.unstubAllEnvs());
 
   it("draft ステータス: hr_manager が修正できる (200)", async () => {
-    const updatedDraft = makeDraft({ afterBaseSalary: 270000 });
+    const updatedDraft = makeDraft({ reason: "昇給（修正）" });
     mockDraftGet
       .mockResolvedValueOnce({ exists: true, data: () => makeDraft(), id: "draft-001" })
       .mockResolvedValueOnce({ exists: true, data: () => updatedDraft, id: "draft-001" });
@@ -378,7 +378,7 @@ describe("PATCH /api/salary-drafts/:id", () => {
     const res = await app.request("/api/salary-drafts/draft-001", {
       method: "PATCH",
       headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
-      body: JSON.stringify({ afterBaseSalary: 270000 }),
+      body: JSON.stringify({ reason: "昇給（修正）" }),
     });
 
     expect(res.status).toBe(200);
@@ -391,7 +391,7 @@ describe("PATCH /api/salary-drafts/:id", () => {
     const res = await app.request("/api/salary-drafts/draft-001", {
       method: "PATCH",
       headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
-      body: JSON.stringify({ afterBaseSalary: 270000 }),
+      body: JSON.stringify({ reason: "修正" }),
     });
 
     expect(res.status).toBe(403);
@@ -407,7 +407,7 @@ describe("PATCH /api/salary-drafts/:id", () => {
     const res = await app.request("/api/salary-drafts/draft-001", {
       method: "PATCH",
       headers: { ...AUTH_HEADER, "Content-Type": "application/json" },
-      body: JSON.stringify({ afterBaseSalary: 270000 }),
+      body: JSON.stringify({ reason: "修正" }),
     });
 
     expect(res.status).toBe(409);

--- a/apps/api/src/routes/salary-drafts.ts
+++ b/apps/api/src/routes/salary-drafts.ts
@@ -29,10 +29,6 @@ const listQuerySchema = z.object({
 
 const patchDraftSchema = z
   .object({
-    beforeBaseSalary: z.number().int().positive().optional(),
-    afterBaseSalary: z.number().int().positive().optional(),
-    beforeTotal: z.number().int().positive().optional(),
-    afterTotal: z.number().int().positive().optional(),
     effectiveDate: z
       .string()
       .regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD 形式で指定してください")
@@ -199,14 +195,10 @@ app.patch("/:id", zValidator("json", patchDraftSchema), async (c) => {
 
   const body = c.req.valid("json");
 
-  // 更新データ構築
+  // 更新データ構築（金額フィールドは明細との整合性のため PATCH 不可）
   const updateData: Record<string, unknown> = {
     updatedAt: FieldValue.serverTimestamp(),
   };
-  if (body.beforeBaseSalary !== undefined) updateData.beforeBaseSalary = body.beforeBaseSalary;
-  if (body.afterBaseSalary !== undefined) updateData.afterBaseSalary = body.afterBaseSalary;
-  if (body.beforeTotal !== undefined) updateData.beforeTotal = body.beforeTotal;
-  if (body.afterTotal !== undefined) updateData.afterTotal = body.afterTotal;
   if (body.reason !== undefined) updateData.reason = body.reason;
   if (body.effectiveDate !== undefined) {
     updateData.effectiveDate = Timestamp.fromDate(new Date(`${body.effectiveDate}T00:00:00Z`));

--- a/apps/api/src/services/chat-sync.ts
+++ b/apps/api/src/services/chat-sync.ts
@@ -5,10 +5,70 @@
  * Firestore に未保存のメッセージのみ追加する。
  */
 
+import type { ClassificationConfig } from "@hr-system/ai";
+import { classifyIntent } from "@hr-system/ai";
 import type { ChatAnnotation, ChatAttachment, ChatSyncConfig, SyncMetadata } from "@hr-system/db";
-import { collections } from "@hr-system/db";
-import { Timestamp } from "firebase-admin/firestore";
+import { collections, db, loadClassificationConfig } from "@hr-system/db";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { GoogleAuth } from "google-auth-library";
+
+// --- 分類設定キャッシュ（Worker の classification-config.ts と同パターン）---
+const CONFIG_TTL_MS = 5 * 60 * 1000; // 5分
+let configCache: { config: ClassificationConfig; loadedAt: number } | null = null;
+
+async function getClassificationConfig(): Promise<ClassificationConfig> {
+  if (configCache && Date.now() - configCache.loadedAt < CONFIG_TTL_MS) return configCache.config;
+  const loaded = await loadClassificationConfig();
+  const config: ClassificationConfig = {
+    regexRules: loaded.regexRules,
+    systemPrompt: loaded.systemPrompt,
+    fewShotExamples: loaded.fewShotExamples,
+  };
+  configCache = { config, loadedAt: Date.now() };
+  return config;
+}
+
+/** メッセージを分類して IntentRecord を保存し processedAt を更新する（バッチ書き込み） */
+async function classifyAndSaveIntent(
+  docId: string,
+  content: string,
+  config: ClassificationConfig,
+): Promise<void> {
+  if (!content.trim()) return; // 空メッセージはスキップ
+
+  const result = await classifyIntent(content, undefined, config);
+
+  const batch = db.batch();
+  batch.set(collections.intentRecords.doc(), {
+    chatMessageId: docId,
+    category: result.category,
+    confidenceScore: result.confidence,
+    extractedParams: null,
+    classificationMethod: result.classificationMethod,
+    regexPattern: result.regexPattern ?? null,
+    llmInput: result.classificationMethod === "ai" ? content : null,
+    llmOutput: result.classificationMethod === "ai" ? result.reasoning : null,
+    isManualOverride: false,
+    originalCategory: null,
+    overriddenBy: null,
+    overriddenAt: null,
+    responseStatus: "unresponded",
+    responseStatusUpdatedBy: null,
+    responseStatusUpdatedAt: null,
+    taskPriority: null,
+    taskSummary: null,
+    assignees: null,
+    notes: null,
+    workflowSteps: null,
+    workflowUpdatedBy: null,
+    workflowUpdatedAt: null,
+    createdAt: FieldValue.serverTimestamp() as never,
+  });
+  batch.update(collections.chatMessages.doc(docId), {
+    processedAt: FieldValue.serverTimestamp(),
+  });
+  await batch.commit();
+}
 
 const DEFAULT_SPACE_ID = process.env.CHAT_SPACE_ID ?? "AAAA-qf5jX0";
 const CHAT_API_BASE = "https://chat.googleapis.com/v1";
@@ -104,6 +164,7 @@ export async function syncChatMessages(spaceId: string): Promise<SyncResult> {
     : new Date(Date.now() - 24 * 60 * 60 * 1000);
 
   const authHeaders = await getAuthHeaders();
+  const classificationConfig = await getClassificationConfig();
   const filter = `createTime > "${since.toISOString()}"`;
 
   let newMessages = 0;
@@ -143,9 +204,17 @@ export async function syncChatMessages(spaceId: string): Promise<SyncResult> {
       const googleMessageId = msg.name as string;
       const docId = sanitizeDocId(googleMessageId);
 
-      // 重複チェック
+      // 重複チェック（保存済みだが未分類のメッセージは再分類を試みる）
       const existing = await collections.chatMessages.doc(docId).get();
       if (existing.exists) {
+        const existingData = existing.data();
+        if (existingData && !existingData.processedAt) {
+          try {
+            await classifyAndSaveIntent(docId, existingData.content ?? "", classificationConfig);
+          } catch (e) {
+            console.error(`Re-classification failed for ${docId}:`, e);
+          }
+        }
         duplicateSkipped++;
         continue;
       }
@@ -241,6 +310,13 @@ export async function syncChatMessages(spaceId: string): Promise<SyncResult> {
         processedAt: null,
         createdAt,
       });
+
+      // Intent 分類 + IntentRecord 保存（失敗時は processedAt=null のまま → 次回再分類）
+      try {
+        await classifyAndSaveIntent(docId, content, classificationConfig);
+      } catch (e) {
+        console.error(`Intent classification failed for ${docId}:`, e);
+      }
 
       newMessages++;
     }


### PR DESCRIPTION
## Summary
- **#167**: `syncChatMessages` (REST API 同期経路) で Intent 分類が行われず `IntentRecord` が作られない問題を修正
  - `classifyAndSaveIntent()` を追加し、分類 + `IntentRecord` 保存 + `processedAt` 更新を Firestore バッチで1回にまとめた
  - 分類設定は TTL 5分のインメモリキャッシュで取得（Worker と同パターン）
  - 既存メッセージが `processedAt: null` のまま放置される永久スタックを解消（次回同期時に再分類）
- **#168**: `PATCH /api/salary-drafts/:id` スキーマから金額フィールドを除去し、ヘッダと明細（`salaryDraftItems`）の乖離を防止
  - 更新可能フィールドを `effectiveDate` / `reason` のみに限定

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm lint` — 警告なし増加
- [x] `pnpm test --run` — 67テスト全通過

Closes #167
Closes #168

🤖 Generated with [Claude Code](https://claude.com/claude-code)