### PR TITLE
perf(web): タスクボード・受信箱に loading.tsx スケルトン追加

### DIFF
--- a/apps/web/src/app/(protected)/inbox/loading.tsx
+++ b/apps/web/src/app/(protected)/inbox/loading.tsx
@@ -1,0 +1,66 @@
+function SkeletonMessage() {
+  return (
+    <div className="px-4 py-3">
+      <div className="flex items-center gap-2">
+        <div className="h-2 w-2 rounded-full bg-slate-200" />
+        <div className="h-4 w-20 animate-pulse rounded bg-slate-200" />
+        <div className="ml-auto h-4 w-24 animate-pulse rounded bg-slate-200" />
+      </div>
+      <div className="mt-1 h-4 w-full animate-pulse rounded bg-slate-200" />
+      <div className="mt-1.5 flex gap-1.5">
+        <div className="h-5 w-12 animate-pulse rounded bg-slate-200" />
+        <div className="h-5 w-8 animate-pulse rounded bg-slate-200" />
+      </div>
+    </div>
+  );
+}
+
+export default function InboxLoading() {
+  return (
+    <div className="-m-6 flex h-[calc(100vh-52px)] flex-col">
+      {/* ヘッダー スケルトン */}
+      <div className="flex-shrink-0 border-b border-border/60 bg-white px-5 py-3">
+        <div className="mb-2 flex items-center justify-between">
+          <div className="h-6 w-16 animate-pulse rounded bg-slate-200" />
+          <div className="h-4 w-16 animate-pulse rounded bg-slate-200" />
+        </div>
+        <div className="mb-2 flex gap-1">
+          <div className="h-7 w-24 animate-pulse rounded-lg bg-slate-200" />
+          <div className="h-7 w-16 animate-pulse rounded-lg bg-slate-200" />
+        </div>
+        <div className="flex gap-1.5">
+          <div className="h-7 w-16 animate-pulse rounded-full bg-slate-200" />
+          <div className="h-7 w-16 animate-pulse rounded-full bg-slate-200" />
+          <div className="h-7 w-16 animate-pulse rounded-full bg-slate-200" />
+          <div className="h-7 w-16 animate-pulse rounded-full bg-slate-200" />
+          <div className="h-7 w-16 animate-pulse rounded-full bg-slate-200" />
+        </div>
+      </div>
+
+      {/* メッセージリスト スケルトン */}
+      <div className="flex-1 overflow-hidden">
+        <div className="w-full divide-y divide-border/40 md:w-[320px]">
+          <SkeletonMessage />
+          <SkeletonMessage />
+          <SkeletonMessage />
+          <SkeletonMessage />
+          <SkeletonMessage />
+          <SkeletonMessage />
+          <SkeletonMessage />
+          <SkeletonMessage />
+          <SkeletonMessage />
+          <SkeletonMessage />
+        </div>
+      </div>
+
+      {/* ページネーション スケルトン */}
+      <div className="flex-shrink-0 border-t border-border/60 bg-white px-5 py-2">
+        <div className="flex items-center justify-center gap-2">
+          <div className="h-8 w-14 animate-pulse rounded-lg bg-slate-200" />
+          <div className="h-8 w-20 animate-pulse rounded-lg bg-slate-100" />
+          <div className="h-8 w-14 animate-pulse rounded-lg bg-slate-200" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(protected)/task-board/loading.tsx
+++ b/apps/web/src/app/(protected)/task-board/loading.tsx
@@ -1,0 +1,56 @@
+function SkeletonRow() {
+  return (
+    <div className="px-5 py-3">
+      <div className="flex items-center gap-2">
+        <div className="h-2 w-2 rounded-full bg-slate-200" />
+        <div className="h-3 w-3 rounded-full bg-slate-200" />
+        <div className="h-4 w-20 animate-pulse rounded bg-slate-200" />
+        <div className="ml-auto h-4 w-12 animate-pulse rounded bg-slate-200" />
+        <div className="h-4 w-24 animate-pulse rounded bg-slate-200" />
+      </div>
+      <div className="mt-1 h-4 w-3/4 animate-pulse rounded bg-slate-200" />
+    </div>
+  );
+}
+
+export default function TaskBoardLoading() {
+  return (
+    <div className="-m-6 flex h-[calc(100vh-52px)] flex-col">
+      {/* フィルターヘッダー スケルトン */}
+      <div className="flex-shrink-0 border-b border-border/60 bg-white px-5 py-3">
+        <div className="mb-2 flex items-center justify-between">
+          <div className="h-6 w-24 animate-pulse rounded bg-slate-200" />
+          <div className="h-4 w-16 animate-pulse rounded bg-slate-200" />
+        </div>
+        <div className="mb-2 flex gap-1.5">
+          <div className="h-7 w-12 animate-pulse rounded-full bg-slate-200" />
+          <div className="h-7 w-12 animate-pulse rounded-full bg-slate-200" />
+          <div className="h-7 w-12 animate-pulse rounded-full bg-slate-200" />
+          <div className="h-7 w-12 animate-pulse rounded-full bg-slate-200" />
+          <div className="h-7 w-12 animate-pulse rounded-full bg-slate-200" />
+        </div>
+        <div className="flex gap-1.5">
+          <div className="h-7 w-16 animate-pulse rounded-lg bg-slate-200" />
+          <div className="h-7 w-16 animate-pulse rounded-lg bg-slate-200" />
+          <div className="h-7 w-16 animate-pulse rounded-lg bg-slate-200" />
+          <div className="h-7 w-4 bg-transparent" />
+          <div className="h-7 w-16 animate-pulse rounded-lg bg-slate-200" />
+          <div className="h-7 w-16 animate-pulse rounded-lg bg-slate-200" />
+          <div className="h-7 w-16 animate-pulse rounded-lg bg-slate-200" />
+        </div>
+      </div>
+
+      {/* タスクリスト スケルトン */}
+      <div className="flex-1 divide-y divide-border/40 overflow-hidden">
+        <SkeletonRow />
+        <SkeletonRow />
+        <SkeletonRow />
+        <SkeletonRow />
+        <SkeletonRow />
+        <SkeletonRow />
+        <SkeletonRow />
+        <SkeletonRow />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- タスクボード (`/task-board`) と受信箱 (`/inbox`) に `loading.tsx` を追加
- ルート遷移・フィルター切替時に即座にスケルトン UI を表示（真っ白な画面を解消）
- Next.js App Router の自動 Suspense boundary を活用

## Test plan

- [x] typecheck 通過 (11/11)
- [x] lint 通過（新規ファイルのみ確認）
- [x] test 通過
- [x] build 成功 (7/7)
- [ ] `/task-board` 遷移時にスケルトン表示 → データ表示を確認
- [ ] `/inbox` 遷移時にスケルトン表示 → データ表示を確認
- [ ] フィルタータブ切替時にスケルトン → 再表示を確認

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)