### PR TITLE
feat(web): タスクボードに詳細パネルを追加（ページ遷移なし）

### DIFF
--- a/apps/web/src/__tests__/task-board.test.tsx
+++ b/apps/web/src/__tests__/task-board.test.tsx
@@ -1,0 +1,366 @@
+/**
+ * タスクボード テスト
+ *
+ * TaskList / TaskDetailPanel コンポーネントの表示・操作を検証
+ * - renderToStaticMarkup + HTMLタグ除去パターン（inbox-3pane.test.tsx 準拠）
+ */
+import React from "react";
+import ReactDOMServer from "react-dom/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// --- モック設定 ---
+
+const mockReplace = vi.fn();
+const mockSearchParams = new URLSearchParams();
+
+vi.mock("@/lib/constants", () => ({
+  RESPONSE_STATUS_DOT_COLORS: {
+    unresponded: "bg-red-500",
+    in_progress: "bg-yellow-500",
+    responded: "bg-green-500",
+    not_required: "bg-gray-400",
+  },
+  RESPONSE_STATUS_LABELS: {
+    unresponded: "未対応",
+    in_progress: "対応中",
+    responded: "対応済",
+    not_required: "対応不要",
+  },
+}));
+
+vi.mock("@/lib/utils", () => ({
+  cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
+  formatDateTimeJST: (d: string) => new Date(d).toLocaleString("ja-JP"),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({
+    children,
+    href,
+    ...props
+  }: { children: React.ReactNode; href: string } & Record<string, unknown>) =>
+    React.createElement("a", { href, ...props }, children),
+}));
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: mockReplace }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+vi.mock("lucide-react", () => ({
+  MessageSquareText: () => React.createElement("span", { "data-testid": "icon-gchat" }),
+  MessageCircle: () => React.createElement("span", { "data-testid": "icon-line" }),
+  ArrowLeft: () => React.createElement("span", { "data-testid": "icon-arrow-left" }),
+  ArrowUpRight: () => React.createElement("span", { "data-testid": "icon-arrow-up-right" }),
+  Calendar: () => React.createElement("span", { "data-testid": "icon-calendar" }),
+  X: () => React.createElement("span", { "data-testid": "icon-x" }),
+  User: () => React.createElement("span", { "data-testid": "icon-user" }),
+  Users: () => React.createElement("span", { "data-testid": "icon-users" }),
+}));
+
+vi.mock("@/components/task-priority-selector", () => ({
+  TaskPriorityDot: ({ priority }: Record<string, unknown>) =>
+    priority
+      ? React.createElement("span", {
+          "data-testid": "task-priority-dot",
+          "data-priority": priority,
+        })
+      : null,
+}));
+
+// --- インポート ---
+
+import type { TaskItem } from "../app/(protected)/task-board/task-list";
+
+const { TaskList } = await import("../app/(protected)/task-board/task-list");
+const { TaskDetailPanel } = await import("../app/(protected)/task-board/task-detail-panel");
+
+// --- ヘルパー ---
+
+function renderToText(element: React.ReactElement): string {
+  const html = ReactDOMServer.renderToStaticMarkup(element);
+  return html.replace(/<[^>]*>/g, "");
+}
+
+function renderToHtml(element: React.ReactElement): string {
+  return ReactDOMServer.renderToStaticMarkup(element);
+}
+
+function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
+  return {
+    id: "msg-1",
+    source: "gchat",
+    senderName: "田中太郎",
+    content: "給与変更をお願いします",
+    taskPriority: "medium",
+    responseStatus: "unresponded",
+    taskSummary: null,
+    assignees: null,
+    groupName: null,
+    createdAt: "2026-03-01T09:00:00Z",
+    ...overrides,
+  };
+}
+
+// --- テスト ---
+
+describe("TaskList", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+  });
+
+  it("タスクが0件の場合「タスクはありません」が表示される", () => {
+    const text = renderToText(React.createElement(TaskList, { tasks: [], selectedId: null }));
+    expect(text).toContain("タスクはありません");
+  });
+
+  it("タスク一覧が正しく描画される（senderName, content）", () => {
+    const text = renderToText(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ senderName: "田中太郎", content: "給与変更をお願いします" })],
+        selectedId: null,
+      }),
+    );
+    expect(text).toContain("田中太郎");
+    expect(text).toContain("給与変更をお願いします");
+  });
+
+  it("優先度ドットが表示される", () => {
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ taskPriority: "high" })],
+        selectedId: null,
+      }),
+    );
+    expect(html).toContain('data-testid="task-priority-dot"');
+    expect(html).toContain('data-priority="high"');
+  });
+
+  it("gchat ソースの場合に Google Chat アイコンが表示される", () => {
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ source: "gchat" })],
+        selectedId: null,
+      }),
+    );
+    expect(html).toContain('data-testid="icon-gchat"');
+  });
+
+  it("LINE ソースの場合に LINE アイコンが表示される", () => {
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ source: "line" })],
+        selectedId: null,
+      }),
+    );
+    expect(html).toContain('data-testid="icon-line"');
+  });
+
+  it("タスクをクリックすると router.replace が正しい URL で呼ばれる", () => {
+    // selectTask は source-id を URL パラメータに設定する
+    // selectedId でハイライト検証することで、source-id 形式が正しいことを間接的に検証
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ id: "msg-42", source: "gchat" })],
+        selectedId: "gchat-msg-42",
+      }),
+    );
+    // ボタンが存在すること
+    expect(html).toContain("button");
+    // selectedId が gchat-msg-42 でマッチし、bg-accent が適用されること
+    expect(html).toContain("bg-accent");
+  });
+
+  it("selectedId に一致するタスクがハイライトされる", () => {
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ id: "msg-1", source: "gchat", taskPriority: "medium" })],
+        selectedId: "gchat-msg-1",
+      }),
+    );
+    expect(html).toContain("bg-accent");
+  });
+
+  it("critical タスクに赤い border-l が表示される", () => {
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ taskPriority: "critical" })],
+        selectedId: null,
+      }),
+    );
+    expect(html).toContain("border-l-4");
+    expect(html).toContain("border-l-red-500");
+  });
+
+  it("LINE タスクにグループ名が表示される", () => {
+    const text = renderToText(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ source: "line", groupName: "有川チーム" })],
+        selectedId: null,
+      }),
+    );
+    expect(text).toContain("有川チーム");
+  });
+
+  it("taskSummary がある場合は content の代わりに表示される", () => {
+    const text = renderToText(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ taskSummary: "給与テーブル更新依頼", content: "元のメッセージ" })],
+        selectedId: null,
+      }),
+    );
+    expect(text).toContain("給与テーブル更新依頼");
+    expect(text).not.toContain("元のメッセージ");
+  });
+
+  it("担当者がある場合に表示される", () => {
+    const text = renderToText(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ assignees: "佐藤花子" })],
+        selectedId: null,
+      }),
+    );
+    expect(text).toContain("担当: 佐藤花子");
+  });
+
+  it("対応状況ラベルが表示される", () => {
+    const text = renderToText(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ responseStatus: "in_progress" })],
+        selectedId: null,
+      }),
+    );
+    expect(text).toContain("対応中");
+  });
+});
+
+describe("TaskDetailPanel", () => {
+  beforeEach(() => {
+    mockReplace.mockClear();
+  });
+
+  it("タスク詳細が正しく表示される（priority badge, status, sender, source）", () => {
+    const task = makeTask({
+      taskPriority: "high",
+      responseStatus: "unresponded",
+      senderName: "田中太郎",
+      source: "gchat",
+    });
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).toContain("高");
+    expect(text).toContain("未対応");
+    expect(text).toContain("田中太郎");
+    expect(text).toContain("Google Chat");
+  });
+
+  it("タスク概要がある場合は表示される", () => {
+    const task = makeTask({ taskSummary: "給与テーブル更新依頼" });
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).toContain("タスク概要");
+    expect(text).toContain("給与テーブル更新依頼");
+  });
+
+  it("タスク概要がない場合は概要セクションが表示されない", () => {
+    const task = makeTask({ taskSummary: null });
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).not.toContain("タスク概要");
+  });
+
+  it("メッセージ本文が表示される", () => {
+    const task = makeTask({ content: "給与変更をお願いします" });
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).toContain("メッセージ");
+    expect(text).toContain("給与変更をお願いします");
+  });
+
+  it("gchat タスクの「受信箱で開く」リンクが /inbox?id=xxx を持つ", () => {
+    const task = makeTask({ id: "msg-42", source: "gchat" });
+    const html = renderToHtml(React.createElement(TaskDetailPanel, { task }));
+
+    expect(html).toContain('href="/inbox?id=msg-42"');
+  });
+
+  it("LINE タスクの「受信箱で開く」リンクが /inbox?source=line&id=xxx を持つ", () => {
+    const task = makeTask({ id: "msg-99", source: "line" });
+    const html = renderToHtml(React.createElement(TaskDetailPanel, { task }));
+
+    expect(html).toContain('href="/inbox?source=line&amp;id=msg-99"');
+  });
+
+  it("閉じるボタンが存在する", () => {
+    const task = makeTask();
+    const html = renderToHtml(React.createElement(TaskDetailPanel, { task }));
+
+    // モバイル戻るボタン + デスクトップ閉じるボタン
+    expect(html).toContain('data-testid="icon-arrow-left"');
+    expect(html).toContain('data-testid="icon-x"');
+  });
+
+  it("担当者がある場合は表示される", () => {
+    const task = makeTask({ assignees: "佐藤花子, 鈴木一郎" });
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).toContain("担当者");
+    expect(text).toContain("佐藤花子, 鈴木一郎");
+  });
+
+  it("担当者がない場合は担当者行が表示されない", () => {
+    const task = makeTask({ assignees: null });
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).not.toContain("担当者");
+  });
+
+  it("グループ名がある場合は表示される", () => {
+    const task = makeTask({ groupName: "有川チーム" });
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).toContain("グループ");
+    expect(text).toContain("有川チーム");
+  });
+
+  it("グループ名がない場合はグループ行が表示されない", () => {
+    const task = makeTask({ groupName: null });
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).not.toContain("グループ");
+  });
+
+  it("LINE ソースの場合に LINE と表示される", () => {
+    const task = makeTask({ source: "line" });
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).toContain("LINE");
+  });
+
+  it("critical タスクのヘッダーに赤い背景が適用される", () => {
+    const task = makeTask({ taskPriority: "critical" });
+    const html = renderToHtml(React.createElement(TaskDetailPanel, { task }));
+
+    expect(html).toContain("bg-red-50/80");
+  });
+
+  it("優先度バッジの色が正しい（critical: red, high: orange, medium: sky, low: slate）", () => {
+    for (const [priority, colorFragment] of [
+      ["critical", "bg-red-100"],
+      ["high", "bg-orange-50"],
+      ["medium", "bg-sky-50"],
+      ["low", "bg-slate-50"],
+    ] as const) {
+      const task = makeTask({ taskPriority: priority });
+      const html = renderToHtml(React.createElement(TaskDetailPanel, { task }));
+      expect(html).toContain(colorFragment);
+    }
+  });
+
+  it("受信箱リンクのテキストが正しい", () => {
+    const task = makeTask();
+    const text = renderToText(React.createElement(TaskDetailPanel, { task }));
+
+    expect(text).toContain("受信箱で開く");
+  });
+});

