### PR TITLE
feat: ダッシュボード統計に LINE メッセージを統合

### DIFF
--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -19,28 +19,49 @@ const CATEGORY_LABELS: Record<ChatCategory, string> = {
   other: "その他",
 };
 
-// GET /api/stats/summary — サマリー
+// GET /api/stats/summary — サマリー（Google Chat + LINE）
 statsRoutes.get("/summary", async (c) => {
-  const allMessages = await collections.chatMessages.count().get();
-  const total = allMessages.data().count;
-
   const now = new Date();
   const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
   const weekStart = new Date(todayStart);
   weekStart.setDate(weekStart.getDate() - weekStart.getDay());
   const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
 
-  const [todaySnap, weekSnap, monthSnap] = await Promise.all([
-    collections.chatMessages.where("createdAt", ">=", Timestamp.fromDate(todayStart)).count().get(),
-    collections.chatMessages.where("createdAt", ">=", Timestamp.fromDate(weekStart)).count().get(),
-    collections.chatMessages.where("createdAt", ">=", Timestamp.fromDate(monthStart)).count().get(),
-  ]);
+  const [chatTotal, lineTotal, chatToday, lineToday, chatWeek, lineWeek, chatMonth, lineMonth] =
+    await Promise.all([
+      collections.chatMessages.count().get(),
+      collections.lineMessages.count().get(),
+      collections.chatMessages
+        .where("createdAt", ">=", Timestamp.fromDate(todayStart))
+        .count()
+        .get(),
+      collections.lineMessages
+        .where("createdAt", ">=", Timestamp.fromDate(todayStart))
+        .count()
+        .get(),
+      collections.chatMessages
+        .where("createdAt", ">=", Timestamp.fromDate(weekStart))
+        .count()
+        .get(),
+      collections.lineMessages
+        .where("createdAt", ">=", Timestamp.fromDate(weekStart))
+        .count()
+        .get(),
+      collections.chatMessages
+        .where("createdAt", ">=", Timestamp.fromDate(monthStart))
+        .count()
+        .get(),
+      collections.lineMessages
+        .where("createdAt", ">=", Timestamp.fromDate(monthStart))
+        .count()
+        .get(),
+    ]);
 
   return c.json({
-    total,
-    today: todaySnap.data().count,
-    thisWeek: weekSnap.data().count,
-    thisMonth: monthSnap.data().count,
+    total: chatTotal.data().count + lineTotal.data().count,
+    today: chatToday.data().count + lineToday.data().count,
+    thisWeek: chatWeek.data().count + lineWeek.data().count,
+    thisMonth: chatMonth.data().count + lineMonth.data().count,
   });
 });
 
