### PR TITLE
test: manual-tasks CRUD API の統合テスト追加

### DIFF
--- a/apps/api/src/__tests__/manual-tasks.test.ts
+++ b/apps/api/src/__tests__/manual-tasks.test.ts
@@ -173,10 +173,10 @@ describe("manual-tasks routes", () => {
       const res = await app.request("/api/manual-tasks");
       expect(res.status).toBe(200);
 
-      const body = await res.json();
+      const body = (await res.json()) as { data: { id: string; title: string }[]; total: number };
       expect(body.data).toHaveLength(1);
-      expect(body.data[0].id).toBe("task-1");
-      expect(body.data[0].title).toBe("テストタスク");
+      expect(body.data[0]!.id).toBe("task-1");
+      expect(body.data[0]!.title).toBe("テストタスク");
       expect(body.total).toBe(1);
     });
   });
@@ -197,7 +197,7 @@ describe("manual-tasks routes", () => {
       });
 
       expect(res.status).toBe(201);
-      const body = await res.json();
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.title).toBe("テストタスク");
       expect(mockAuditAdd).toHaveBeenCalledOnce();
     });
@@ -233,7 +233,7 @@ describe("manual-tasks routes", () => {
       const res = await app.request("/api/manual-tasks/task-1");
       expect(res.status).toBe(200);
 
-      const body = await res.json();
+      const body = (await res.json()) as Record<string, unknown>;
       expect(body.id).toBe("task-1");
     });
 


### PR DESCRIPTION
## Summary

- `POST/GET/PATCH/DELETE /api/manual-tasks` の全5エンドポイントを13テストケースでカバー
- 正常系・バリデーション（400）・RBAC viewer制限（403）・存在しない ID（404）を網羅
- `vi.clearAllMocks()` が `mockResolvedValueOnce` キューをクリアしない Vitest の挙動に対応

## Test plan

- [x] 全167テスト通過（新規13テスト含む）
- [x] typecheck 通過（11/11パッケージ）
- [x] lint 通過

Closes #228

🤖 Generated with [Claude Code](https://claude.com/claude-code)