### PR TITLE
fix: タイプスケール準拠 — text-[11px] を text-xs に統一

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/[id]/ai-panel.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/ai-panel.tsx
@@ -57,7 +57,7 @@ export function AiPanel({ intent }: AiPanelProps) {
               {conf.label} ({(intent.confidenceScore * 100).toFixed(0)}%)
             </span>
           </div>
-          <p className="text-[11px] text-muted-foreground">
+          <p className="text-xs text-muted-foreground">
             {intent.classificationMethod === "ai"
               ? "Gemini による自動分類"
               : intent.classificationMethod === "regex"
@@ -87,7 +87,7 @@ export function AiPanel({ intent }: AiPanelProps) {
       {/* AI 推論 */}
       {intent.reasoning && (
         <div className="rounded-lg border border-border/60 bg-muted/40 p-3">
-          <p className="mb-1 text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">
+          <p className="mb-1 text-xs font-semibold text-muted-foreground uppercase tracking-wider">
             AI の判断理由
           </p>
           <p className="text-xs leading-relaxed text-foreground/80">{intent.reasoning}</p>

--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -172,7 +172,7 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
                   {senderDisplay}
                 </span>
                 {msg.isEdited && (
-                  <span className="flex shrink-0 items-center gap-0.5 text-[11px] text-muted-foreground">
+                  <span className="flex shrink-0 items-center gap-0.5 text-xs text-muted-foreground">
                     <Pencil size={9} />
                     編集済
                   </span>

--- a/apps/web/src/app/(protected)/dashboard/inbox-status-bar.tsx
+++ b/apps/web/src/app/(protected)/dashboard/inbox-status-bar.tsx
@@ -24,7 +24,7 @@ export function InboxStatusBar({ counts }: { counts: InboxCounts }) {
           return (
             <div key={seg.label} className="flex-1 min-w-0">
               <div className="flex items-center justify-between mb-1.5">
-                <span className="text-[11px] text-muted-foreground">{seg.label}</span>
+                <span className="text-xs text-muted-foreground">{seg.label}</span>
                 <span className="text-xs font-semibold tabular-nums">{seg.count}</span>
               </div>
               <div className="h-2 rounded-full bg-muted overflow-hidden">

--- a/apps/web/src/app/(protected)/inbox/handover-form.tsx
+++ b/apps/web/src/app/(protected)/inbox/handover-form.tsx
@@ -47,7 +47,7 @@ export function HandoverForm({ chatMessageId, taskSummary, assignees, notes }: H
           <button
             type="button"
             onClick={() => setEditing(true)}
-            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-[11px] text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+            className="flex items-center gap-1 rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
           >
             <Pencil className="h-3 w-3" />
             {hasContent ? "編集" : "追加"}
@@ -75,10 +75,10 @@ export function HandoverForm({ chatMessageId, taskSummary, assignees, notes }: H
             )}
           </div>
         ) : (
-          <p className="text-[11px] text-muted-foreground/60 italic">メモなし</p>
+          <p className="text-xs text-muted-foreground/60 italic">メモなし</p>
         )}
         {saved && (
-          <p className="flex items-center gap-1 text-[11px] text-[var(--status-ok)]">
+          <p className="flex items-center gap-1 text-xs text-[var(--status-ok)]">
             <Check className="h-3 w-3" />
             保存しました
           </p>

--- a/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
@@ -75,7 +75,7 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
                   )}
                 />
                 <span className="truncate text-xs font-medium">{msg.senderName}</span>
-                <span className="ml-auto text-[11px] text-muted-foreground">
+                <span className="ml-auto text-xs text-muted-foreground">
                   {formatDateTimeJST(msg.createdAt)}
                 </span>
               </div>
@@ -83,11 +83,11 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
               <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{msg.content}</p>
 
               <div className="mt-1.5 flex items-center gap-1.5">
-                <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
                   {CATEGORY_LABELS[category] ?? category}
                 </span>
                 {intent?.confidenceScore != null && (
-                  <span className="text-[11px] tabular-nums text-muted-foreground">
+                  <span className="text-xs tabular-nums text-muted-foreground">
                     {(intent.confidenceScore * 100).toFixed(0)}%
                   </span>
                 )}

--- a/apps/web/src/app/(protected)/inbox/inbox-list.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-list.tsx
@@ -103,7 +103,7 @@ function InboxCard({
             </span>
             <span
               className={cn(
-                "rounded-full px-2 py-0.5 text-[11px] font-medium",
+                "rounded-full px-2 py-0.5 text-xs font-medium",
                 RESPONSE_STATUS_BADGE_COLORS[currentStatus],
               )}
             >

--- a/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
@@ -59,11 +59,9 @@ export function LineInbox3Pane({ messages, selectedMessage, selectedId }: LineIn
                 />
                 <span className="truncate text-xs font-medium">{msg.senderName}</span>
                 {msg.groupName && (
-                  <span className="truncate text-[11px] text-muted-foreground">
-                    @ {msg.groupName}
-                  </span>
+                  <span className="truncate text-xs text-muted-foreground">@ {msg.groupName}</span>
                 )}
-                <span className="ml-auto text-[11px] text-muted-foreground">
+                <span className="ml-auto text-xs text-muted-foreground">
                   {formatDateTimeJST(msg.createdAt)}
                 </span>
               </div>
@@ -80,11 +78,11 @@ export function LineInbox3Pane({ messages, selectedMessage, selectedId }: LineIn
               </p>
 
               <div className="mt-1.5 flex items-center gap-1.5">
-                <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-[11px] text-emerald-700">
+                <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-xs text-emerald-700">
                   LINE
                 </span>
                 {msg.lineMessageType !== "text" && (
-                  <span className="rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+                  <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
                     {msg.lineMessageType}
                   </span>
                 )}

--- a/apps/web/src/app/(protected)/inbox/page.tsx
+++ b/apps/web/src/app/(protected)/inbox/page.tsx
@@ -171,7 +171,7 @@ export default async function InboxPage({ searchParams }: Props) {
               >
                 {tab.label}
                 <span
-                  className={`rounded-full px-1.5 py-0.5 text-[11px] tabular-nums ${
+                  className={`rounded-full px-1.5 py-0.5 text-xs tabular-nums ${
                     isActive ? "bg-white/20" : "bg-slate-100"
                   }`}
                 >

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -73,13 +73,13 @@ export function TaskList({ tasks }: { tasks: TaskItem[] }) {
                 <MessageCircle size={12} className="text-emerald-500" />
               )}
               {task.groupName && (
-                <span className="text-[11px] text-muted-foreground">@ {task.groupName}</span>
+                <span className="text-xs text-muted-foreground">@ {task.groupName}</span>
               )}
               {/* 対応状況 */}
-              <span className="ml-auto text-[11px] text-muted-foreground">
+              <span className="ml-auto text-xs text-muted-foreground">
                 {RESPONSE_STATUS_LABELS[task.responseStatus]}
               </span>
-              <span className="text-[11px] text-muted-foreground">
+              <span className="text-xs text-muted-foreground">
                 {formatDateTimeJST(task.createdAt)}
               </span>
             </div>
@@ -96,7 +96,7 @@ export function TaskList({ tasks }: { tasks: TaskItem[] }) {
 
             {/* 担当者 */}
             {task.assignees && (
-              <p className="mt-1 text-[11px] text-muted-foreground">担当: {task.assignees}</p>
+              <p className="mt-1 text-xs text-muted-foreground">担当: {task.assignees}</p>
             )}
           </Link>
         );

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -117,6 +117,17 @@
   --status-warn: oklch(0.65 0.18 75);
   --status-danger: oklch(0.58 0.22 25);
   --status-info: oklch(0.55 0.16 230);
+
+  /* 黄金比タイポグラフィスケール
+   * caption: 10px | label: 12px | body: 15px | subhead: 19px | heading: 24px | display: 31px
+   * 各ステップは √φ (≈1.272) の倍率
+   */
+  --type-caption: 0.625rem; /* 10px */
+  --type-label: 0.75rem; /* 12px */
+  --type-body: 0.9375rem; /* 15px */
+  --type-subhead: 1.1875rem; /* 19px */
+  --type-heading: 1.5rem; /* 24px */
+  --type-display: 1.9375rem; /* 31px */
 }
 
 .dark {
@@ -169,18 +180,6 @@
     letter-spacing: -0.02em;
     font-weight: 700;
     line-height: 1.25; /* 見出しは詰め気味 */
-  }
-  /* 黄金比タイポグラフィスケール変数
-   * caption: 10px | label: 12px | body: 15px | subhead: 19px | heading: 24px | display: 31px
-   * 各ステップは √φ (≈1.272) の倍率
-   */
-  :root {
-    --type-caption: 0.625rem; /* 10px */
-    --type-label: 0.75rem; /* 12px */
-    --type-body: 0.9375rem; /* 15px */
-    --type-subhead: 1.1875rem; /* 19px */
-    --type-heading: 1.5rem; /* 24px */
-    --type-display: 1.9375rem; /* 31px */
   }
 }
 

--- a/apps/web/src/components/chat/attachment-list.tsx
+++ b/apps/web/src/components/chat/attachment-list.tsx
@@ -52,7 +52,7 @@ export function AttachmentList({ attachments }: AttachmentListProps) {
               {displayName}
             </button>
             {att.contentType && (
-              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[11px] text-muted-foreground">
+              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
                 {att.contentType.split("/").pop()}
               </span>
             )}

--- a/apps/web/src/components/chat/mention-badge.tsx
+++ b/apps/web/src/components/chat/mention-badge.tsx
@@ -12,7 +12,7 @@ export function MentionBadge({ displayName }: MentionBadgeProps) {
   const initial = name.slice(0, 1);
   return (
     <span className="inline-flex items-center gap-1 rounded-full border border-indigo-200 bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700">
-      <span className="flex h-4 w-4 items-center justify-center rounded-full bg-indigo-200 text-[11px] font-bold text-indigo-700">
+      <span className="flex h-4 w-4 items-center justify-center rounded-full bg-indigo-200 text-xs font-bold text-indigo-700">
         {initial}
       </span>
       @{name}

--- a/apps/web/src/components/chat/sync-button.tsx
+++ b/apps/web/src/components/chat/sync-button.tsx
@@ -181,7 +181,7 @@ export function ChatSyncButton() {
           </div>
 
           {config.updatedAt && (
-            <p className="mt-3 text-[11px] text-slate-400">
+            <p className="mt-3 text-xs text-slate-400">
               更新: {formatDateTimeJST(config.updatedAt)}
             </p>
           )}

--- a/apps/web/src/components/sidebar-nav.tsx
+++ b/apps/web/src/components/sidebar-nav.tsx
@@ -40,7 +40,7 @@ export function SidebarNav() {
             href={item.href}
             title={item.label}
             className={cn(
-              "relative flex w-10 flex-col items-center gap-0.5 rounded-lg px-1 py-2 text-[11px] font-medium transition-all duration-150",
+              "relative flex w-10 flex-col items-center gap-0.5 rounded-lg px-1 py-2 text-xs font-medium transition-all duration-150",
               active &&
                 "bg-gradient-accent-soft border border-[var(--gradient-from)]/20 text-[var(--gradient-from)]",
               !active &&

--- a/apps/web/src/components/workflow-panel.tsx
+++ b/apps/web/src/components/workflow-panel.tsx
@@ -91,12 +91,12 @@ export function WorkflowPanel({ steps, onUpdate, compact = false }: WorkflowPane
               >
                 {step.label}
               </span>
-              <span className={cn("text-[11px]", config.color)}>{config.label}</span>
+              <span className={cn("text-xs", config.color)}>{config.label}</span>
             </button>
           );
         })}
       </div>
-      {saving && <p className="text-[11px] text-muted-foreground">保存中...</p>}
+      {saving && <p className="text-xs text-muted-foreground">保存中...</p>}
     </div>
   );
 }
@@ -128,7 +128,7 @@ export function WorkflowProgressBar({ steps }: { steps: WorkflowSteps | null }) 
           />
         );
       })}
-      <span className="ml-1 text-[11px] tabular-nums text-muted-foreground">
+      <span className="ml-1 text-xs tabular-nums text-muted-foreground">
         {completedCount}/{STEP_LABELS.length}
       </span>
     </div>


### PR DESCRIPTION
## Summary
- `/simplify` レビューで検出された問題を修正
- `text-[11px]`（黄金比スケールに存在しない孤立値）を全27箇所で `text-xs`（12px = `--type-label`）に統一
- タイプスケール CSS 変数を `@layer base` 内の `:root` から外側の `:root` に移動して他のデザイントークンと一元管理

## Test plan
- [x] `text-[11px]` の残存: 0件（grep確認済み）
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm test --run` — 96テスト全通過
- [ ] ブラウザで各ページの視認性を目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)