--- a/apps/web/src/app/(protected)/inbox/use-select-message.ts
+++ b/apps/web/src/app/(protected)/inbox/use-select-message.ts
@@ -1,22 +1,7 @@
 "use client";
 
-import { useRouter, useSearchParams } from "next/navigation";
-import { useCallback } from "react";
+import { useUrlSelection } from "@/hooks/use-url-selection";
 
 export function useSelectMessage() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-
-  return useCallback(
-    (id: string | null) => {
-      const sp = new URLSearchParams(searchParams.toString());
-      if (id) {
-        sp.set("id", id);
-      } else {
-        sp.delete("id");
-      }
-      router.replace(`/inbox?${sp.toString()}`, { scroll: false });
-    },
-    [router, searchParams],
-  );
+  return useUrlSelection("/inbox");
 }

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -1,8 +1,10 @@
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import Link from "next/link";
 import { getChatMessages, getLineMessages } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { TaskDetailPanel } from "./task-detail-panel";
 import type { TaskItem } from "./task-list";
-import { TaskList } from "./task-list";
+import { TaskList, taskCompositeId } from "./task-list";
 
 type Source = "all" | "gchat" | "line";
 
@@ -39,6 +41,7 @@ interface Props {
     priority?: string;
     source?: string;
     status?: string;
+    id?: string;
   }>;
 }
 
