### PR TITLE
refactor(help): カテゴリ配列を CATEGORY_LABELS 定数に置換

### DIFF
--- a/apps/web/src/app/(protected)/help/page.tsx
+++ b/apps/web/src/app/(protected)/help/page.tsx
@@ -3,6 +3,7 @@
 import { BookOpen, CheckCircle2, List, Monitor, X } from "lucide-react";
 import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
+import { CATEGORY_LABELS } from "@/lib/constants";
 import { permissionData, tocItems, useActiveSection } from "./help-data";
 
 /* ─────────────────────────── Atoms ─────────────────────────── */
@@ -469,18 +470,7 @@ export default function HelpPage() {
               正規表現によるプレ分類と LLM による高精度分類の2段階で処理されます。
             </p>
             <div className="grid grid-cols-2 sm:grid-cols-5 gap-2 my-4">
-              {[
-                "給与・社保",
-                "退職・休職",
-                "入社・採用",
-                "契約変更",
-                "施設・異動",
-                "外国人・ビザ",
-                "研修・監査",
-                "健康診断",
-                "勤怠・休暇",
-                "その他",
-              ].map((cat) => (
+              {Object.values(CATEGORY_LABELS).map((cat) => (
                 <span
                   key={cat}
                   className="text-xs text-center px-2 py-1.5 rounded-md border border-border/60 bg-card text-muted-foreground"


### PR DESCRIPTION
## Summary
- ヘルプページにハードコードされていた10カテゴリ文字列配列を `CATEGORY_LABELS` 定数（`lib/constants.ts`）から取得するように変更
- `/simplify` + `/safe-refactor` 品質ゲート通過済み

## Test plan
- [x] `pnpm typecheck` — 通過
- [x] `pnpm lint` — 通過（既存 warnings のみ）
- [x] 表示内容に変更なし（同一の10カテゴリラベルを参照）

🤖 Generated with [Claude Code](https://claude.com/claude-code)