### PR TITLE
fix: 現行給与の重複データ未検出で誤ったドラフトが生成されるリスクを修正

### DIFF
--- a/apps/worker/src/__tests__/salary-handler.test.ts
+++ b/apps/worker/src/__tests__/salary-handler.test.ts
@@ -159,7 +159,7 @@ function setupFirestoreMocks() {
     ],
   });
   mockSalariesWhere.mockReturnValue({
-    where: vi.fn().mockReturnValue({ limit: vi.fn().mockReturnValue({ get: mockSalaryGet }) }),
+    where: vi.fn().mockReturnValue({ get: mockSalaryGet }),
   });
 
   // pitchTables
@@ -578,6 +578,48 @@ describe("handleSalary", () => {
 
       await expect(handleSalary("chat-001", makeEvent(), makeIntentResult())).rejects.toThrow(
         expect.objectContaining({ code: "DB_ERROR", shouldNack: true }),
+      );
+    });
+
+    it("現行給与が重複(effectiveTo=null が2件以上)している場合は WorkerError(SALARY_CALC_ERROR)", async () => {
+      mockExtractSalaryParams.mockResolvedValue({
+        employeeIdentifier: "E001",
+        changeType: "mechanical",
+        targetSalary: 260000,
+        allowanceType: null,
+        reasoning: "2ピッチアップ",
+      });
+
+      // salaries: effectiveTo=null が2件
+      const mockDuplicateSalaryGet = vi.fn().mockResolvedValue({
+        empty: false,
+        docs: [
+          {
+            id: "salary-001",
+            data: () => ({
+              employeeId: "emp-001",
+              baseSalary: 247000,
+              totalSalary: 267000,
+              effectiveTo: null,
+            }),
+          },
+          {
+            id: "salary-002",
+            data: () => ({
+              employeeId: "emp-001",
+              baseSalary: 260000,
+              totalSalary: 280000,
+              effectiveTo: null,
+            }),
+          },
+        ],
+      });
+      mockSalariesWhere.mockReturnValue({
+        where: vi.fn().mockReturnValue({ get: mockDuplicateSalaryGet }),
+      });
+
+      await expect(handleSalary("chat-001", makeEvent(), makeIntentResult())).rejects.toThrow(
+        expect.objectContaining({ code: "SALARY_CALC_ERROR", shouldNack: false }),
       );
     });
   });

--- a/apps/worker/src/pipeline/salary-handler.ts
+++ b/apps/worker/src/pipeline/salary-handler.ts
@@ -344,17 +344,21 @@ async function getCurrentSalary(employeeId: string): Promise<{ id: string } & Sa
   const snap = await collections.salaries
     .where("employeeId", "==", employeeId)
     .where("effectiveTo", "==", null)
-    .limit(1)
     .get();
 
   if (snap.empty) {
     throw new WorkerError("SALARY_CALC_ERROR", "現行給与が見つかりません", false);
   }
 
-  const doc = snap.docs.at(0);
-  if (!doc) {
-    throw new WorkerError("SALARY_CALC_ERROR", "現行給与が見つかりません", false);
+  if (snap.docs.length > 1) {
+    throw new WorkerError(
+      "SALARY_CALC_ERROR",
+      `現行給与が${snap.docs.length}件存在します（effectiveTo=null が重複）。データを修正してください`,
+      false,
+    );
   }
+
+  const doc = snap.docs[0]!;
   return { id: doc.id, ...doc.data() };
 }
 


### PR DESCRIPTION
## Summary
- `getCurrentSalary()` が `limit(1)` で取得していたため、`effectiveTo=null` が重複しているデータ異常時にサイレントに1件目を使用していた問題を修正
- `effectiveTo=null` が2件以上存在する場合は `WorkerError(SALARY_CALC_ERROR)` で処理を停止するように変更
- 重複検出のテストケースを追加

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm test --run` — 全143テスト通過（重複検出テスト1件追加）

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)