### PR TITLE
fix(api): 認証・権限のハードニング追加修正

### DIFF
--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -85,6 +85,43 @@ describe("authMiddleware", () => {
     expect(body.user.sub).toBe("12345");
   });
 
+  it("GOOGLE_CLIENT_ID 設定時 → verifyIdToken に audience が渡される", async () => {
+    vi.stubEnv("GOOGLE_CLIENT_ID", "my-client-id.apps.googleusercontent.com");
+    mockVerifyIdToken.mockResolvedValue({
+      getPayload: () => ({
+        email: "staff@aozora-cg.com",
+        name: "Staff",
+        sub: "sub-1",
+      }),
+    });
+
+    const app = createTestApp();
+    await app.request("/test", {
+      headers: { Authorization: "Bearer valid-token" },
+    });
+
+    expect(mockVerifyIdToken).toHaveBeenCalledWith({
+      idToken: "valid-token",
+      audience: "my-client-id.apps.googleusercontent.com",
+    });
+
+    vi.unstubAllEnvs();
+  });
+
+  it("本番環境で GOOGLE_CLIENT_ID 未設定 → 500 (フェイルクローズ)", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    // GOOGLE_CLIENT_ID は設定しない
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer valid-token" },
+    });
+
+    expect(res.status).toBe(500);
+
+    vi.unstubAllEnvs();
+  });
+
   it("Authorization ヘッダーなし → 401", async () => {
     const app = createTestApp();
     const res = await app.request("/test");
@@ -168,6 +205,51 @@ describe("authMiddleware", () => {
     });
 
     expect(res.status).toBe(403);
+  });
+
+  it("複数SAホワイトリスト → 2番目のSAも許可される", async () => {
+    vi.stubEnv(
+      "ALLOWED_SERVICE_ACCOUNTS",
+      "sa1@project.iam.gserviceaccount.com,sa2@project.iam.gserviceaccount.com",
+    );
+    mockVerifyIdToken.mockResolvedValue({
+      getPayload: () => ({
+        email: "sa2@project.iam.gserviceaccount.com",
+        sub: "sa2-sub",
+      }),
+    });
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer sa2-token" },
+    });
+
+    expect(res.status).toBe(200);
+
+    vi.unstubAllEnvs();
+  });
+
+  it("許可されたSA → actorRole は null（業務操作不可）", async () => {
+    vi.stubEnv("ALLOWED_SERVICE_ACCOUNTS", "scheduler@project.iam.gserviceaccount.com");
+    vi.stubEnv("CEO_EMAIL", "ceo@test.com");
+    vi.stubEnv("HR_MANAGER_EMAILS", "");
+    mockVerifyIdToken.mockResolvedValue({
+      getPayload: () => ({
+        email: "scheduler@project.iam.gserviceaccount.com",
+        sub: "sa-sub",
+      }),
+    });
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer sa-token" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { actorRole: string | null };
+    expect(body.actorRole).toBeNull();
+
+    vi.unstubAllEnvs();
   });
 });
 

--- a/apps/api/src/__tests__/chat-sync-routes.test.ts
+++ b/apps/api/src/__tests__/chat-sync-routes.test.ts
@@ -44,16 +44,18 @@ vi.mock("@hr-system/db", () => ({
   },
 }));
 