@@ -90,14 +111,21 @@ statsRoutes.get("/timeline", async (c) => {
   const from = fromParam ? new Date(fromParam) : defaultFrom;
   const to = toParam ? new Date(toParam) : now;
 
-  const snapshot = await collections.chatMessages
-    .where("createdAt", ">=", Timestamp.fromDate(from))
-    .where("createdAt", "<=", Timestamp.fromDate(to))
-    .orderBy("createdAt", "asc")
-    .get();
+  const [chatSnap, lineSnap] = await Promise.all([
+    collections.chatMessages
+      .where("createdAt", ">=", Timestamp.fromDate(from))
+      .where("createdAt", "<=", Timestamp.fromDate(to))
+      .orderBy("createdAt", "asc")
+      .get(),
+    collections.lineMessages
+      .where("createdAt", ">=", Timestamp.fromDate(from))
+      .where("createdAt", "<=", Timestamp.fromDate(to))
+      .orderBy("createdAt", "asc")
+      .get(),
+  ]);
 
   const buckets: Record<string, number> = {};
-  for (const doc of snapshot.docs) {
+  for (const doc of [...chatSnap.docs, ...lineSnap.docs]) {
     const date = doc.data().createdAt.toDate();
     let key: string;
     if (granularity === "month") {
@@ -119,37 +147,66 @@ statsRoutes.get("/timeline", async (c) => {
   return c.json({ timeline, granularity, from: from.toISOString(), to: to.toISOString() });
 });
 
-// GET /api/stats/spaces — スペース別集計
+// GET /api/stats/spaces — ソース別集計（Google Chat スペース + LINE グループ）
 statsRoutes.get("/spaces", async (c) => {
   const CACHE_KEY = "stats:spaces";
   const cached = getCached<{ spaces: unknown[]; total: number }>(CACHE_KEY);
   if (cached) return c.json(cached);
 
-  const snapshot = await collections.chatMessages.get();
+  const [chatSnap, lineSnap, spaceConfigSnap] = await Promise.all([
+    collections.chatMessages.get(),
+    collections.lineMessages.get(),
+    collections.chatSpaces.get(),
+  ]);
 
+  // Google Chat スペース別
   const spaceCounts: Record<string, number> = {};
-  for (const doc of snapshot.docs) {
+  for (const doc of chatSnap.docs) {
     const spaceId = doc.data().spaceId;
     spaceCounts[spaceId] = (spaceCounts[spaceId] ?? 0) + 1;
   }
 
-  // chat_spaces から displayName を取得してマッピング
-  const spaceConfigSnap = await collections.chatSpaces.get();
   const displayNameMap: Record<string, string> = {};
   for (const doc of spaceConfigSnap.docs) {
     const d = doc.data();
     displayNameMap[d.spaceId] = d.displayName;
   }
 
-  const spaces = Object.entries(spaceCounts)
-    .sort(([, a], [, b]) => b - a)
-    .map(([spaceId, count]) => ({
-      spaceId,
-      displayName: displayNameMap[spaceId] ?? spaceId,
+  const spaces: { spaceId: string; displayName: string; count: number; source: string }[] =
+    Object.entries(spaceCounts)
+      .sort(([, a], [, b]) => b - a)
+      .map(([spaceId, count]) => ({
+        spaceId,
+        displayName: displayNameMap[spaceId] ?? spaceId,
+        count,
+        source: "gchat",
+      }));
+
+  // LINE グループ別
+  const groupCounts = new Map<string, { count: number; groupName: string | null }>();
+  for (const doc of lineSnap.docs) {
+    const msg = doc.data();
+    const existing = groupCounts.get(msg.groupId);
+    if (existing) {
+      existing.count++;
+    } else {
+      groupCounts.set(msg.groupId, { count: 1, groupName: msg.groupName });
+    }
+  }
+
+  const lineSpaces = Array.from(groupCounts.entries())
+    .sort(([, a], [, b]) => b.count - a.count)
+    .map(([groupId, { count, groupName }]) => ({
+      spaceId: groupId,
+      displayName: groupName ?? groupId,
       count,
+      source: "line",
     }));
 
-  const result = { spaces, total: snapshot.docs.length };
+  const allSpaces = [...spaces, ...lineSpaces].sort((a, b) => b.count - a.count);
+  const total = chatSnap.docs.length + lineSnap.docs.length;
+
+  const result = { spaces: allSpaces, total };
   setCache(CACHE_KEY, result, TTL.STATS);
   return c.json(result);
 });

--- a/apps/web/src/app/(protected)/dashboard/page.tsx
+++ b/apps/web/src/app/(protected)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { AutoRefresh } from "@/components/auto-refresh";
 import { CategoryDistributionChart, TimelineChart } from "@/components/dashboard-charts";
 import {
   getInboxCounts,
+  getLineInboxCounts,
   getStatsCategories,
   getStatsSpaces,
   getStatsSummary,
@@ -12,15 +13,23 @@ import { cn } from "@/lib/utils";
 import { InboxStatusBar } from "./inbox-status-bar";
 
 export default async function DashboardPage() {
-  const [summary, categoriesData, timelineData, spacesData, inboxData] = await Promise.all([
-    getStatsSummary(),
-    getStatsCategories(),
-    getStatsTimeline({ granularity: "day" }),
-    getStatsSpaces(),
-    getInboxCounts(),
-  ]);
+  const [summary, categoriesData, timelineData, spacesData, chatInbox, lineInbox] =
+    await Promise.all([
+      getStatsSummary(),
+      getStatsCategories(),
+      getStatsTimeline({ granularity: "day" }),
+      getStatsSpaces(),
+      getInboxCounts(),
+      getLineInboxCounts(),
+    ]);
 
-  const counts = inboxData.counts;
+  // Google Chat + LINE の対応状況を合算
+  const counts = {
+    unresponded: chatInbox.counts.unresponded + lineInbox.counts.unresponded,
+    in_progress: chatInbox.counts.in_progress + lineInbox.counts.in_progress,
+    responded: chatInbox.counts.responded + lineInbox.counts.responded,
+    not_required: chatInbox.counts.not_required + lineInbox.counts.not_required,
+  };
 
   return (
     <div className="space-y-6">
@@ -85,23 +94,35 @@ export default async function DashboardPage() {
           />
         </div>
 
-        {/* スペース別 */}
+        {/* ソース別メッセージ */}
         <div className="rounded-xl border border-border/60 bg-card p-5">
           <div className="mb-4">
-            <h2 className="text-sm font-semibold">スペース別メッセージ</h2>
+            <h2 className="text-sm font-semibold">ソース別メッセージ</h2>
             <p className="text-xs text-muted-foreground">全{spacesData.total}件</p>
           </div>
           <div className="space-y-2.5">
             {spacesData.spaces.map((space) => {
               const pct = spacesData.total > 0 ? (space.count / spacesData.total) * 100 : 0;
+              const isLine = space.source === "line";
               return (
                 <div key={space.spaceId} className="flex items-center gap-3">
+                  <span
+                    className={cn(
+                      "shrink-0 rounded px-1 py-0.5 text-[10px] font-medium leading-none",
+                      isLine ? "bg-emerald-100 text-emerald-700" : "bg-blue-100 text-blue-700",
+                    )}
+                  >
+                    {isLine ? "LINE" : "Chat"}
+                  </span>
                   <span className="text-xs text-muted-foreground truncate min-w-0 flex-1">
                     {space.displayName}
                   </span>
                   <div className="h-1.5 w-32 rounded-full bg-muted overflow-hidden flex-shrink-0">
                     <div
-                      className="h-full rounded-full bg-[var(--gradient-from)] transition-[width] duration-500"
+                      className={cn(
+                        "h-full rounded-full transition-[width] duration-500",
+                        isLine ? "bg-emerald-500" : "bg-[var(--gradient-from)]",
+                      )}
                       style={{ width: `${pct}%` }}
                     />
                   </div>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -172,6 +172,7 @@ export interface SpaceStat {
   spaceId: string;
   displayName: string;
   count: number;
+  source?: string;
 }
 
 // --- Admin Users ---


### PR DESCRIPTION
## Summary

- ダッシュボード統計（総数・今日・今週・今月）に LINE メッセージを合算
- タイムライン推移（直近30日）に LINE メッセージを含める
- ソース別メッセージに LINE グループを追加（Chat/LINE ラベル + 色分け）
- 対応状況バーに LINE inbox counts を統合（Google Chat + LINE 合算）

## Test plan

- [x] typecheck 通過 (11/11)
- [x] lint 通過
- [x] test 通過 (154テスト)
- [x] build 成功 (7/7)
- [ ] ダッシュボードのサマリーカードに LINE メッセージが含まれた値が表示される
- [ ] ソース別メッセージに LINE グループが Chat/LINE ラベル付きで表示される
- [ ] 対応状況バーが Google Chat + LINE の合算値を表示する
- [ ] タイムラインに LINE メッセージが含まれる

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)