### PR TITLE
fix(web): 承認ページのタイトルを「承認一覧」に修正

### DIFF
--- a/apps/web/src/app/(protected)/help/page.tsx
+++ b/apps/web/src/app/(protected)/help/page.tsx
@@ -384,7 +384,7 @@ export default function HelpPage() {
           </Section>
 
           {/* 04 承認 */}
-          <Section id="tasks" num="04" title="承認（タスク一覧）">
+          <Section id="tasks" num="04" title="承認（承認一覧）">
             <p className="text-sm mb-3 text-muted-foreground leading-relaxed">
               AI が生成した給与変更ドラフトの承認ワークフローを管理します。 ドラフト → レビュー済 →
               社長承認待ち → 承認済の流れで処理します。

--- a/apps/web/src/app/(protected)/tasks/page.tsx
+++ b/apps/web/src/app/(protected)/tasks/page.tsx
@@ -62,7 +62,7 @@ export default async function TasksPage({ searchParams }: Props) {
       <div className={cn("flex-1 overflow-y-auto p-6", selectedDraft && "hidden lg:block")}>
         <div className="space-y-6">
           <div className="flex items-center justify-between">
-            <h1 className="text-2xl font-bold">タスク一覧</h1>
+            <h1 className="text-2xl font-bold">承認一覧</h1>
             <p className="text-sm text-muted-foreground">全{total}件</p>
           </div>
 
@@ -113,7 +113,7 @@ export default async function TasksPage({ searchParams }: Props) {
                 {drafts.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={7} className="h-24 text-center text-muted-foreground">
-                      タスクがありません
+                      承認ドラフトがありません
                     </TableCell>
                   </TableRow>
                 ) : (


### PR DESCRIPTION
## Summary
- サイドバー「承認」とページタイトル「タスク一覧」の不整合を修正
- ページタイトル: 「タスク一覧」→「承認一覧」
- 空状態メッセージ: 「タスクがありません」→「承認ドラフトがありません」
- ヘルプページのセクションタイトルも同期

## Test plan
- [ ] `/tasks` ページでタイトルが「承認一覧」になっていることを確認
- [ ] データがない状態で「承認ドラフトがありません」と表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)