### PR TITLE
fix(web): Chat 同期操作の権限を admin に限定

### DIFF
--- a/apps/web/src/__tests__/access-control.test.ts
+++ b/apps/web/src/__tests__/access-control.test.ts
@@ -187,4 +187,53 @@ describe("access-control", () => {
       expect(mockRedirect).toHaveBeenCalledWith("/login");
     });
   });
+
+  describe("getSessionRole", () => {
+    it("未認証 → null を返す", async () => {
+      mockAuth.mockResolvedValue(null);
+
+      const { getSessionRole } = await import("../lib/access-control");
+      const role = await getSessionRole();
+      expect(role).toBeNull();
+    });
+
+    it("ホワイトリストに存在しない → null を返す", async () => {
+      mockAuth.mockResolvedValue({
+        user: { email: "unknown@example.com" },
+      });
+      mockFirestoreGet.mockResolvedValue({ empty: true, docs: [] });
+
+      const { getSessionRole } = await import("../lib/access-control");
+      const role = await getSessionRole();
+      expect(role).toBeNull();
+    });
+
+    it("admin ユーザー → 'admin' を返す", async () => {
+      mockAuth.mockResolvedValue({
+        user: { email: "admin@aozora-cg.com" },
+      });
+      mockFirestoreGet.mockResolvedValue({
+        empty: false,
+        docs: [{ data: () => ({ role: "admin" }) }],
+      });
+
+      const { getSessionRole } = await import("../lib/access-control");
+      const role = await getSessionRole();
+      expect(role).toBe("admin");
+    });
+
+    it("viewer ユーザー → 'viewer' を返す", async () => {
+      mockAuth.mockResolvedValue({
+        user: { email: "viewer@aozora-cg.com" },
+      });
+      mockFirestoreGet.mockResolvedValue({
+        empty: false,
+        docs: [{ data: () => ({ role: "viewer" }) }],
+      });
+
+      const { getSessionRole } = await import("../lib/access-control");
+      const role = await getSessionRole();
+      expect(role).toBe("viewer");
+    });
+  });
 });

--- a/apps/web/src/app/(protected)/chat-messages/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 import { Suspense } from "react";
 import { ChatSyncButton } from "@/components/chat/sync-button";
+import { requireAccess } from "@/lib/access-control";
 import {
   getChatMessages,
   getChatSpaces,
@@ -58,6 +59,8 @@ function FilterRow({ label, children }: { label: string; children: ReactNode }) 
 }
 
 export default async function ChatMessagesPage({ searchParams }: Props) {
+  const access = await requireAccess();
+  const isAdmin = access.role === "admin";
   const params = await searchParams;
   const source = params.source === "line" ? "line" : "gchat";
   const page = Math.max(1, Number(params.page) || 1);
@@ -233,7 +236,7 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
         </div>
         <div className="flex items-center gap-2">
           {sourceTabsHtml}
-          <ChatSyncButton />
+          {isAdmin && <ChatSyncButton />}
         </div>
       </div>
 

--- a/apps/web/src/app/api/chat-messages/sync/config/route.ts
+++ b/apps/web/src/app/api/chat-messages/sync/config/route.ts
@@ -22,6 +22,12 @@ export async function PATCH(request: Request) {
     return Response.json({ error: "認証されていません" }, { status: 401 });
   }
 
+  const { getSessionRole } = await import("@/lib/access-control");
+  const role = await getSessionRole();
+  if (role !== "admin") {
+    return Response.json({ error: "管理者のみ実行可能です" }, { status: 403 });
+  }
+
   const body = await request.json();
   const res = await fetch(`${API_BASE_URL}/api/chat-messages/sync/config`, {
     method: "PATCH",

--- a/apps/web/src/app/api/chat-messages/sync/route.ts
+++ b/apps/web/src/app/api/chat-messages/sync/route.ts
@@ -1,4 +1,5 @@
 import { auth } from "@/auth";
+import { getSessionRole } from "@/lib/access-control";
 
 const API_BASE_URL = process.env.API_BASE_URL ?? "http://localhost:3001";
 
@@ -6,6 +7,11 @@ export async function POST() {
   const session = await auth();
   if (!session?.idToken) {
     return Response.json({ error: "認証されていません" }, { status: 401 });
+  }
+
+  const role = await getSessionRole();
+  if (role !== "admin") {
+    return Response.json({ error: "管理者のみ実行可能です" }, { status: 403 });
   }
 
   const res = await fetch(`${API_BASE_URL}/api/chat-messages/sync`, {

--- a/apps/web/src/lib/access-control.ts
+++ b/apps/web/src/lib/access-control.ts
@@ -54,3 +54,21 @@ export async function requireAdmin(): Promise<AccessInfo> {
   }
   return access;
 }
+
+/**
+ * API Route 用: セッションユーザーのロールを取得する。
+ * redirect せず null を返すため、Route Handler (GET/POST/PATCH) で使用可能。
+ */
+export async function getSessionRole(): Promise<UserRole | null> {
+  const session = await auth();
+  if (!session?.user?.email) return null;
+
+  const snapshot = await collections.allowedUsers
+    .where("email", "==", session.user.email)
+    .where("isActive", "==", true)
+    .limit(1)
+    .get();
+
+  const doc = snapshot.docs[0];
+  return doc?.data().role ?? null;
+}


### PR DESCRIPTION
## Summary

- フロントエンド API ルート (POST `/api/chat-messages/sync`, PATCH `/api/chat-messages/sync/config`) に admin ロールチェックを追加
- `chat-messages` ページで非 admin ユーザーに同期ボタン (`ChatSyncButton`) を非表示
- API Route 用の `getSessionRole()` ヘルパーを `access-control.ts` に追加（redirect せず null を返す）
- `getSessionRole` のユニットテスト 4 件追加（未認証、非ホワイトリスト、admin、viewer）

バックエンド (`chat-sync.ts` ミドルウェア L18-28) は既に admin + サービスアカウントに制限済み。本変更はフロントエンド側の defense-in-depth を追加。

Closes #200

## Test plan

- [x] typecheck 通過
- [x] lint 通過
- [x] web テスト 177/177 通過（+4 新規）
- [x] api テスト 154/154 通過
- [x] ビルド 7/7 成功
- [ ] admin ユーザーでログイン → 同期ボタン表示・実行可能
- [ ] viewer ユーザーでログイン → 同期ボタン非表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)