### PR TITLE
fix: Intent フィルタ使用時のページネーション不正を修正

### DIFF
--- a/apps/api/src/__tests__/chat-messages-routes.test.ts
+++ b/apps/api/src/__tests__/chat-messages-routes.test.ts
@@ -220,6 +220,151 @@ describe("chat-messages routes", () => {
       expect(body.data).toHaveLength(1);
       expect(body.data[0]!.id).toBe("msg-2");
     });
+
+    it("Intent フィルタ + ページネーション: offset/limit がフィルタ後に適用される", async () => {
+      // 5件のメッセージ、うち3件が salary カテゴリ
+      mockChatMessagesGet.mockResolvedValueOnce({
+        docs: [
+          makeChatDoc("msg-1"),
+          makeChatDoc("msg-2"),
+          makeChatDoc("msg-3"),
+          makeChatDoc("msg-4"),
+          makeChatDoc("msg-5"),
+        ],
+      });
+      mockIntentRecordsGet.mockResolvedValueOnce({
+        docs: [
+          ...makeIntentSnap("msg-1", 0.9, "unresponded").docs, // salary
+          {
+            id: "intent-msg-2",
+            data: () => ({
+              chatMessageId: "msg-2",
+              category: "retirement",
+              confidenceScore: 0.8,
+              classificationMethod: "ai",
+              isManualOverride: false,
+              originalCategory: null,
+              regexPattern: null,
+              responseStatus: "unresponded",
+              createdAt: now,
+            }),
+          },
+          ...makeIntentSnap("msg-3", 0.7, "unresponded").docs, // salary
+          {
+            id: "intent-msg-4",
+            data: () => ({
+              chatMessageId: "msg-4",
+              category: "retirement",
+              confidenceScore: 0.8,
+              classificationMethod: "ai",
+              isManualOverride: false,
+              originalCategory: null,
+              regexPattern: null,
+              responseStatus: "unresponded",
+              createdAt: now,
+            }),
+          },
+          ...makeIntentSnap("msg-5", 0.6, "unresponded").docs, // salary
+        ],
+      });
+
+      // limit=2, offset=0 — salary のうち最初の2件（msg-1, msg-3）を返し hasMore=true
+      const res = await app.request("/api/chat-messages?category=salary&limit=2&offset=0");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        data: Array<{ id: string }>;
+        pagination: { limit: number; offset: number; hasMore: boolean };
+      };
+      expect(body.data).toHaveLength(2);
+      expect(body.data[0]!.id).toBe("msg-1");
+      expect(body.data[1]!.id).toBe("msg-3");
+      expect(body.pagination.hasMore).toBe(true);
+    });
+
+    it("Intent フィルタ + ページネーション: 2ページ目を正しく返す", async () => {
+      // 同じ5件、salary が3件
+      mockChatMessagesGet.mockResolvedValueOnce({
+        docs: [
+          makeChatDoc("msg-1"),
+          makeChatDoc("msg-2"),
+          makeChatDoc("msg-3"),
+          makeChatDoc("msg-4"),
+          makeChatDoc("msg-5"),
+        ],
+      });
+      mockIntentRecordsGet.mockResolvedValueOnce({
+        docs: [
+          ...makeIntentSnap("msg-1", 0.9, "unresponded").docs,
+          {
+            id: "intent-msg-2",
+            data: () => ({
+              chatMessageId: "msg-2",
+              category: "retirement",
+              confidenceScore: 0.8,
+              classificationMethod: "ai",
+              isManualOverride: false,
+              originalCategory: null,
+              regexPattern: null,
+              responseStatus: "unresponded",
+              createdAt: now,
+            }),
+          },
+          ...makeIntentSnap("msg-3", 0.7, "unresponded").docs,
+          {
+            id: "intent-msg-4",
+            data: () => ({
+              chatMessageId: "msg-4",
+              category: "retirement",
+              confidenceScore: 0.8,
+              classificationMethod: "ai",
+              isManualOverride: false,
+              originalCategory: null,
+              regexPattern: null,
+              responseStatus: "unresponded",
+              createdAt: now,
+            }),
+          },
+          ...makeIntentSnap("msg-5", 0.6, "unresponded").docs,
+        ],
+      });
+
+      // limit=2, offset=2 — salary の3件目（msg-5）のみ、hasMore=false
+      const res = await app.request("/api/chat-messages?category=salary&limit=2&offset=2");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        data: Array<{ id: string }>;
+        pagination: { limit: number; offset: number; hasMore: boolean };
+      };
+      expect(body.data).toHaveLength(1);
+      expect(body.data[0]!.id).toBe("msg-5");
+      expect(body.pagination.hasMore).toBe(false);
+    });
+
+    it("Intent フィルタなしでは Firestore レベルのページネーションを使用する", async () => {
+      // limit+1 件取得して hasMore 判定する従来ロジック
+      mockChatMessagesGet.mockResolvedValueOnce({
+        docs: [makeChatDoc("msg-1"), makeChatDoc("msg-2"), makeChatDoc("msg-3")],
+      });
+      mockIntentRecordsGet.mockResolvedValueOnce({
+        docs: [
+          ...makeIntentSnap("msg-1", 0.9).docs,
+          ...makeIntentSnap("msg-2", 0.8).docs,
+          // msg-3 は limit+1 の余剰分として切り捨てられる想定だが
+          // モック上は 3件返す → hasMore=true, data は 2件
+          ...makeIntentSnap("msg-3", 0.7).docs,
+        ],
+      });
+
+      const res = await app.request("/api/chat-messages?limit=2&offset=0");
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        data: Array<{ id: string }>;
+        pagination: { limit: number; offset: number; hasMore: boolean };
+      };
+      // 3件返ったので hasMore=true、data は先頭2件
+      expect(body.data).toHaveLength(2);
+      expect(body.pagination.hasMore).toBe(true);
+    });
   });
 
   describe("GET /api/chat-messages/inbox-counts", () => {

--- a/apps/api/src/routes/chat-messages.ts
+++ b/apps/api/src/routes/chat-messages.ts
@@ -56,6 +56,10 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
     return c.json({ error: "Forbidden" }, 403);
   }
 
+  // Intent 系フィルタ（別コレクション依存のため Firestore クエリ不可）
+  const hasIntentFilter =
+    category !== undefined || responseStatus !== undefined || maxConfidence !== undefined;
+
   let query = collections.chatMessages.orderBy("createdAt", "desc") as FirebaseFirestore.Query;
 
   if (spaceId) {
@@ -68,12 +72,26 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
     query = query.where("threadName", "==", threadName);
   }
 
-  const snapshot = await query
-    .limit(lim + 1)
-    .offset(off)
-    .get();
-  const hasMore = snapshot.docs.length > lim;
-  const docs = snapshot.docs.slice(0, lim);
+  // Intent フィルタあり: 全件取得 → post-filter → アプリ側ページング
+  // Intent フィルタなし: Firestore レベルでページング（従来どおり）
+  let docs: FirebaseFirestore.QueryDocumentSnapshot[];
+  let hasMore: boolean;
+
+  if (hasIntentFilter) {
+    // 上限キャップ（過大なクエリ防止）
+    const MAX_FETCH = 2000;
+    const snapshot = await query.limit(MAX_FETCH).get();
+    docs = snapshot.docs;
+    // hasMore は post-filter 後に再計算するのでここでは仮値
+    hasMore = false;
+  } else {
+    const snapshot = await query
+      .limit(lim + 1)
+      .offset(off)
+      .get();
+    hasMore = snapshot.docs.length > lim;
+    docs = snapshot.docs.slice(0, lim);
+  }
 
   // IntentRecord を一括取得（N+1 → バッチクエリ）
   // Firestore の "in" は最大30件。ページサイズが30超の場合はチャンク処理
@@ -163,6 +181,20 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
   });
 
   const filtered = items.filter(Boolean);
+
+  // Intent フィルタあり: フィルタ後のリストでページング
+  if (hasIntentFilter) {
+    const paged = filtered.slice(off, off + lim);
+    hasMore = off + lim < filtered.length;
+    return c.json({
+      data: paged,
+      pagination: {
+        limit: lim,
+        offset: off,
+        hasMore,
+      },
+    });
+  }
 
   return c.json({
     data: filtered,


### PR DESCRIPTION
## Summary
- Intent フィルタ（`category`, `responseStatus`, `maxConfidence`）使用時に offset/limit が Firestore レベルで適用されていたため、post-filter 後のページが疎になり `hasMore` も不正確だったバグを修正
- Intent フィルタあり → 全件取得（上限2000）→ post-filter → アプリ側ページネーション
- Intent フィルタなし → 従来の Firestore レベルページネーション（変更なし）

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm lint` — 全パッケージ通過（warnings のみ）
- [x] `pnpm test --run` — 76テスト全通過（フィルタ+ページネーション3件追加）

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)