### PR TITLE
fix: chat-sync の fire-and-forget 停止リスクと二重起動を修正

### DIFF
--- a/apps/api/src/__tests__/chat-sync-routes.test.ts
+++ b/apps/api/src/__tests__/chat-sync-routes.test.ts
@@ -1,11 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- モック変数（vi.hoisted で vi.mock と同時にホイスト） ---
-const { mockGetRequestHeaders, mockGet, mockSet, mockAdd } = vi.hoisted(() => ({
+const { mockGetRequestHeaders, mockGet, mockSet, mockAdd, mockRunTransaction } = vi.hoisted(() => ({
   mockGetRequestHeaders: vi.fn().mockResolvedValue({ Authorization: "Bearer test-token" }),
   mockGet: vi.fn(),
   mockSet: vi.fn().mockResolvedValue(undefined),
   mockAdd: vi.fn().mockResolvedValue({ id: "audit-1" }),
+  mockRunTransaction: vi.fn(),
 }));
 
 vi.mock("google-auth-library", () => ({
@@ -17,7 +18,14 @@ vi.mock("google-auth-library", () => ({
 }));
 
 vi.mock("@hr-system/db", () => ({
-  db: {},
+  db: {
+    runTransaction: mockRunTransaction,
+  },
+  loadClassificationConfig: vi.fn().mockResolvedValue({
+    regexRules: [],
+    systemPrompt: "",
+    fewShotExamples: [],
+  }),
   collections: {
     syncMetadata: {
       doc: vi.fn(() => ({ get: mockGet, set: mockSet })),
@@ -66,33 +74,52 @@ import { app } from "../app.js";
 describe("chat-sync routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // syncChatMessages 内の getSyncMetadata() / chatMessages.doc().get() 等のデフォルト
+    mockGet.mockResolvedValue({ exists: false });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ messages: [] }), { status: 200 }),
     );
   });
 
   describe("POST /api/chat-messages/sync", () => {
-    it("202 で同期を開始する", async () => {
-      // getSyncMetadata → idle
-      mockGet.mockResolvedValueOnce({
-        exists: true,
-        data: () => ({ status: "idle" }),
+    it("同期完了後に結果を返す", async () => {
+      // acquireSyncLock → 成功（トランザクション内で idle → running）
+      mockRunTransaction.mockImplementationOnce(async (fn: (tx: unknown) => Promise<boolean>) => {
+        const tx = {
+          get: vi.fn().mockResolvedValue({
+            exists: true,
+            data: () => ({ status: "idle" }),
+          }),
+          set: vi.fn(),
+        };
+        return fn(tx);
       });
 
       const res = await app.request("/api/chat-messages/sync", {
         method: "POST",
       });
 
-      expect(res.status).toBe(202);
-      const body = (await res.json()) as { message: string };
-      expect(body.message).toBe("同期を開始しました");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { message: string; result: { newMessages: number } };
+      expect(body.message).toBe("同期が完了しました");
+      expect(body.result.newMessages).toBe(0);
     });
 
-    it("409 で重複実行を防止する", async () => {
-      // getSyncMetadata → running
-      mockGet.mockResolvedValueOnce({
-        exists: true,
-        data: () => ({ status: "running" }),
+    it("409 で重複実行を防止する（トランザクションで検出）", async () => {
+      const { Timestamp } = await import("firebase-admin/firestore");
+      // acquireSyncLock → 失敗（running かつ stale でない）
+      mockRunTransaction.mockImplementationOnce(async (fn: (tx: unknown) => Promise<boolean>) => {
+        const tx = {
+          get: vi.fn().mockResolvedValue({
+            exists: true,
+            data: () => ({
+              status: "running",
+              updatedAt: Timestamp.now(), // 直近更新 → stale ではない
+            }),
+          }),
+          set: vi.fn(),
+        };
+        return fn(tx);
       });
 
       const res = await app.request("/api/chat-messages/sync", {
@@ -102,6 +129,75 @@ describe("chat-sync routes", () => {
       expect(res.status).toBe(409);
       const body = (await res.json()) as { error: string };
       expect(body.error).toBe("同期が既に実行中です");
+    });
+
+    it("stale lock を検出してロックを上書きする", async () => {
+      const { Timestamp } = await import("firebase-admin/firestore");
+      // 20分前の updatedAt → stale lock
+      const staleDate = new Date(Date.now() - 20 * 60 * 1000);
+      const mockTxSet = vi.fn();
+
+      mockRunTransaction.mockImplementationOnce(async (fn: (tx: unknown) => Promise<boolean>) => {
+        const tx = {
+          get: vi.fn().mockResolvedValue({
+            exists: true,
+            data: () => ({
+              status: "running",
+              updatedAt: Timestamp.fromDate(staleDate),
+            }),
+          }),
+          set: mockTxSet,
+        };
+        return fn(tx);
+      });
+
+      const res = await app.request("/api/chat-messages/sync", {
+        method: "POST",
+      });
+
+      // stale lock を上書きして同期成功
+      expect(res.status).toBe(200);
+      expect(mockTxSet).toHaveBeenCalled();
+    });
+
+    it("初回起動時（メタデータなし）にロックを取得できる", async () => {
+      mockRunTransaction.mockImplementationOnce(async (fn: (tx: unknown) => Promise<boolean>) => {
+        const tx = {
+          get: vi.fn().mockResolvedValue({ exists: false }),
+          set: vi.fn(),
+        };
+        return fn(tx);
+      });
+
+      const res = await app.request("/api/chat-messages/sync", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { message: string };
+      expect(body.message).toBe("同期が完了しました");
+    });
+
+    it("同期失敗時に 500 とエラーメッセージを返す", async () => {
+      // ロック取得成功
+      mockRunTransaction.mockImplementationOnce(async (fn: (tx: unknown) => Promise<boolean>) => {
+        const tx = {
+          get: vi.fn().mockResolvedValue({ exists: false }),
+          set: vi.fn(),
+        };
+        return fn(tx);
+      });
+
+      // Chat API 呼び出しを失敗させる
+      vi.spyOn(globalThis, "fetch").mockRejectedValueOnce(new Error("Network error"));
+
+      const res = await app.request("/api/chat-messages/sync", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toContain("同期に失敗しました");
     });
   });
 

--- a/apps/api/src/routes/chat-sync.ts
+++ b/apps/api/src/routes/chat-sync.ts
@@ -1,6 +1,8 @@
+import { Timestamp } from "firebase-admin/firestore";
 import { Hono } from "hono";
 import { HTTPException } from "hono/http-exception";
 import {
+  acquireSyncLock,
   getChatSyncConfig,
   getSyncMetadata,
   syncAllActiveSpaces,
@@ -22,9 +24,10 @@ chatSyncRoutes.use("*", async (c, next) => {
 });
 
 /**
- * POST /api/chat-messages/sync — 同期開始
+ * POST /api/chat-messages/sync — 同期実行
  * ?source=scheduler の場合は intervalMinutes チェックを行い、スキップ可能
- * 409 if already running, 202 accepted
+ * 同期完了まで待機して結果を返す（Cloud Run 途中停止を防止）
+ * 409 if already running
  */
 chatSyncRoutes.post("/", async (c) => {
   const isScheduler = c.req.query("source") === "scheduler";
@@ -47,50 +50,46 @@ chatSyncRoutes.post("/", async (c) => {
     }
   }
 
-  const meta = await getSyncMetadata();
-  if (meta?.status === "running") {
+  // Firestore トランザクションで排他ロック取得（stale lock は 15 分で自動解放）
+  const acquired = await acquireSyncLock();
+  if (!acquired) {
     return c.json({ error: "同期が既に実行中です" }, 409);
   }
 
-  await updateSyncMetadata({
-    status: "running",
-    errorMessage: null,
-  });
-
-  // バックグラウンドで同期実行（全アクティブスペース）
-  const syncPromise = syncAllActiveSpaces();
-  syncPromise
-    .then(async (results) => {
-      const { Timestamp } = await import("firebase-admin/firestore");
-      const totalNew = results.reduce((sum, r) => sum + r.newMessages, 0);
-      const totalDup = results.reduce((sum, r) => sum + r.duplicateSkipped, 0);
-      const totalMs = results.reduce((sum, r) => sum + r.durationMs, 0);
-      await updateSyncMetadata({
-        status: "idle",
-        lastSyncedAt: Timestamp.now(),
-        lastResult: {
-          newMessages: totalNew,
-          duplicateSkipped: totalDup,
-          durationMs: totalMs,
-          syncedAt: Timestamp.now(),
-        },
-        errorMessage: null,
-      });
-    })
-    .catch(async (err: unknown) => {
-      const message = err instanceof Error ? err.message : "不明なエラー";
-      console.error("Chat sync failed:", message);
-      try {
-        await updateSyncMetadata({
-          status: "error",
-          errorMessage: message,
-        });
-      } catch (updateErr) {
-        console.error("Failed to update sync status:", updateErr);
-      }
+  // 同期実行（完了まで待機 — Cloud Run 途中停止を防止）
+  try {
+    const results = await syncAllActiveSpaces();
+    const totalNew = results.reduce((sum, r) => sum + r.newMessages, 0);
+    const totalDup = results.reduce((sum, r) => sum + r.duplicateSkipped, 0);
+    const totalMs = results.reduce((sum, r) => sum + r.durationMs, 0);
+    await updateSyncMetadata({
+      status: "idle",
+      lastSyncedAt: Timestamp.now(),
+      lastResult: {
+        newMessages: totalNew,
+        duplicateSkipped: totalDup,
+        durationMs: totalMs,
+        syncedAt: Timestamp.now(),
+      },
+      errorMessage: null,
     });
-
-  return c.json({ message: "同期を開始しました" }, 202);
+    return c.json({
+      message: "同期が完了しました",
+      result: { newMessages: totalNew, duplicateSkipped: totalDup, durationMs: totalMs },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : "不明なエラー";
+    console.error("Chat sync failed:", message);
+    try {
+      await updateSyncMetadata({
+        status: "error",
+        errorMessage: message,
+      });
+    } catch (updateErr) {
+      console.error("Failed to update sync status:", updateErr);
+    }
+    return c.json({ error: `同期に失敗しました: ${message}` }, 500);
+  }
 });
 
 /**

--- a/apps/api/src/services/chat-sync.ts
+++ b/apps/api/src/services/chat-sync.ts
@@ -136,6 +136,46 @@ export async function updateSyncMetadata(data: Partial<SyncMetadata>): Promise<v
     .set({ ...data, updatedAt: Timestamp.now() } as SyncMetadata, { merge: true });
 }
 
+/** stale lock とみなす閾値（15 分） */
+const STALE_LOCK_MS = 15 * 60 * 1000;
+
+/**
+ * Firestore トランザクションで排他ロックを取得する。
+ * - status が "running" かつ updatedAt が STALE_LOCK_MS 以内 → ロック取得失敗
+ * - status が "running" でも STALE_LOCK_MS 超過 → stale lock として上書き
+ * @returns true: ロック取得成功, false: 既に実行中
+ */
+export async function acquireSyncLock(): Promise<boolean> {
+  const docRef = collections.syncMetadata.doc("chat_messages");
+  try {
+    return await db.runTransaction(async (tx) => {
+      const snap = await tx.get(docRef);
+      if (snap.exists) {
+        const data = snap.data() as SyncMetadata;
+        if (data.status === "running") {
+          const elapsed = Date.now() - data.updatedAt.toDate().getTime();
+          if (elapsed < STALE_LOCK_MS) {
+            return false; // 正常に稼働中 → ロック取得拒否
+          }
+          // stale lock → 上書き
+          console.warn(
+            `[chat-sync] Stale lock detected (${Math.round(elapsed / 1000)}s ago). Overriding.`,
+          );
+        }
+      }
+      tx.set(
+        docRef,
+        { status: "running", errorMessage: null, updatedAt: Timestamp.now() } as SyncMetadata,
+        { merge: true },
+      );
+      return true;
+    });
+  } catch (e) {
+    console.error("[chat-sync] Failed to acquire lock:", e);
+    return false;
+  }
+}
+
 /** chat_sync_config/default ドキュメントを取得 */
 export async function getChatSyncConfig(): Promise<ChatSyncConfig | null> {
   const doc = await collections.chatSyncConfig.doc("default").get();

--- a/apps/web/src/components/chat/sync-button.tsx
+++ b/apps/web/src/components/chat/sync-button.tsx
@@ -50,24 +50,6 @@ export function ChatSyncButton() {
     fetchStatus();
   }, [fetchStatus]);
 
-  // ポーリング（同期中のみ）
-  useEffect(() => {
-    if (!isSyncing) return;
-
-    const startTime = Date.now();
-    const maxDuration = 30_000; // 最大30秒
-
-    const interval = setInterval(async () => {
-      const data = await fetchStatus();
-      if (data?.status !== "running" || Date.now() - startTime > maxDuration) {
-        setIsSyncing(false);
-        clearInterval(interval);
-      }
-    }, 2_000);
-
-    return () => clearInterval(interval);
-  }, [isSyncing, fetchStatus]);
-
   const handleSync = async () => {
     setIsSyncing(true);
     try {
@@ -76,10 +58,11 @@ export function ChatSyncButton() {
         // 既に実行中
         return;
       }
-      if (!res.ok) {
-        setIsSyncing(false);
-      }
+      // 同期完了（成功/失敗問わず）→ ステータス再取得
+      await fetchStatus();
     } catch {
+      // ネットワークエラー等
+    } finally {
       setIsSyncing(false);
     }
   };


### PR DESCRIPTION
## Summary
- fire-and-forget を同期実行に変更し、Cloud Run がレスポンス後にコンテナを停止して同期が中断するリスクを解消
- Firestore トランザクションで排他ロック取得し、同時 POST による二重起動の race condition を防止
- stale lock detection（15分超）で、クラッシュ後のデッドロックを自動解放
- フロントエンドのポーリングを除去し、POST レスポンスで直接完了を検知

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm test --run` — 265テスト全通過（chat-sync 7件含む）
- [x] 同期完了後に結果を返すテスト
- [x] 二重起動防止（トランザクションで検出）テスト
- [x] stale lock 検出・上書きテスト
- [x] 初回起動時（メタデータなし）テスト
- [x] 同期失敗時の 500 レスポンステスト

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)