### PR TITLE
fix(api): 認証境界の強化 + 給与ドラフト状態遷移のトランザクション保護

### DIFF
--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -111,6 +111,64 @@ describe("authMiddleware", () => {
 
     expect(res.status).toBe(401);
   });
+
+  it("許可されたサービスアカウント → 200 (dashboardRole: null)", async () => {
+    vi.stubEnv("ALLOWED_SERVICE_ACCOUNTS", "scheduler@hr-system-487809.iam.gserviceaccount.com");
+    mockVerifyIdToken.mockResolvedValue({
+      getPayload: () => ({
+        email: "scheduler@hr-system-487809.iam.gserviceaccount.com",
+        sub: "sa-sub",
+      }),
+    });
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer sa-token" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: { email: string; dashboardRole: null } };
+    expect(body.user.email).toBe("scheduler@hr-system-487809.iam.gserviceaccount.com");
+    expect(body.user.dashboardRole).toBeNull();
+
+    vi.unstubAllEnvs();
+  });
+
+  it("未許可のサービスアカウント → 403", async () => {
+    vi.stubEnv("ALLOWED_SERVICE_ACCOUNTS", "scheduler@hr-system-487809.iam.gserviceaccount.com");
+    mockVerifyIdToken.mockResolvedValue({
+      getPayload: () => ({
+        email: "attacker@evil-project.iam.gserviceaccount.com",
+        sub: "evil-sub",
+      }),
+    });
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer evil-sa-token" },
+    });
+
+    expect(res.status).toBe(403);
+
+    vi.unstubAllEnvs();
+  });
+
+  it("ALLOWED_SERVICE_ACCOUNTS 未設定 → SA は全拒否 (403)", async () => {
+    // 環境変数を設定しない（デフォルト）
+    mockVerifyIdToken.mockResolvedValue({
+      getPayload: () => ({
+        email: "any@project.iam.gserviceaccount.com",
+        sub: "sa-sub",
+      }),
+    });
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer sa-token" },
+    });
+
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("rbacMiddleware", () => {

--- a/apps/api/src/__tests__/salary-drafts.test.ts
+++ b/apps/api/src/__tests__/salary-drafts.test.ts
@@ -21,6 +21,9 @@ vi.mock("google-auth-library", () => {
 // Firestore モック
 const mockDraftGet = vi.fn();
 const mockDraftUpdate = vi.fn();
+const mockTxGet = vi.fn();
+const mockTxUpdate = vi.fn();
+const mockTxSet = vi.fn();
 const mockBatchUpdate = vi.fn();
 const mockBatchSet = vi.fn();
 const mockBatchCommit = vi.fn();
@@ -36,6 +39,13 @@ vi.mock("@hr-system/db", () => {
         set: mockBatchSet,
         commit: mockBatchCommit,
       })),
+      runTransaction: vi.fn(async (fn: (tx: unknown) => Promise<unknown>) => {
+        return fn({
+          get: mockTxGet,
+          update: mockTxUpdate,
+          set: mockTxSet,
+        });
+      }),
     },
     collections: {
       salaryDrafts: {
@@ -233,16 +243,19 @@ describe("POST /api/salary-drafts/:id/transition", () => {
     vi.clearAllMocks();
     vi.stubEnv("CEO_EMAIL", "ceo@aozora-cg.com");
     vi.stubEnv("HR_MANAGER_EMAILS", "manager@aozora-cg.com");
-    mockBatchCommit.mockResolvedValue(undefined);
     stubAsHrManager();
   });
   afterEach(() => vi.unstubAllEnvs());
 
   it("draft → reviewed: hr_manager が遷移できる (200)", async () => {
     const reviewedDraft = makeDraft({ status: "reviewed" });
-    mockDraftGet
-      .mockResolvedValueOnce({ exists: true, data: () => makeDraft(), id: "draft-001" })
-      .mockResolvedValueOnce({ exists: true, data: () => reviewedDraft, id: "draft-001" });
+    // tx.get → トランザクション内読み取り、mockDraftGet → トランザクション後読み取り
+    mockTxGet.mockResolvedValueOnce({ exists: true, data: () => makeDraft(), id: "draft-001" });
+    mockDraftGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => reviewedDraft,
+      id: "draft-001",
+    });
 
     const res = await app.request("/api/salary-drafts/draft-001/transition", {
       method: "POST",
@@ -253,18 +266,22 @@ describe("POST /api/salary-drafts/:id/transition", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as { status: string };
     expect(body.status).toBe("reviewed");
-    expect(mockBatchCommit).toHaveBeenCalledOnce();
+    expect(mockTxUpdate).toHaveBeenCalledOnce();
+    expect(mockTxSet).toHaveBeenCalledTimes(2); // approvalLog + auditLog
   });
 
   it("reviewed → approved: 機械的変更 + hr_manager (200)", async () => {
     const approvedDraft = makeDraft({ status: "approved", changeType: "mechanical" });
-    mockDraftGet
-      .mockResolvedValueOnce({
-        exists: true,
-        data: () => makeDraft({ status: "reviewed", changeType: "mechanical" }),
-        id: "draft-001",
-      })
-      .mockResolvedValueOnce({ exists: true, data: () => approvedDraft, id: "draft-001" });
+    mockTxGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => makeDraft({ status: "reviewed", changeType: "mechanical" }),
+      id: "draft-001",
+    });
+    mockDraftGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => approvedDraft,
+      id: "draft-001",
+    });
 
     const res = await app.request("/api/salary-drafts/draft-001/transition", {
       method: "POST",
@@ -278,7 +295,7 @@ describe("POST /api/salary-drafts/:id/transition", () => {
   });
 
   it("reviewed → approved: 裁量的変更 + hr_manager → 409 (変更タイプ制約違反)", async () => {
-    mockDraftGet.mockResolvedValue({
+    mockTxGet.mockResolvedValue({
       exists: true,
       data: () => makeDraft({ status: "reviewed", changeType: "discretionary" }),
       id: "draft-001",
@@ -299,13 +316,16 @@ describe("POST /api/salary-drafts/:id/transition", () => {
     stubAsCeo(); // CEO に切り替え
 
     const approvedDraft = makeDraft({ status: "approved", changeType: "discretionary" });
-    mockDraftGet
-      .mockResolvedValueOnce({
-        exists: true,
-        data: () => makeDraft({ status: "pending_ceo_approval", changeType: "discretionary" }),
-        id: "draft-001",
-      })
-      .mockResolvedValueOnce({ exists: true, data: () => approvedDraft, id: "draft-001" });
+    mockTxGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => makeDraft({ status: "pending_ceo_approval", changeType: "discretionary" }),
+      id: "draft-001",
+    });
+    mockDraftGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => approvedDraft,
+      id: "draft-001",
+    });
 
     const res = await app.request("/api/salary-drafts/draft-001/transition", {
       method: "POST",
@@ -317,7 +337,7 @@ describe("POST /api/salary-drafts/:id/transition", () => {
   });
 
   it("pending_ceo_approval → approved: hr_manager は承認不可 → 409", async () => {
-    mockDraftGet.mockResolvedValue({
+    mockTxGet.mockResolvedValue({
       exists: true,
       data: () => makeDraft({ status: "pending_ceo_approval", changeType: "discretionary" }),
       id: "draft-001",
@@ -333,7 +353,7 @@ describe("POST /api/salary-drafts/:id/transition", () => {
   });
 
   it("completed → reviewed: 遷移不可 → 409", async () => {
-    mockDraftGet.mockResolvedValue({
+    mockTxGet.mockResolvedValue({
       exists: true,
       data: () => makeDraft({ status: "completed" }),
       id: "draft-001",
@@ -364,16 +384,18 @@ describe("PATCH /api/salary-drafts/:id", () => {
     vi.clearAllMocks();
     vi.stubEnv("CEO_EMAIL", "ceo@aozora-cg.com");
     vi.stubEnv("HR_MANAGER_EMAILS", "manager@aozora-cg.com");
-    mockBatchCommit.mockResolvedValue(undefined);
     stubAsHrManager();
   });
   afterEach(() => vi.unstubAllEnvs());
 
   it("draft ステータス: hr_manager が修正できる (200)", async () => {
     const updatedDraft = makeDraft({ reason: "昇給（修正）" });
-    mockDraftGet
-      .mockResolvedValueOnce({ exists: true, data: () => makeDraft(), id: "draft-001" })
-      .mockResolvedValueOnce({ exists: true, data: () => updatedDraft, id: "draft-001" });
+    mockTxGet.mockResolvedValueOnce({ exists: true, data: () => makeDraft(), id: "draft-001" });
+    mockDraftGet.mockResolvedValueOnce({
+      exists: true,
+      data: () => updatedDraft,
+      id: "draft-001",
+    });
 
     const res = await app.request("/api/salary-drafts/draft-001", {
       method: "PATCH",
@@ -382,7 +404,8 @@ describe("PATCH /api/salary-drafts/:id", () => {
     });
 
     expect(res.status).toBe(200);
-    expect(mockBatchCommit).toHaveBeenCalledOnce();
+    expect(mockTxUpdate).toHaveBeenCalledOnce();
+    expect(mockTxSet).toHaveBeenCalledOnce(); // auditLog
   });
 
   it("CEO は修正不可 → 403", async () => {
@@ -398,7 +421,7 @@ describe("PATCH /api/salary-drafts/:id", () => {
   });
 
   it("approved ステータス: 修正不可 → 409", async () => {
-    mockDraftGet.mockResolvedValue({
+    mockTxGet.mockResolvedValue({
       exists: true,
       data: () => makeDraft({ status: "approved" }),
       id: "draft-001",

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -58,12 +58,22 @@ export const authMiddleware = createMiddleware(async (c, next) => {
   }
 
   try {
-    const ticket = await client.verifyIdToken({ idToken: token });
+    // audience: Web の OAuth Client ID を指定し、他アプリ向けトークンを拒否
+    const audience = process.env.GOOGLE_CLIENT_ID;
+    const ticket = await client.verifyIdToken({
+      idToken: token,
+      ...(audience ? { audience } : {}),
+    });
     const payload = ticket.getPayload();
     if (!payload?.email) throw new Error("No email in token");
 
-    // サービスアカウント（Cloud Scheduler 等）は allowed_users チェックをスキップ
+    // サービスアカウント: ホワイトリストで明示的に許可されたSAのみ通過
     if (payload.email.endsWith(".iam.gserviceaccount.com")) {
+      const allowedSAs = (process.env.ALLOWED_SERVICE_ACCOUNTS ?? "").split(",").filter(Boolean);
+      if (allowedSAs.length === 0 || !allowedSAs.includes(payload.email)) {
+        logger.warn("Unauthorized service account", { email: payload.email });
+        throw new HTTPException(403, { message: "Service account not allowed" });
+      }
       logger.info("Service account authenticated", { email: payload.email });
       c.set("user", {
         email: payload.email,

--- a/apps/api/src/routes/salary-drafts.ts
+++ b/apps/api/src/routes/salary-drafts.ts
@@ -179,52 +179,53 @@ app.patch("/:id", zValidator("json", patchDraftSchema), async (c) => {
     forbidden("CEOはドラフトを直接修正できません");
   }
 
-  const draftRef = collections.salaryDrafts.doc(id);
-  const draftSnap = await draftRef.get();
-  if (!draftSnap.exists) notFound("SalaryDraft", id);
-
-  const draft = draftSnap.data() as SalaryDraft;
-  if (draft.status !== "draft" && draft.status !== "reviewed") {
-    throw new AppError(
-      "INVALID_STATUS_TRANSITION",
-      "draft または reviewed のステータスのみ修正できます",
-      409,
-      { current_status: draft.status },
-    );
-  }
-
   const body = c.req.valid("json");
+  const draftRef = collections.salaryDrafts.doc(id);
 
-  // 更新データ構築（金額フィールドは明細との整合性のため PATCH 不可）
-  const updateData: Record<string, unknown> = {
-    updatedAt: FieldValue.serverTimestamp(),
-  };
-  if (body.reason !== undefined) updateData.reason = body.reason;
-  if (body.effectiveDate !== undefined) {
-    updateData.effectiveDate = Timestamp.fromDate(new Date(`${body.effectiveDate}T00:00:00Z`));
-  }
+  // トランザクションで read→validate→write を一括実行
+  await db.runTransaction(async (tx) => {
+    const draftSnap = await tx.get(draftRef);
+    if (!draftSnap.exists) notFound("SalaryDraft", id);
 
-  // 変更前フィールドを記録
-  const modifiedFields: Record<string, unknown> = {};
-  for (const key of Object.keys(body) as (keyof typeof body)[]) {
-    const before = draft[key as keyof typeof draft];
-    const after = body[key];
-    if (before !== undefined) modifiedFields[key] = { before, after };
-  }
+    const draft = draftSnap.data() as SalaryDraft;
+    if (draft.status !== "draft" && draft.status !== "reviewed") {
+      throw new AppError(
+        "INVALID_STATUS_TRANSITION",
+        "draft または reviewed のステータスのみ修正できます",
+        409,
+        { current_status: draft.status },
+      );
+    }
 
-  // バッチ書き込み（ドラフト更新 + 監査ログ）
-  const batch = db.batch();
-  batch.update(draftRef, updateData);
-  batch.set(collections.auditLogs.doc(), {
-    eventType: "draft_modified" as AuditEventType,
-    entityType: "SalaryDraft",
-    entityId: id,
-    actorEmail: user.email,
-    actorRole,
-    details: { modifiedFields },
-    createdAt: FieldValue.serverTimestamp(),
+    // 更新データ構築（金額フィールドは明細との整合性のため PATCH 不可）
+    const updateData: Record<string, unknown> = {
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+    if (body.reason !== undefined) updateData.reason = body.reason;
+    if (body.effectiveDate !== undefined) {
+      updateData.effectiveDate = Timestamp.fromDate(new Date(`${body.effectiveDate}T00:00:00Z`));
+    }
+
+    // 変更前フィールドを記録
+    const modifiedFields: Record<string, unknown> = {};
+    for (const key of Object.keys(body) as (keyof typeof body)[]) {
+      const before = draft[key as keyof typeof draft];
+      const after = body[key];
+      if (before !== undefined) modifiedFields[key] = { before, after };
+    }
+
+    // トランザクション内で書き込み（ドラフト更新 + 監査ログ）
+    tx.update(draftRef, updateData);
+    tx.set(collections.auditLogs.doc(), {
+      eventType: "draft_modified" as AuditEventType,
+      entityType: "SalaryDraft",
+      entityId: id,
+      actorEmail: user.email,
+      actorRole,
+      details: { modifiedFields },
+      createdAt: FieldValue.serverTimestamp(),
+    });
   });
-  await batch.commit();
 
   // 更新後のドラフトを返却
   const updatedSnap = await draftRef.get();
@@ -247,64 +248,68 @@ app.post("/:id/transition", zValidator("json", transitionSchema), async (c) => {
   }
 
   const draftRef = collections.salaryDrafts.doc(id);
-  const draftSnap = await draftRef.get();
-  if (!draftSnap.exists) notFound("SalaryDraft", id);
 
-  const draft = draftSnap.data() as SalaryDraft;
-  const fromStatus = draft.status;
+  // トランザクションで read→validate→write を一括実行（同時操作による後勝ち更新を防止）
+  const transactionResult = await db.runTransaction(async (tx) => {
+    const draftSnap = await tx.get(draftRef);
+    if (!draftSnap.exists) notFound("SalaryDraft", id);
 
-  // 遷移バリデーション（状態 + ロール + 変更タイプをチェック）
-  const result = validateTransition(fromStatus, toStatus, actorRole, draft.changeType);
-  if (!result.valid) {
-    const allowed = getNextActions(fromStatus, actorRole, draft.changeType);
-    invalidTransition(fromStatus, toStatus, allowed);
-  }
+    const draft = draftSnap.data() as SalaryDraft;
+    const fromStatus = draft.status;
 
-  // ドラフト更新データ
-  const draftUpdate: Record<string, unknown> = {
-    status: toStatus,
-    updatedAt: FieldValue.serverTimestamp(),
-  };
-  if (toStatus === "reviewed") {
-    draftUpdate.reviewedBy = user.email;
-    draftUpdate.reviewedAt = FieldValue.serverTimestamp();
-  } else if (toStatus === "approved") {
-    draftUpdate.approvedBy = user.email;
-    draftUpdate.approvedAt = FieldValue.serverTimestamp();
-  }
+    // 遷移バリデーション（状態 + ロール + 変更タイプをチェック）
+    const result = validateTransition(fromStatus, toStatus, actorRole, draft.changeType);
+    if (!result.valid) {
+      const allowed = getNextActions(fromStatus, actorRole, draft.changeType);
+      invalidTransition(fromStatus, toStatus, allowed);
+    }
 
-  // 承認ログ
-  const approvalLogData = {
-    draftId: id,
-    action: toApprovalAction(toStatus) as ApprovalAction,
-    fromStatus,
-    toStatus,
-    actorEmail: user.email,
-    actorRole,
-    comment: comment ?? null,
-    modifiedFields: null,
-    createdAt: FieldValue.serverTimestamp(),
-  };
+    // ドラフト更新データ
+    const draftUpdate: Record<string, unknown> = {
+      status: toStatus,
+      updatedAt: FieldValue.serverTimestamp(),
+    };
+    if (toStatus === "reviewed") {
+      draftUpdate.reviewedBy = user.email;
+      draftUpdate.reviewedAt = FieldValue.serverTimestamp();
+    } else if (toStatus === "approved") {
+      draftUpdate.approvedBy = user.email;
+      draftUpdate.approvedAt = FieldValue.serverTimestamp();
+    }
 
-  // 監査ログ
-  const auditLogData = {
-    eventType: "status_changed" as AuditEventType,
-    entityType: "SalaryDraft",
-    entityId: id,
-    actorEmail: user.email,
-    actorRole,
-    details: { fromStatus, toStatus, comment: comment ?? null },
-    createdAt: FieldValue.serverTimestamp(),
-  };
+    // 承認ログ
+    const approvalLogData = {
+      draftId: id,
+      action: toApprovalAction(toStatus) as ApprovalAction,
+      fromStatus,
+      toStatus,
+      actorEmail: user.email,
+      actorRole,
+      comment: comment ?? null,
+      modifiedFields: null,
+      createdAt: FieldValue.serverTimestamp(),
+    };
 
-  // バッチ書き込み（ドラフト更新 + 承認ログ + 監査ログ）
-  const batch = db.batch();
-  batch.update(draftRef, draftUpdate);
-  batch.set(collections.approvalLogs.doc(), approvalLogData);
-  batch.set(collections.auditLogs.doc(), auditLogData);
-  await batch.commit();
+    // 監査ログ
+    const auditLogData = {
+      eventType: "status_changed" as AuditEventType,
+      entityType: "SalaryDraft",
+      entityId: id,
+      actorEmail: user.email,
+      actorRole,
+      details: { fromStatus, toStatus, comment: comment ?? null },
+      createdAt: FieldValue.serverTimestamp(),
+    };
 
-  // 更新後のドラフトと次アクション一覧を返却
+    // トランザクション内で書き込み（ドラフト更新 + 承認ログ + 監査ログ）
+    tx.update(draftRef, draftUpdate);
+    tx.set(collections.approvalLogs.doc(), approvalLogData);
+    tx.set(collections.auditLogs.doc(), auditLogData);
+
+    return { fromStatus, changeType: draft.changeType };
+  });
+
+  // トランザクション成功後、更新済みドラフトを取得して返却
   const updatedSnap = await draftRef.get();
   const updated = updatedSnap.data() as SalaryDraft;
   const nextActions = actorRole ? getNextActions(toStatus, actorRole, updated.changeType) : [];


### PR DESCRIPTION
## Summary
- `verifyIdToken` に `audience` (GOOGLE_CLIENT_ID) を追加し、他アプリ向けトークンでのAPI認証を拒否 (#196)
- サービスアカウント認証をドメインチェックから `ALLOWED_SERVICE_ACCOUNTS` ホワイトリストに変更 (#196)
- salary-drafts の `transition` / `patch` ハンドラを `db.runTransaction()` で保護し、同時操作による後勝ち更新・重複ApprovalLogを防止 (#197)

## 必要な環境変数（Cloud Run）
| 変数名 | 説明 | 例 |
|--------|------|----|
| `GOOGLE_CLIENT_ID` | Web OAuth Client ID（audience検証用） | `1234...apps.googleusercontent.com` |
| `ALLOWED_SERVICE_ACCOUNTS` | 許可するSAメールのカンマ区切り | `scheduler@hr-system-487809.iam.gserviceaccount.com` |

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm test --run` — 397テスト全通過（SA認証テスト3件追加）
- [ ] Cloud Run デプロイ後、環境変数を設定して動作確認

Closes #196, Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)