### PR TITLE
fix(worker): 同姓同名の従業員がいる場合にドラフト作成を保留する

### DIFF
--- a/apps/worker/src/__tests__/salary-handler.test.ts
+++ b/apps/worker/src/__tests__/salary-handler.test.ts
@@ -383,14 +383,103 @@ describe("handleSalary", () => {
       });
 
       // 両方のクエリで見つからない
-      const mockGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
-      mockEmployeesWhere.mockReturnValue({
-        where: vi.fn().mockReturnValue({ limit: vi.fn().mockReturnValue({ get: mockGet }) }),
+      const mockEmptyResult = { empty: true, size: 0, docs: [] };
+      const mockGet = vi.fn().mockResolvedValue(mockEmptyResult);
+      mockEmployeesWhere.mockImplementation((field: string) => {
+        if (field === "employeeNumber") {
+          return {
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({ get: mockGet }),
+            }),
+          };
+        }
+        // name 検索: limit なし
+        return { where: vi.fn().mockReturnValue({ get: mockGet }) };
       });
 
       await expect(handleSalary("chat-001", makeEvent(), makeIntentResult())).rejects.toThrow(
         expect.objectContaining({ code: "EMPLOYEE_NOT_FOUND" }),
       );
+    });
+
+    it("同姓同名の従業員が複数いる場合は WorkerError(EMPLOYEE_AMBIGUOUS)", async () => {
+      mockExtractSalaryParams.mockResolvedValue({
+        employeeIdentifier: "山田 花子",
+        changeType: "mechanical",
+        targetSalary: 260000,
+        allowanceType: null,
+        reasoning: "2ピッチアップ",
+      });
+
+      // employeeNumber 検索 → 見つからない
+      const mockEmptyGet = vi.fn().mockResolvedValue({ empty: true, docs: [] });
+      // name 検索 → 2件ヒット（同姓同名）
+      const mockAmbiguousGet = vi.fn().mockResolvedValue({
+        empty: false,
+        size: 2,
+        docs: [
+          {
+            id: "emp-001",
+            data: () => ({
+              employeeNumber: "E001",
+              name: "山田 花子",
+              department: "本社",
+              isActive: true,
+            }),
+          },
+          {
+            id: "emp-002",
+            data: () => ({
+              employeeNumber: "E002",
+              name: "山田 花子",
+              department: "大阪支社",
+              isActive: true,
+            }),
+          },
+        ],
+      });
+
+      mockEmployeesWhere.mockImplementation((field: string) => {
+        if (field === "employeeNumber") {
+          return {
+            where: vi.fn().mockReturnValue({
+              limit: vi.fn().mockReturnValue({ get: mockEmptyGet }),
+            }),
+          };
+        }
+        // name 検索: limit なしで直接 get
+        return {
+          where: vi.fn().mockReturnValue({ get: mockAmbiguousGet }),
+        };
+      });
+
+      await expect(handleSalary("chat-001", makeEvent(), makeIntentResult())).rejects.toThrow(
+        expect.objectContaining({
+          code: "EMPLOYEE_AMBIGUOUS",
+          shouldNack: false,
+        }),
+      );
+    });
+
+    it("同姓同名でも社員番号で指定すれば一意に特定できる", async () => {
+      mockExtractSalaryParams.mockResolvedValue({
+        employeeIdentifier: "E001",
+        changeType: "mechanical",
+        targetSalary: 260000,
+        allowanceType: null,
+        reasoning: "2ピッチアップ",
+      });
+      mockApplyMechanicalChange.mockReturnValue({
+        changeType: "mechanical",
+        before: MOCK_BREAKDOWN,
+        after: MOCK_AFTER_BREAKDOWN,
+        items: [],
+      });
+
+      // employeeNumber 検索 → 1件ヒット（社員番号は一意）
+      await handleSalary("chat-001", makeEvent(), makeIntentResult());
+
+      expect(mockBatchCommit).toHaveBeenCalledOnce();
     });
 
     it("extractSalaryParams が失敗した場合は WorkerError(LLM_ERROR, shouldNack=true)", async () => {

--- a/apps/worker/src/lib/errors.ts
+++ b/apps/worker/src/lib/errors.ts
@@ -4,6 +4,7 @@ export type WorkerErrorCode =
   | "PARSE_ERROR"
   | "DUPLICATE_MESSAGE"
   | "EMPLOYEE_NOT_FOUND"
+  | "EMPLOYEE_AMBIGUOUS"
   | "SALARY_CALC_ERROR"
   | "LLM_ERROR"
   | "DB_ERROR"

--- a/apps/worker/src/pipeline/salary-handler.ts
+++ b/apps/worker/src/pipeline/salary-handler.ts
@@ -311,12 +311,25 @@ async function findEmployee(identifier: string | null): Promise<{ id: string } &
     if (doc) return { id: doc.id, ...doc.data() };
   }
 
-  // 2. name で検索
+  // 2. name で検索（同姓同名チェック付き）
   const byName = await collections.employees
     .where("name", "==", identifier)
     .where("isActive", "==", true)
-    .limit(1)
     .get();
+
+  if (byName.size > 1) {
+    const candidates = byName.docs.map((d) => ({
+      id: d.id,
+      employeeNumber: d.data().employeeNumber,
+      department: d.data().department,
+    }));
+    throw new WorkerError(
+      "EMPLOYEE_AMBIGUOUS",
+      `同名の従業員が${byName.size}名見つかりました（${identifier}）。社員番号で指定してください`,
+      false,
+      { identifier, candidates },
+    );
+  }
 
   if (!byName.empty) {
     const doc = byName.docs.at(0);


### PR DESCRIPTION
## Summary
- `findEmployee()` の name 検索から `limit(1)` を除去し、同姓同名チェックを追加
- 複数ヒット時は `EMPLOYEE_AMBIGUOUS` エラーで社員番号指定を促す（Human-in-the-loop）
- `details` に候補リスト（id, employeeNumber, department）を含め、手動対応を支援

Closes #171

## Test plan
- [x] 同姓同名テスト: 2名ヒット時に `EMPLOYEE_AMBIGUOUS` エラー
- [x] 社員番号指定テスト: 同姓同名でも `employeeNumber` で一意特定可能
- [x] 既存テスト: 71件全通過（Worker）、全パッケージ全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)