### PR TITLE
ui: サイドバーナビ再設計 — 可読性・アクティブ状態の改善

### DIFF
--- a/apps/web/src/__tests__/sidebar-nav.test.tsx
+++ b/apps/web/src/__tests__/sidebar-nav.test.tsx
@@ -50,6 +50,13 @@ describe("sidebar-nav 構造", () => {
     expect(admin).toBeDefined();
     expect(admin!.href).toBe("/admin");
   });
+
+  it("全項目に shortLabel が定義されていること", () => {
+    for (const item of navItems) {
+      expect(item.shortLabel).toBeDefined();
+      expect(item.shortLabel.length).toBeLessThanOrEqual(3);
+    }
+  });
 });
 
 describe("isNavActive ルーティング判定", () => {

--- a/apps/web/src/components/sidebar-nav.tsx
+++ b/apps/web/src/components/sidebar-nav.tsx
@@ -8,17 +8,18 @@ import { cn } from "@/lib/utils";
 export interface NavItem {
   href: string;
   label: string;
+  shortLabel: string;
   icon: React.ComponentType<{ className?: string }>;
   badge?: number;
   badgeVariant?: "default" | "warn";
 }
 
 export const navItems: NavItem[] = [
-  { href: "/inbox", label: "受信箱", icon: Inbox },
-  { href: "/task-board", label: "タスク", icon: ListTodo },
-  { href: "/tasks", label: "承認", icon: ClipboardList },
-  { href: "/dashboard", label: "ダッシュボード", icon: BarChart3 },
-  { href: "/admin", label: "管理", icon: Settings },
+  { href: "/inbox", label: "受信箱", shortLabel: "受信箱", icon: Inbox },
+  { href: "/task-board", label: "タスク", shortLabel: "タスク", icon: ListTodo },
+  { href: "/tasks", label: "承認", shortLabel: "承認", icon: ClipboardList },
+  { href: "/dashboard", label: "ダッシュボード", shortLabel: "分析", icon: BarChart3 },
+  { href: "/admin", label: "管理", shortLabel: "管理", icon: Settings },
 ];
 
 export function isNavActive(href: string, pathname: string): boolean {
@@ -29,41 +30,87 @@ export function SidebarNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="flex w-14 flex-col items-center gap-0.5 border-r border-border bg-card pt-3">
-      {navItems.map((item) => {
-        const active = isNavActive(item.href, pathname);
-        const Icon = item.icon;
+    <nav className="relative flex w-[60px] flex-col items-center border-r border-border/50 bg-card">
+      {/* メインナビ（上部） */}
+      <div className="flex flex-1 flex-col items-center gap-1 pt-4">
+        {navItems.slice(0, 4).map((item) => (
+          <SidebarItem key={item.href} item={item} pathname={pathname} />
+        ))}
+      </div>
 
-        return (
-          <Link
-            key={item.href}
-            href={item.href}
-            title={item.label}
-            className={cn(
-              "relative flex w-10 flex-col items-center gap-0.5 rounded-lg px-1 py-2 text-xs font-medium transition-all duration-150",
-              active &&
-                "bg-gradient-accent-soft border border-[var(--gradient-from)]/20 text-[var(--gradient-from)]",
-              !active &&
-                "border border-transparent text-muted-foreground hover:bg-accent hover:text-foreground",
-            )}
-          >
-            <Icon
-              className={cn("h-4 w-4 flex-shrink-0", active && "text-[var(--gradient-from)]")}
-            />
-            <span className="leading-tight">{item.label}</span>
-            {item.badge != null && item.badge > 0 && (
-              <span
-                className={cn(
-                  "absolute -top-0.5 -right-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full px-1 text-[9px] font-bold text-white ring-1.5 ring-card",
-                  item.badgeVariant === "warn" ? "bg-[var(--status-warn)]" : "bg-destructive",
-                )}
-              >
-                {item.badge}
-              </span>
-            )}
-          </Link>
-        );
-      })}
+      {/* 設定（下部） */}
+      <div className="flex flex-col items-center gap-1 pb-4">
+        {navItems.slice(4).map((item) => (
+          <SidebarItem key={item.href} item={item} pathname={pathname} />
+        ))}
+      </div>
     </nav>
+  );
+}
+
+function SidebarItem({ item, pathname }: { item: NavItem; pathname: string }) {
+  const active = isNavActive(item.href, pathname);
+  const Icon = item.icon;
+
+  return (
+    <Link
+      href={item.href}
+      title={item.label}
+      className={cn(
+        "group relative flex w-11 flex-col items-center gap-1 rounded-lg py-2 transition-all duration-200",
+        active && "text-[var(--gradient-from)]",
+        !active && "text-muted-foreground hover:text-foreground",
+      )}
+    >
+      {/* アクティブインジケーター: 左端のアクセントバー */}
+      <span
+        className={cn(
+          "absolute left-0 top-1/2 -translate-y-1/2 w-[3px] rounded-r-full transition-all duration-200",
+          active
+            ? "h-6 bg-gradient-to-b from-[var(--gradient-from)] to-[var(--gradient-to)]"
+            : "h-0",
+        )}
+      />
+
+      {/* アクティブ背景 */}
+      <span
+        className={cn(
+          "absolute inset-1 rounded-lg transition-all duration-200",
+          active && "bg-[var(--gradient-from)]/[0.06]",
+          !active && "group-hover:bg-accent/60",
+        )}
+      />
+
+      {/* アイコン */}
+      <Icon
+        className={cn(
+          "relative z-10 h-[18px] w-[18px] transition-transform duration-200",
+          active && "text-[var(--gradient-from)]",
+          !active && "group-hover:scale-105",
+        )}
+      />
+
+      {/* ラベル */}
+      <span
+        className={cn(
+          "relative z-10 text-[10px] font-medium leading-none tracking-tight",
+          active && "font-semibold",
+        )}
+      >
+        {item.shortLabel}
+      </span>
+
+      {/* バッジ */}
+      {item.badge != null && item.badge > 0 && (
+        <span
+          className={cn(
+            "absolute top-0.5 right-0 z-20 flex h-3.5 min-w-3.5 items-center justify-center rounded-full px-1 text-[9px] font-bold text-white ring-1.5 ring-card",
+            item.badgeVariant === "warn" ? "bg-[var(--status-warn)]" : "bg-destructive",
+          )}
+        >
+          {item.badge}
+        </span>
+      )}
+    </Link>
   );
 }


### PR DESCRIPTION
## Summary
- サイドバー幅56→60px、`shortLabel`導入で全ラベル1行表示（「ダッシュボード」→「分析」）
- アクティブ状態を左端グラデーションバー + 背景ティントに強化
- メインナビ（上部4項目）/ 設定（下部）に分離、`SidebarItem`コンポーネント抽出

## Test plan
- [x] `pnpm typecheck` — web通過
- [x] `pnpm lint` — web通過
- [x] `pnpm test` — 97テスト全通過（sidebar 16件、shortLabel テスト1件追加）
- [ ] ブラウザ目視確認（デプロイ後）

🤖 Generated with [Claude Code](https://claude.com/claude-code)