### PR TITLE
fix(web): デスクトップヘルプページのサイドバーTOCがスクロール追随するよう修正

### DIFF
--- a/apps/web/src/app/(protected)/help/layout.tsx
+++ b/apps/web/src/app/(protected)/help/layout.tsx
@@ -1,9 +1,15 @@
 import type { Metadata } from "next";
+import { HelpOverflowFix } from "./overflow-fix";
 
 export const metadata: Metadata = {
   title: "操作マニュアル | HR-AI Agent",
 };
 
 export default function HelpLayout({ children }: { children: React.ReactNode }) {
-  return <>{children}</>;
+  return (
+    <>
+      <HelpOverflowFix />
+      {children}
+    </>
+  );
 }

--- a/apps/web/src/app/(protected)/help/overflow-fix.tsx
+++ b/apps/web/src/app/(protected)/help/overflow-fix.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { useEffect } from "react";
+
+/**
+ * ヘルプページ専用: 親レイアウトの overflow 制約を一時的に解除し、
+ * サイドバーの position:sticky を有効にする。
+ *
+ * 対象:
+ * - <main overflow-y-auto> → overflow:visible（スクロールコンテナ解除）
+ * - <div overflow-hidden>（main の親）→ overflow:visible（sticky コンテキスト解除）
+ * アンマウント時に元に戻す。
+ */
+export function HelpOverflowFix() {
+  useEffect(() => {
+    const main = document.querySelector("main");
+    if (!main) return;
+    const flexRow = main.parentElement;
+
+    main.style.overflow = "visible";
+    if (flexRow) flexRow.style.overflow = "visible";
+
+    return () => {
+      main.style.overflow = "";
+      if (flexRow) flexRow.style.overflow = "";
+    };
+  }, []);
+  return null;
+}


### PR DESCRIPTION
## Summary
- 共有レイアウトの `overflow-y-auto` / `overflow-hidden` が `position:sticky` を無効化していた問題を修正
- ヘルプページ専用の `HelpOverflowFix` クライアントコンポーネントで親要素の overflow を一時的に `visible` に上書き
- アンマウント時に自動復元するため、他ページへの影響なし（受信箱ページで確認済み）

## Test plan
- [x] `pnpm typecheck` 通過
- [x] Playwright でスクロール位置 1200px / 5000px のスクリーンショット確認 — サイドバーTOC が追随し、アクティブセクションがハイライト
- [x] 受信箱ページで通常レイアウトに影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)