### PR TITLE
feat: Google Chat 受信箱にスペース名を表示（LINE 同様）

### DIFF
--- a/apps/api/src/__tests__/chat-messages-routes.test.ts
+++ b/apps/api/src/__tests__/chat-messages-routes.test.ts
@@ -31,6 +31,9 @@ vi.mock("@hr-system/db", () => {
           get: vi.fn(() => mockChatMessagesByIdGet()),
         })),
       },
+      chatSpaces: {
+        get: vi.fn(() => Promise.resolve({ docs: [] })),
+      },
       intentRecords: {
         get: vi.fn(() => mockIntentRecordsGet()),
         where: vi.fn(() => {

--- a/apps/api/src/routes/chat-messages.ts
+++ b/apps/api/src/routes/chat-messages.ts
@@ -34,6 +34,21 @@ const patchIntentSchema = z.object({
 
 export const chatMessageRoutes = new Hono();
 
+/** chatSpaces の displayName マップを取得（キャッシュ付き） */
+async function getSpaceDisplayNameMap(): Promise<Map<string, string>> {
+  const CACHE_KEY = "space-display-name-map";
+  const cached = getCached<Map<string, string>>(CACHE_KEY);
+  if (cached) return cached;
+  const snap = await collections.chatSpaces.get();
+  const map = new Map<string, string>();
+  for (const doc of snap.docs) {
+    const d = doc.data();
+    map.set(d.spaceId, d.displayName);
+  }
+  setCache(CACHE_KEY, map, TTL.STATS);
+  return map;
+}
+
 // ---------------------------------------------------------------------------
 // GET /api/chat-messages — メッセージ一覧（フィルタリング・スレッド構造付き）
 // ---------------------------------------------------------------------------
@@ -55,6 +70,8 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
   if (!actorRole || !["hr_staff", "hr_manager", "ceo"].includes(actorRole)) {
     return c.json({ error: "Forbidden" }, 403);
   }
+
+  const spaceNameMap = await getSpaceDisplayNameMap();
 
   // Intent 系フィルタ（別コレクション依存のため Firestore クエリ不可）
   const hasIntentFilter =
@@ -184,6 +201,7 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
         return {
           id: doc.id,
           spaceId: msg.spaceId,
+          spaceDisplayName: spaceNameMap.get(msg.spaceId) ?? null,
           googleMessageId: msg.googleMessageId,
           senderUserId: msg.senderUserId,
           senderName: msg.senderName,
@@ -239,6 +257,7 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
       return {
         id: doc.id,
         spaceId: msg.spaceId,
+        spaceDisplayName: spaceNameMap.get(msg.spaceId) ?? null,
         googleMessageId: msg.googleMessageId,
         senderUserId: msg.senderUserId,
         senderName: msg.senderName,
@@ -431,7 +450,10 @@ chatMessageRoutes.get("/:id", async (c) => {
     return c.json({ error: "Forbidden" }, 403);
   }
 
-  const docSnap = await collections.chatMessages.doc(id).get();
+  const [spaceNameMap, docSnap] = await Promise.all([
+    getSpaceDisplayNameMap(),
+    collections.chatMessages.doc(id).get(),
+  ]);
   if (!docSnap.exists) throw notFound("ChatMessage", id);
 
   // biome-ignore lint/style/noNonNullAssertion: docSnap.exists checked above
@@ -469,6 +491,7 @@ chatMessageRoutes.get("/:id", async (c) => {
   return c.json({
     id: docSnap.id,
     spaceId: msg.spaceId,
+    spaceDisplayName: spaceNameMap.get(msg.spaceId) ?? null,
     googleMessageId: msg.googleMessageId,
     senderUserId: msg.senderUserId,
     senderName: msg.senderName,

--- a/apps/web/src/__tests__/api-contract.test.ts
+++ b/apps/web/src/__tests__/api-contract.test.ts
@@ -128,6 +128,7 @@ const sampleIntentDetail: IntentDetail = {
 const sampleChatMessage: ChatMessageSummary = {
   id: "msg-001",
   spaceId: "spaces/AAAA-qf5jX0",
+  spaceDisplayName: "人事関連（全社共通）",
   googleMessageId: "spaces/test/messages/test-msg-001",
   senderUserId: "users/12345",
   senderName: "田中 花子",

--- a/apps/web/src/__tests__/inbox-3pane.test.tsx
+++ b/apps/web/src/__tests__/inbox-3pane.test.tsx
@@ -150,6 +150,7 @@ function makeSummary(overrides: Partial<ChatMessageSummary> = {}): ChatMessageSu
   return {
     id: "msg-1",
     spaceId: "space-1",
+    spaceDisplayName: null,
     googleMessageId: "gm-1",
     senderUserId: "user-1",
     senderName: "田中太郎",

--- a/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
@@ -67,6 +67,11 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
                   )}
                 />
                 <span className="truncate text-xs font-medium">{msg.senderName}</span>
+                {msg.spaceDisplayName && (
+                  <span className="truncate text-xs text-muted-foreground">
+                    @ {msg.spaceDisplayName}
+                  </span>
+                )}
                 <span className="ml-auto text-xs text-muted-foreground">
                   {formatDateTimeJST(msg.createdAt)}
                 </span>

--- a/apps/web/src/components/message-detail-pane.tsx
+++ b/apps/web/src/components/message-detail-pane.tsx
@@ -53,6 +53,9 @@ export function ChatMessageDetailPane({
               <X className="h-4 w-4" />
             </button>
             <h2 className="text-base font-bold">{message.senderName}</h2>
+            {message.spaceDisplayName && (
+              <span className="text-xs text-muted-foreground">@ {message.spaceDisplayName}</span>
+            )}
             <span className="text-xs text-muted-foreground">
               {formatDateTimeJST(message.createdAt)}
             </span>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -249,6 +249,7 @@ export interface ChatAttachment {
 export interface ChatMessageSummary {
   id: string;
   spaceId: string;
+  spaceDisplayName: string | null;
   googleMessageId: string;
   senderUserId: string;
   senderName: string;


### PR DESCRIPTION
## Summary

- API `/api/chat-messages` レスポンスに `spaceDisplayName` フィールドを追加（chatSpaces コレクションから lookup、5分キャッシュ）
- 受信箱リスト・詳細ペインに `@ スペース名` を表示（LINE の `@ グループ名` と同じパターン）

## Test plan

- [x] typecheck 通過 (11/11)
- [x] lint 通過
- [x] test 通過 (167テスト)
- [ ] 受信箱で Google Chat メッセージにスペース名が表示されることを確認
- [ ] 詳細ペインのヘッダーにもスペース名が表示されることを確認

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)