@@ -47,6 +50,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
   const priorityFilter = (params.priority as TaskPriority | undefined) ?? undefined;
   const sourceFilter: Source = (params.source as Source) ?? "all";
   const statusFilter = (params.status as ResponseStatus | undefined) ?? undefined;
+  const selectedId = params.id ?? null;
 
   // 両ソースを並列取得
   const [chatResult, lineResult] = await Promise.all([
@@ -112,6 +116,11 @@ export default async function TaskBoardPage({ searchParams }: Props) {
 
   const criticalCount = filtered.filter((t) => t.taskPriority === "critical").length;
 
+  // 選択されたタスクを検索
+  const selectedTask = selectedId
+    ? (filtered.find((t) => taskCompositeId(t) === selectedId) ?? null)
+    : null;
+
   function buildUrl(overrides: { priority?: string; source?: string; status?: string }) {
     const sp = new URLSearchParams();
     const p = "priority" in overrides ? overrides.priority : params.priority;
@@ -120,14 +129,21 @@ export default async function TaskBoardPage({ searchParams }: Props) {
     if (p && p !== "all") sp.set("priority", p);
     if (src && src !== "all") sp.set("source", src);
     if (s && s !== "all") sp.set("status", s);
+    // フィルター切替時は選択を維持
+    if (params.id) sp.set("id", params.id);
     const qs = sp.toString();
     return `/task-board${qs ? `?${qs}` : ""}`;
   }
 
   return (
     <div className="-m-6 flex h-[calc(100vh-52px)] flex-col">
-      {/* ヘッダー */}
-      <div className="flex-shrink-0 border-b border-border/60 bg-white px-5 py-3">
+      {/* ヘッダー（選択中はモバイルで非表示） */}
+      <div
+        className={cn(
+          "flex-shrink-0 border-b border-border/60 bg-white px-5 py-3",
+          selectedTask && "hidden lg:block",
+        )}
+      >
         <div className="mb-2 flex items-center justify-between">
           <h1 className="text-lg font-bold tracking-tight">タスク</h1>
           <span className="text-xs text-muted-foreground">
@@ -195,9 +211,23 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         </div>
       </div>
 
-      {/* タスク一覧 */}
-      <div className="flex-1 overflow-y-auto">
-        <TaskList tasks={filtered} />
+      {/* メインエリア: リスト + 詳細パネル */}
+      <div className="flex flex-1 overflow-hidden">
+        {/* 左: タスク一覧 (選択中はモバイルで非表示) */}
+        <div className={cn("flex-1 overflow-y-auto", selectedTask && "hidden lg:block")}>
+          <TaskList tasks={filtered} selectedId={selectedTask ? selectedId : null} />
+        </div>
+
+        {/* 右: 詳細パネル */}
+        {selectedTask ? (
+          <div className="w-full lg:w-[420px] flex-shrink-0 overflow-hidden">
+            <TaskDetailPanel task={selectedTask} />
+          </div>
+        ) : (
+          <div className="hidden w-[420px] flex-shrink-0 items-center justify-center border-l border-border/60 bg-muted/10 lg:flex">
+            <p className="text-sm text-muted-foreground">タスクを選択してください</p>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/app/(protected)/task-board/task-detail-panel.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-detail-panel.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import type { TaskPriority } from "@hr-system/shared";
+import {
+  ArrowLeft,
+  ArrowUpRight,
+  Calendar,
+  MessageCircle,
+  MessageSquareText,
+  User,
+  Users,
+  X,
+} from "lucide-react";
+import Link from "next/link";
+import { TaskPriorityDot } from "@/components/task-priority-selector";
+import { useUrlSelection } from "@/hooks/use-url-selection";
+import { RESPONSE_STATUS_DOT_COLORS, RESPONSE_STATUS_LABELS } from "@/lib/constants";
+import { cn, formatDateTimeJST } from "@/lib/utils";
+import type { TaskItem } from "./task-list";
+
+const PRIORITY_LABELS: Record<TaskPriority, string> = {
+  critical: "極高",
+  high: "高",
+  medium: "中",
+  low: "低",
+};
+
+const PRIORITY_COLORS: Record<TaskPriority, string> = {
+  critical: "bg-red-100 text-red-800 border-red-200",
+  high: "bg-orange-50 text-orange-700 border-orange-200",
+  medium: "bg-sky-50 text-sky-700 border-sky-200",
+  low: "bg-slate-50 text-slate-600 border-slate-200",
+};
+
+export function TaskDetailPanel({ task }: { task: TaskItem }) {
+  const select = useUrlSelection("/task-board");
+  const close = () => select(null);
+
+  const inboxUrl =
+    task.source === "gchat" ? `/inbox?id=${task.id}` : `/inbox?source=line&id=${task.id}`;
+
+  const isCritical = task.taskPriority === "critical";
+
+  return (
+    <div className="flex h-full flex-col border-l border-border/60 bg-white">
+      {/* ヘッダー */}
+      <div
+        className={cn(
+          "flex items-center justify-between border-b px-4 py-3",
+          isCritical ? "border-red-200 bg-red-50/80" : "border-border/60",
+        )}
+      >
+        <div className="flex items-center gap-2">
+          {/* モバイル: 戻るボタン */}
+          <button
+            type="button"
+            onClick={close}
+            className="rounded p-1 text-muted-foreground hover:bg-accent lg:hidden"
+          >
+            <ArrowLeft className="h-4 w-4" />
+          </button>
+          <h2 className="text-sm font-bold">タスク詳細</h2>
+        </div>
+        <div className="flex items-center gap-1">
+          <Link
+            href={inboxUrl}
+            className="rounded p-1.5 text-muted-foreground hover:bg-accent"
+            title="受信箱で開く"
+          >
+            <ArrowUpRight className="h-4 w-4" />
+          </Link>
+          {/* デスクトップ: 閉じるボタン */}
+          <button
+            type="button"
+            onClick={close}
+            className="hidden rounded p-1.5 text-muted-foreground hover:bg-accent lg:block"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* コンテンツ */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-4">
+        {/* 優先度 & ステータス */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <span
+            className={cn(
+              "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-semibold",
+              PRIORITY_COLORS[task.taskPriority],
+            )}
+          >
+            <TaskPriorityDot priority={task.taskPriority} />
+            {PRIORITY_LABELS[task.taskPriority]}
+          </span>
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-border/60 bg-white px-2.5 py-1 text-xs font-medium text-muted-foreground">
+            <span
+              className={cn(
+                "h-2 w-2 rounded-full",
+                RESPONSE_STATUS_DOT_COLORS[task.responseStatus],
+              )}
+            />
+            {RESPONSE_STATUS_LABELS[task.responseStatus]}
+          </span>
+        </div>
+
+        {/* タスク概要 */}
+        {task.taskSummary && (
+          <section className="space-y-1.5">
+            <h3 className="text-xs font-semibold text-muted-foreground">タスク概要</h3>
+            <p className="text-sm leading-relaxed">{task.taskSummary}</p>
+          </section>
+        )}
+
+        {/* メッセージ本文 */}
+        <section className="space-y-1.5">
+          <h3 className="text-xs font-semibold text-muted-foreground">メッセージ</h3>
+          <div className="rounded-lg bg-muted/50 p-3.5 text-sm leading-relaxed">{task.content}</div>
+        </section>
+
+        {/* 情報 */}
+        <section className="space-y-1.5">
+          <h3 className="text-xs font-semibold text-muted-foreground">情報</h3>
+          <div className="rounded-lg border border-border/60 p-3 space-y-2.5 text-xs">
+            {/* 送信者 */}
+            <div className="flex items-center gap-2">
+              <User className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-muted-foreground">送信者</span>
+              <span className="ml-auto font-medium">{task.senderName}</span>
+            </div>
+
+            {/* ソース */}
+            <div className="flex items-center gap-2">
+              {task.source === "gchat" ? (
+                <MessageSquareText className="h-3.5 w-3.5 text-muted-foreground" />
+              ) : (
+                <MessageCircle className="h-3.5 w-3.5 text-emerald-500" />
+              )}
+              <span className="text-muted-foreground">ソース</span>
+              <span className="ml-auto font-medium">
+                {task.source === "gchat" ? "Google Chat" : "LINE"}
+              </span>
+            </div>
+
+            {/* グループ名 */}
+            {task.groupName && (
+              <div className="flex items-center gap-2">
+                <Users className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-muted-foreground">グループ</span>
+                <span className="ml-auto font-medium">{task.groupName}</span>
+              </div>
+            )}
+
+            {/* 担当者 */}
+            {task.assignees && (
+              <div className="flex items-center gap-2">
+                <Users className="h-3.5 w-3.5 text-muted-foreground" />
+                <span className="text-muted-foreground">担当者</span>
+                <span className="ml-auto font-medium">{task.assignees}</span>
+              </div>
+            )}
+
+            {/* 日時 */}
+            <div className="flex items-center gap-2">
+              <Calendar className="h-3.5 w-3.5 text-muted-foreground" />
+              <span className="text-muted-foreground">受信日時</span>
+              <span className="ml-auto font-medium tabular-nums">
+                {formatDateTimeJST(task.createdAt)}
+              </span>
+            </div>
+          </div>
+        </section>
+
+        {/* 受信箱で開くボタン */}
+        <Link
+          href={inboxUrl}
+          className="flex w-full items-center justify-center gap-2 rounded-lg border border-border/60 bg-white px-4 py-2.5 text-xs font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+        >
+          <ArrowUpRight className="h-3.5 w-3.5" />
+          受信箱で開く（対応状況変更・スレッド表示）
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -2,9 +2,9 @@
 
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { MessageCircle, MessageSquareText } from "lucide-react";
-import Link from "next/link";
 import { TaskPriorityDot } from "@/components/task-priority-selector";
-import { RESPONSE_STATUS_DOT_COLORS } from "@/lib/constants";
+import { useUrlSelection } from "@/hooks/use-url-selection";
+import { RESPONSE_STATUS_DOT_COLORS, RESPONSE_STATUS_LABELS } from "@/lib/constants";
 import { cn, formatDateTimeJST } from "@/lib/utils";
 
 export interface TaskItem {
@@ -20,14 +20,13 @@ export interface TaskItem {
   createdAt: string;
 }
 
-const RESPONSE_STATUS_LABELS: Record<ResponseStatus, string> = {
-  unresponded: "未対応",
-  in_progress: "対応中",
-  responded: "対応済",
-  not_required: "対応不要",
-};
+export function taskCompositeId(task: Pick<TaskItem, "source" | "id">): string {
+  return `${task.source}-${task.id}`;
+}
 
-export function TaskList({ tasks }: { tasks: TaskItem[] }) {
+export function TaskList({ tasks, selectedId }: { tasks: TaskItem[]; selectedId: string | null }) {
+  const selectTask = useUrlSelection("/task-board");
+
   if (tasks.length === 0) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -40,16 +39,19 @@ export function TaskList({ tasks }: { tasks: TaskItem[] }) {
     <div className="divide-y divide-border/40">
       {tasks.map((task) => {
         const isCritical = task.taskPriority === "critical";
-        const inboxUrl =
-          task.source === "gchat" ? `/inbox?id=${task.id}` : `/inbox?source=line&id=${task.id}`;
+        const compositeId = taskCompositeId(task);
+        const isSelected = compositeId === selectedId;
 
         return (
-          <Link
-            key={`${task.source}-${task.id}`}
-            href={inboxUrl}
+          <button
+            key={compositeId}
+            type="button"
+            onClick={() => selectTask(compositeId)}
             className={cn(
-              "block px-5 py-3 transition-colors hover:bg-accent/50",
+              "block w-full text-left px-5 py-3 transition-colors hover:bg-accent/50",
               isCritical && "border-l-4 border-l-red-500 bg-red-50/50 hover:bg-red-50",
+              isSelected && !isCritical && "bg-accent",
+              isSelected && isCritical && "bg-red-100/70",
             )}
           >
             <div className="flex items-center gap-2">
@@ -98,7 +100,7 @@ export function TaskList({ tasks }: { tasks: TaskItem[] }) {
             {task.assignees && (
               <p className="mt-1 text-xs text-muted-foreground">担当: {task.assignees}</p>
             )}
-          </Link>
+          </button>
         );
       })}
     </div>

--- a/apps/web/src/hooks/use-url-selection.ts
+++ b/apps/web/src/hooks/use-url-selection.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback } from "react";
+
+/**
+ * URL クエリパラメータ `id` による選択状態管理フック。
+ * task-board / inbox 等で共通利用。
+ */
+export function useUrlSelection(basePath: string) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const select = useCallback(
+    (id: string | null) => {
+      const sp = new URLSearchParams(searchParams.toString());
+      if (id) {
+        sp.set("id", id);
+      } else {
+        sp.delete("id");
+      }
+      router.replace(`${basePath}?${sp.toString()}`, { scroll: false });
+    },
+    [router, searchParams, basePath],
+  );
+
+  return select;
+}

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,6 +1,12 @@
+import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "src"),
+    },
+  },
   esbuild: {
     jsx: "automatic",
   },


### PR DESCRIPTION
## Summary
- タスククリック時にページ遷移せず右側パネルに詳細表示（デスクトップ: `lg+`）
- モバイルはリスト非表示 + 全幅で詳細表示、戻るボタン付き
- URL `?id=source-id` で選択状態を管理（ブックマーク・リロード対応）

## 主な変更
- `task-detail-panel.tsx` 新設: 優先度バッジ・対応状況・メッセージ本文・送信者情報・「受信箱で開く」ボタン
- `useUrlSelection(basePath)` フックを `src/hooks/` に新設し inbox/task-board で共通化
- `taskCompositeId()` ヘルパーで `gchat-xxx`/`line-xxx` 複合キー生成を一元管理
- `RESPONSE_STATUS_LABELS` の重複定義を削除し `@/lib/constants` からインポートに統一
- `PRIORITY_LABELS/COLORS` の型を `Record<TaskPriority, string>` に修正
- 絵文字 📅 → lucide `Calendar` アイコンに置換
- `vitest.config.ts` に `@/*` パスエイリアス追加

## Test plan
- [x] `pnpm typecheck` — 全パッケージ通過
- [x] `pnpm lint` — 全パッケージ通過（既存 warnings のみ）
- [x] `pnpm test --run` — 165テスト通過（task-board.test.tsx 27件含む）
- [ ] ブラウザ動作確認（デスクトップ: 詳細パネル表示、モバイル: 全幅表示）

Closes #210（関連）

🤖 Generated with [Claude Code](https://claude.com/claude-code)