-// 認証ミドルウェアのモック（admin ユーザーをセット）
+// 認証ミドルウェアのモック（デフォルト: admin ユーザー。テスト内で上書き可能）
+let mockAuthUser = {
+  email: "admin@test.com",
+  name: "Admin",
+  sub: "sub-1",
+  dashboardRole: "admin" as string | null,
+};
+
 vi.mock("../middleware/auth.js", () => ({
   authMiddleware: vi.fn(
     async (c: { set: (key: string, value: unknown) => void }, next: () => Promise<void>) => {
-      c.set("user", {
-        email: "admin@test.com",
-        name: "Admin",
-        sub: "sub-1",
-        dashboardRole: "admin",
-      });
+      c.set("user", mockAuthUser);
       await next();
     },
   ),
@@ -74,6 +76,13 @@ import { app } from "../app.js";
 describe("chat-sync routes", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // デフォルト: admin ユーザーに戻す
+    mockAuthUser = {
+      email: "admin@test.com",
+      name: "Admin",
+      sub: "sub-1",
+      dashboardRole: "admin",
+    };
     // syncChatMessages 内の getSyncMetadata() / chatMessages.doc().get() 等のデフォルト
     mockGet.mockResolvedValue({ exists: false });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
@@ -237,6 +246,47 @@ describe("chat-sync routes", () => {
       const body = (await res.json()) as { status: string; lastResult: { newMessages: number } };
       expect(body.status).toBe("idle");
       expect(body.lastResult.newMessages).toBe(5);
+    });
+  });
+
+  describe("権限チェック", () => {
+    it("hr_staff は POST /sync を実行できない → 403", async () => {
+      mockAuthUser = {
+        email: "staff@test.com",
+        name: "Staff",
+        sub: "sub-staff",
+        dashboardRole: "hr_staff",
+      };
+
+      const res = await app.request("/api/chat-messages/sync", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(403);
+    });
+
+    it("サービスアカウント（dashboardRole: null, name: system）は POST /sync を実行できる", async () => {
+      mockAuthUser = {
+        email: "scheduler@project.iam.gserviceaccount.com",
+        name: "system",
+        sub: "sa-sub",
+        dashboardRole: null,
+      };
+
+      // acquireSyncLock
+      mockRunTransaction.mockImplementationOnce(async (fn: (tx: unknown) => Promise<boolean>) => {
+        const tx = {
+          get: vi.fn().mockResolvedValue({ exists: false }),
+          set: vi.fn(),
+        };
+        return fn(tx);
+      });
+
+      const res = await app.request("/api/chat-messages/sync", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
     });
   });
 });

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -59,7 +59,12 @@ export const authMiddleware = createMiddleware(async (c, next) => {
 
   try {
     // audience: Web の OAuth Client ID を指定し、他アプリ向けトークンを拒否
+    // 本番環境では必須（フェイルクローズ）。開発環境では未設定時に audience 検証をスキップ
     const audience = process.env.GOOGLE_CLIENT_ID;
+    if (!audience && process.env.NODE_ENV === "production") {
+      logger.error("GOOGLE_CLIENT_ID is not configured in production");
+      throw new HTTPException(500, { message: "Server misconfiguration" });
+    }
     const ticket = await client.verifyIdToken({
       idToken: token,
       ...(audience ? { audience } : {}),

--- a/apps/api/src/middleware/rbac.ts
+++ b/apps/api/src/middleware/rbac.ts
@@ -17,6 +17,9 @@ export const rbacMiddleware = createMiddleware(async (c, next) => {
   // viewer ロールには業務操作権限を付与しない
   if (user.dashboardRole === "viewer") {
     c.set("actorRole", null);
+  } else if (user.dashboardRole === null && user.name === "system") {
+    // サービスアカウント: 業務操作権限を付与しない（chat-sync 等は独自の権限チェックで許可）
+    c.set("actorRole", null);
   } else {
     c.set("actorRole", resolveRole(user.email));
   }

--- a/apps/api/src/routes/chat-sync.ts
+++ b/apps/api/src/routes/chat-sync.ts
@@ -12,11 +12,15 @@ import {
 
 export const chatSyncRoutes = new Hono();
 
-// 同期操作は viewer を除外（admin / hr_staff / hr_manager / ceo は許可、サービスアカウントは dashboardRole: null で通過）
+// 同期操作の権限チェック:
+// - GET: 全ロール許可
+// - POST/PUT/DELETE: admin + 許可済みサービスアカウントのみ
 chatSyncRoutes.use("*", async (c, next) => {
   if (c.req.method !== "GET") {
-    const { dashboardRole } = c.get("user");
-    if (dashboardRole === "viewer") {
+    const user = c.get("user");
+    const isServiceAccount = user.dashboardRole === null && user.name === "system";
+    const isAdmin = user.dashboardRole === "admin";
+    if (!isServiceAccount && !isAdmin) {
       throw new HTTPException(403, { message: "Admin access required" });
     }
   }

--- a/apps/api/src/routes/salary-drafts.ts
+++ b/apps/api/src/routes/salary-drafts.ts
@@ -250,7 +250,7 @@ app.post("/:id/transition", zValidator("json", transitionSchema), async (c) => {
   const draftRef = collections.salaryDrafts.doc(id);
 
   // トランザクションで read→validate→write を一括実行（同時操作による後勝ち更新を防止）
-  const transactionResult = await db.runTransaction(async (tx) => {
+  await db.runTransaction(async (tx) => {
     const draftSnap = await tx.get(draftRef);
     if (!draftSnap.exists) notFound("SalaryDraft", id);
 
@@ -305,8 +305,6 @@ app.post("/:id/transition", zValidator("json", transitionSchema), async (c) => {
     tx.update(draftRef, draftUpdate);
     tx.set(collections.approvalLogs.doc(), approvalLogData);
     tx.set(collections.auditLogs.doc(), auditLogData);
-
-    return { fromStatus, changeType: draft.changeType };
   });
 
   // トランザクション成功後、更新済みドラフトを取得して返却


### PR DESCRIPTION
## Summary
- PR #203 のレビュー・テスト不足を補完するハードニング修正
- 本番環境での `GOOGLE_CLIENT_ID` 未設定時にフェイルクローズ（500）を返すよう変更
- SA（サービスアカウント）の `actorRole` を `null` に制限し、`hr_staff` 権限の意図しない付与を防止
- chat-sync の POST/PATCH/DELETE を admin + SA のみに権限制限（hr_staff/hr_manager は不可に）
- テスト6件追加（audience 検証、フェイルクローズ、複数SA、SA actorRole null、chat-sync 権限2件）

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm test --run` — 全テスト通過（auth 15件、chat-sync-routes 含む計124件）
- [x] audience パラメータが `verifyIdToken` に渡されることを検証
- [x] 本番 `GOOGLE_CLIENT_ID` 未設定 → 500 を検証
- [x] 複数 SA ホワイトリストの2番目も許可されることを検証
- [x] SA の actorRole が null であることを検証
- [x] hr_staff が chat-sync POST → 403 を検証
- [x] SA が chat-sync POST → 200 を検証

Closes #196
Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)