### PR TITLE
fix(web): サイドメニューのスクロール追随修正

### DIFF
--- a/apps/web/src/__tests__/sidebar-nav.test.tsx
+++ b/apps/web/src/__tests__/sidebar-nav.test.tsx
@@ -14,7 +14,9 @@ vi.mock("@/lib/utils", () => ({
 vi.mock("next/link", () => ({ default: "a" }));
 vi.mock("next/navigation", () => ({ usePathname: () => "/" }));
 
-import { isNavActive, navItems } from "../components/sidebar-nav";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { isNavActive, navItems, SidebarNav } from "../components/sidebar-nav";
 
 describe("sidebar-nav 構造", () => {
   it("ナビゲーション項目が5つであること", () => {
@@ -56,6 +58,20 @@ describe("sidebar-nav 構造", () => {
       expect(item.shortLabel).toBeDefined();
       expect(item.shortLabel.length).toBeLessThanOrEqual(3);
     }
+  });
+});
+
+describe("SidebarNav レンダリング", () => {
+  it("nav 要素に sticky と高さ制約のクラスが含まれる", () => {
+    const html = renderToStaticMarkup(React.createElement(SidebarNav));
+    expect(html).toContain("sticky");
+    expect(html).toContain("top-13");
+    expect(html).toContain("h-[calc(100vh-3.25rem)]");
+  });
+
+  it("nav 要素に幅 w-[60px] が設定されている", () => {
+    const html = renderToStaticMarkup(React.createElement(SidebarNav));
+    expect(html).toContain("w-[60px]");
   });
 });
 

--- a/apps/web/src/components/sidebar-nav.tsx
+++ b/apps/web/src/components/sidebar-nav.tsx
@@ -30,7 +30,7 @@ export function SidebarNav() {
   const pathname = usePathname();
 
   return (
-    <nav className="relative flex w-[60px] flex-col items-center border-r border-border/50 bg-card">
+    <nav className="sticky top-13 flex h-[calc(100vh-3.25rem)] w-[60px] flex-col items-center border-r border-border/50 bg-card">
       {/* メインナビ（上部） */}
       <div className="flex flex-1 flex-col items-center gap-1 pt-4">
         {navItems.slice(0, 4).map((item) => (


### PR DESCRIPTION
## Summary
- ヘルプページ等でスクロール時にサイドメニューが画面外に流れるバグを修正
- `sidebar-nav.tsx` の `<nav>` に `sticky top-13 h-[calc(100vh-3.25rem)]` を追加
- 通常ページでは `overflow-hidden` 親により no-op（副作用なし）

## Root Cause
`HelpOverflowFix` が親の `overflow-hidden` / main の `overflow-y-auto` を解除 → ウィンドウレベルスクロールに移行 → サイドバーに `sticky` がないため一緒にスクロール

## Test plan
- [x] `pnpm typecheck` — 11パッケージ通過
- [x] `pnpm lint` — エラー0件
- [x] `pnpm build` — 全パッケージビルド成功
- [x] `pnpm test` — 172テスト通過（sticky クラス検証テスト2件追加）
- [ ] デプロイ後、ヘルプページでスクロール時にサイドメニューが固定されることを確認

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)