### PR TITLE
fix(worker): replyCount が常に 0 or 1 になるバグを修正

### DIFF
--- a/apps/worker/src/__tests__/process-message.test.ts
+++ b/apps/worker/src/__tests__/process-message.test.ts
@@ -49,16 +49,23 @@ const mockRunTransaction = vi.fn();
 
 // クエリ用の get モック（スレッドコンテキスト取得で使用）
 const mockChatMessagesQueryGet = vi.fn();
+const mockChatMessagesCountGet = vi.fn();
 const mockIntentRecordsQueryGet = vi.fn();
 
 vi.mock("@hr-system/db", () => {
-  // chatMessages のクエリチェーン: .where().orderBy().limit().get()
-  // vi.fn().mockReturnThis() は vi.mock ファクトリ内では this が未定義になるため
-  // 明示的なチェーンオブジェクトを使用する
+  // chatMessages のクエリチェーン:
+  //   .where().orderBy().limit(1).get()  → 親メッセージ取得
+  //   .where().orderBy().count().get()   → スレッド内メッセージ数
+  const limitChain: Record<string, unknown> = {};
+  limitChain.get = mockChatMessagesQueryGet;
+
+  const countChain: Record<string, unknown> = {};
+  countChain.get = mockChatMessagesCountGet;
+
   const chatMsgsChain: Record<string, unknown> = {};
   chatMsgsChain.orderBy = vi.fn(() => chatMsgsChain);
-  chatMsgsChain.limit = vi.fn(() => chatMsgsChain);
-  chatMsgsChain.get = mockChatMessagesQueryGet;
+  chatMsgsChain.limit = vi.fn(() => limitChain);
+  chatMsgsChain.count = vi.fn(() => countChain);
 
   // intentRecords のクエリチェーン: .where().limit().get()
   const intentChain: Record<string, unknown> = {};
@@ -157,6 +164,7 @@ describe("processMessage", () => {
     );
     // デフォルト: スレッドコンテキストなし（空のクエリ結果）
     mockChatMessagesQueryGet.mockResolvedValue(makeQuerySnapshot([]));
+    mockChatMessagesCountGet.mockResolvedValue({ data: () => ({ count: 0 }) });
     mockIntentRecordsQueryGet.mockResolvedValue(makeQuerySnapshot([]));
   });
 
@@ -260,19 +268,17 @@ describe("processMessage", () => {
       const THREAD_NAME = "spaces/AAAA-qf5jX0/threads/thread-001";
       const PARENT_DOC_ID = "parent-chat-msg-001";
 
-      // 親メッセージのクエリ結果
+      // 親メッセージのクエリ結果（limit(1) で親のみ）
       mockChatMessagesQueryGet.mockResolvedValue(
         makeQuerySnapshot([
           makeDocSnapshot(PARENT_DOC_ID, {
             content: "田中さんの給与変更をお願いします",
             threadName: THREAD_NAME,
           }),
-          makeDocSnapshot("chat-msg-001", {
-            content: "承知しました",
-            threadName: THREAD_NAME,
-          }),
         ]),
       );
+      // スレッド内メッセージ数: 親 + 返信1件 = 2
+      mockChatMessagesCountGet.mockResolvedValue({ data: () => ({ count: 2 }) });
 
       // 親の IntentRecord
       mockIntentRecordsQueryGet.mockResolvedValue(
@@ -329,6 +335,53 @@ describe("processMessage", () => {
       );
     });
 
+    it("スレッド返信: 返信が5件ある場合、replyCount が正確に 5 を返す", async () => {
+      const THREAD_NAME = "spaces/AAAA-qf5jX0/threads/thread-many";
+      const PARENT_DOC_ID = "parent-chat-msg-many";
+
+      // 親メッセージのクエリ結果（limit(1) で親のみ）
+      mockChatMessagesQueryGet.mockResolvedValue(
+        makeQuerySnapshot([
+          makeDocSnapshot(PARENT_DOC_ID, {
+            content: "全員の給与を見直してください",
+            threadName: THREAD_NAME,
+          }),
+        ]),
+      );
+      // スレッド内メッセージ数: 親 + 返信5件 = 6
+      mockChatMessagesCountGet.mockResolvedValue({ data: () => ({ count: 6 }) });
+
+      // 親の IntentRecord
+      mockIntentRecordsQueryGet.mockResolvedValue(
+        makeQuerySnapshot([
+          makeDocSnapshot("intent-parent-many", {
+            chatMessageId: PARENT_DOC_ID,
+            category: "salary",
+            confidenceScore: 0.9,
+          }),
+        ]),
+      );
+
+      await processMessage(
+        makeEvent({
+          threadName: THREAD_NAME,
+          messageType: "THREAD_REPLY",
+          text: "6件目の返信です",
+        }),
+      );
+
+      expect(mockClassifyIntent).toHaveBeenCalledWith(
+        "6件目の返信です",
+        expect.objectContaining({
+          parentCategory: "salary",
+          parentConfidence: 0.9,
+          parentSnippet: "全員の給与を見直してください",
+          replyCount: 5,
+        }),
+        expect.any(Object),
+      );
+    });
+
     it("スレッド返信: 親 IntentRecord が存在しない場合、デフォルト値（category: other, confidence: 0）を使用", async () => {
       const THREAD_NAME = "spaces/AAAA-qf5jX0/threads/thread-003";
       const PARENT_DOC_ID = "parent-chat-msg-003";
@@ -342,6 +395,8 @@ describe("processMessage", () => {
           }),
         ]),
       );
+      // スレッド内メッセージ数: 親のみ = 1
+      mockChatMessagesCountGet.mockResolvedValue({ data: () => ({ count: 1 }) });
       mockIntentRecordsQueryGet.mockResolvedValue(makeQuerySnapshot([]));
 
       await processMessage(

--- a/apps/worker/src/pipeline/process-message.ts
+++ b/apps/worker/src/pipeline/process-message.ts
@@ -156,17 +156,20 @@ async function getThreadContext(
   threadName: string,
   currentMessageId: string,
 ): Promise<ThreadContext | undefined> {
-  // スレッド内の全メッセージを createdAt 昇順で取得（先頭が親）
-  const snapshot = await collections.chatMessages
+  // スレッド内の親メッセージを取得（createdAt 昇順の先頭）
+  const threadQuery = collections.chatMessages
     .where("threadName", "==", threadName)
-    .orderBy("createdAt", "asc")
-    .limit(2)
-    .get();
+    .orderBy("createdAt", "asc");
 
-  if (snapshot.empty) return undefined;
+  const [parentSnapshot, countSnapshot] = await Promise.all([
+    threadQuery.limit(1).get(),
+    threadQuery.count().get(),
+  ]);
+
+  if (parentSnapshot.empty) return undefined;
 
   // 先頭メッセージが親（現在処理中のメッセージと同一の場合は親なし）
-  const parentDoc = snapshot.docs[0];
+  const parentDoc = parentSnapshot.docs[0];
   if (!parentDoc || parentDoc.id === currentMessageId) return undefined;
 
   const parentData = parentDoc.data();
@@ -179,8 +182,9 @@ async function getThreadContext(
 
   const parentIntent = intentSnapshot.empty ? null : intentSnapshot.docs[0]?.data();
 
-  // スレッドの返信数（親を除く）
-  const replyCount = snapshot.size > 1 ? snapshot.size - 1 : 0;
+  // スレッドの返信数（親を除く）— count() で正確な値を取得
+  const totalInThread = countSnapshot.data().count;
+  const replyCount = Math.max(0, totalInThread - 1);
 
   return {
     parentCategory: parentIntent?.category ?? "other",


### PR DESCRIPTION
## Summary
- `.limit(2)` により `snapshot.size - 1` が常に 0 or 1 になっていたバグを修正
- Firestore `count()` 集約クエリで正確なスレッド返信数を取得するよう変更
- 親メッセージ取得（`limit(1)`）と `count()` を `Promise.all` で並列実行しパフォーマンス維持

## Test plan
- [x] `pnpm --filter @hr-system/worker test` — 全142テスト通過
- [x] `pnpm --filter @hr-system/worker typecheck` — 通過
- [x] 返信1件: replyCount = 1 を検証（既存テスト更新）
- [x] **返信5件: replyCount = 5 を検証**（新規テスト追加 — バグ再現ケース）
- [x] 親のみ: replyCount = 0 を検証（既存テスト更新）

Closes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)