### PR TITLE
fix: 期限(deadline)の設定・編集UIを追加

### DIFF
--- a/apps/web/src/__tests__/inbox-3pane.test.tsx
+++ b/apps/web/src/__tests__/inbox-3pane.test.tsx
@@ -103,11 +103,11 @@ vi.mock("@/components/task-priority-selector", () => ({
 }));
 
 vi.mock("../app/(protected)/inbox/handover-form", () => ({
-  HandoverForm: ({ taskSummary, assignees, notes }: Record<string, unknown>) =>
+  HandoverForm: ({ taskSummary, assignees, deadline, notes }: Record<string, unknown>) =>
     React.createElement(
       "div",
       { "data-testid": "handover-form" },
-      [taskSummary, assignees, notes].filter(Boolean).join(","),
+      [taskSummary, assignees, deadline, notes].filter(Boolean).join(","),
     ),
 }));
 

--- a/apps/web/src/app/(protected)/inbox/handover-form.tsx
+++ b/apps/web/src/app/(protected)/inbox/handover-form.tsx
@@ -10,25 +10,34 @@ interface HandoverFormProps {
   chatMessageId: string;
   taskSummary: string | null;
   assignees: string | null;
+  deadline: string | null;
   notes: string | null;
 }
 
-export function HandoverForm({ chatMessageId, taskSummary, assignees, notes }: HandoverFormProps) {
+export function HandoverForm({
+  chatMessageId,
+  taskSummary,
+  assignees,
+  deadline,
+  notes,
+}: HandoverFormProps) {
   const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [localTask, setLocalTask] = useState(taskSummary ?? "");
   const [localAssignees, setLocalAssignees] = useState(assignees ?? "");
+  const [localDeadline, setLocalDeadline] = useState(deadline ? deadline.slice(0, 10) : "");
   const [localNotes, setLocalNotes] = useState(notes ?? "");
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
-  const hasContent = !!(taskSummary || assignees || notes);
+  const hasContent = !!(taskSummary || assignees || deadline || notes);
 
   async function handleSave() {
     setSaving(true);
     const body: WorkflowUpdateRequest = {
       taskSummary: localTask || null,
       assignees: localAssignees || null,
+      deadline: localDeadline ? `${localDeadline}T00:00:00+09:00` : null,
       notes: localNotes || null,
     };
     await updateWorkflowAction(chatMessageId, body);
@@ -65,6 +74,12 @@ export function HandoverForm({ chatMessageId, taskSummary, assignees, notes }: H
               <div>
                 <span className="text-muted-foreground">担当者:</span>{" "}
                 <span className="text-foreground">{assignees}</span>
+              </div>
+            )}
+            {deadline && (
+              <div>
+                <span className="text-muted-foreground">期限:</span>{" "}
+                <span className="text-foreground">{deadline.slice(0, 10)}</span>
               </div>
             )}
             {notes && (
@@ -105,6 +120,15 @@ export function HandoverForm({ chatMessageId, taskSummary, assignees, notes }: H
           onChange={(e) => setLocalAssignees(e.target.value)}
           className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-xs placeholder:text-muted-foreground/50 focus:outline-none focus:ring-1 focus:ring-[var(--gradient-from)]"
         />
+        <div>
+          <input
+            type="date"
+            value={localDeadline}
+            onChange={(e) => setLocalDeadline(e.target.value)}
+            className="w-full rounded-md border border-border bg-background px-2.5 py-1.5 text-xs text-muted-foreground focus:outline-none focus:ring-1 focus:ring-[var(--gradient-from)]"
+          />
+          <p className="mt-0.5 text-[10px] text-muted-foreground/60">期限（任意）</p>
+        </div>
         <textarea
           placeholder="引き継ぎメモ"
           value={localNotes}
@@ -132,6 +156,7 @@ export function HandoverForm({ chatMessageId, taskSummary, assignees, notes }: H
             setEditing(false);
             setLocalTask(taskSummary ?? "");
             setLocalAssignees(assignees ?? "");
+            setLocalDeadline(deadline ? deadline.slice(0, 10) : "");
             setLocalNotes(notes ?? "");
           }}
           className="rounded-md border border-border px-3 py-1 text-xs text-muted-foreground hover:bg-accent transition-colors"

--- a/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
@@ -113,6 +113,7 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
                   chatMessageId={selectedMessage.id}
                   taskSummary={selectedMessage.intent.taskSummary ?? null}
                   assignees={selectedMessage.intent.assignees ?? null}
+                  deadline={selectedMessage.intent.deadline ?? null}
                   notes={selectedMessage.intent.notes ?? null}
                 />
               </div>

--- a/apps/web/src/app/(protected)/inbox/inbox-list.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-list.tsx
@@ -179,6 +179,7 @@ function InboxCard({
                 chatMessageId={message.id}
                 taskSummary={intent?.taskSummary ?? null}
                 assignees={intent?.assignees ?? null}
+                deadline={intent?.deadline ?? null}
                 notes={intent?.notes ?? null}
               />
             </div>

--- a/apps/web/src/app/(protected)/task-board/task-board-content.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-board-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
-import { Loader2, X } from "lucide-react";
+import { Calendar, Loader2, Pencil, Users, X } from "lucide-react";
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { LineMessageDetailPane } from "@/components/line-message-detail-pane";
 import { ChatMessageDetailPane } from "@/components/message-detail-pane";
@@ -161,6 +161,7 @@ export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) 
                         chatMessageId={chatDetail.id}
                         taskSummary={chatDetail.intent.taskSummary ?? null}
                         assignees={chatDetail.intent.assignees ?? null}
+                        deadline={chatDetail.intent.deadline ?? null}
                         notes={chatDetail.intent.notes ?? null}
                       />
                     </div>
@@ -187,6 +188,12 @@ export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) 
 /** 手動タスクの詳細ペイン */
 function ManualTaskDetailPane({ task, onClose }: { task: TaskItem; onClose: () => void }) {
   const [isUpdating, startUpdate] = useTransition();
+  const [editingAssignees, setEditingAssignees] = useState(false);
+  const [localAssignees, setLocalAssignees] = useState(task.assignees ?? "");
+  const [editingDeadline, setEditingDeadline] = useState(false);
+  const [localDeadline, setLocalDeadline] = useState(
+    task.deadline ? task.deadline.slice(0, 10) : "",
+  );
 
   const handleResponseStatusChange = (status: ResponseStatus) => {
     startUpdate(async () => {
@@ -242,12 +249,115 @@ function ManualTaskDetailPane({ task, onClose }: { task: TaskItem; onClose: () =
             <span className="w-16 text-muted-foreground">作成日</span>
             <span>{formatDateTimeJST(task.createdAt)}</span>
           </div>
-          {task.assignees && (
-            <div className="flex items-center gap-2">
-              <span className="w-16 text-muted-foreground">担当者</span>
-              <span>{task.assignees}</span>
-            </div>
-          )}
+          {/* 担当者（インライン編集） */}
+          <div className="flex items-center gap-2">
+            <Users className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="w-16 text-muted-foreground">担当者</span>
+            {editingAssignees ? (
+              <form
+                className="ml-auto flex items-center gap-1"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  setEditingAssignees(false);
+                  startUpdate(async () => {
+                    await updateManualTaskAction(task.id, {
+                      assignees: localAssignees || null,
+                    });
+                  });
+                }}
+              >
+                <input
+                  type="text"
+                  value={localAssignees}
+                  onChange={(e) => setLocalAssignees(e.target.value)}
+                  placeholder="担当者名"
+                  className="w-32 rounded border border-border bg-background px-2 py-0.5 text-sm focus:outline-none focus:ring-1 focus:ring-[var(--gradient-from)]"
+                />
+                <button
+                  type="submit"
+                  className="rounded px-1.5 py-0.5 text-xs text-[var(--gradient-from)] hover:bg-accent"
+                >
+                  保存
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingAssignees(false);
+                    setLocalAssignees(task.assignees ?? "");
+                  }}
+                  className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent"
+                >
+                  ✕
+                </button>
+              </form>
+            ) : (
+              <button
+                type="button"
+                className="ml-auto flex items-center gap-1 hover:text-[var(--gradient-from)]"
+                onClick={() => setEditingAssignees(true)}
+              >
+                {task.assignees || <span className="text-muted-foreground/50 italic">未設定</span>}
+                <Pencil className="h-3 w-3 text-muted-foreground" />
+              </button>
+            )}
+          </div>
+
+          {/* 期限（インライン編集） */}
+          <div className="flex items-center gap-2">
+            <Calendar className="h-3.5 w-3.5 text-muted-foreground" />
+            <span className="w-16 text-muted-foreground">期限</span>
+            {editingDeadline ? (
+              <form
+                className="ml-auto flex items-center gap-1"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  setEditingDeadline(false);
+                  startUpdate(async () => {
+                    await updateManualTaskAction(task.id, {
+                      deadline: localDeadline ? `${localDeadline}T00:00:00+09:00` : null,
+                    });
+                  });
+                }}
+              >
+                <input
+                  type="date"
+                  value={localDeadline}
+                  onChange={(e) => setLocalDeadline(e.target.value)}
+                  className="w-32 rounded border border-border bg-background px-2 py-0.5 text-sm focus:outline-none focus:ring-1 focus:ring-[var(--gradient-from)]"
+                />
+                <button
+                  type="submit"
+                  className="rounded px-1.5 py-0.5 text-xs text-[var(--gradient-from)] hover:bg-accent"
+                >
+                  保存
+                </button>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setEditingDeadline(false);
+                    setLocalDeadline(task.deadline ? task.deadline.slice(0, 10) : "");
+                  }}
+                  className="rounded px-1.5 py-0.5 text-xs text-muted-foreground hover:bg-accent"
+                >
+                  ✕
+                </button>
+              </form>
+            ) : (
+              <button
+                type="button"
+                className="ml-auto flex items-center gap-1 hover:text-[var(--gradient-from)]"
+                onClick={() => setEditingDeadline(true)}
+              >
+                {task.deadline ? (
+                  task.deadline.slice(0, 10)
+                ) : (
+                  <span className="text-muted-foreground/50 italic">未設定</span>
+                )}
+                <Pencil className="h-3 w-3 text-muted-foreground" />
+              </button>
+            )}
+          </div>
+
           <div className="flex items-center gap-2">
             <span className="w-16 text-muted-foreground">状況</span>
             <span>{RESPONSE_STATUS_LABELS[task.responseStatus]}</span>


### PR DESCRIPTION
## Summary

- **HandoverForm**: deadline 入力フィールド追加（`<input type="date">`）
  - 受信箱（inbox-3pane, inbox-list）とタスクボードの両方で期限設定可能に
  - 表示モード: 期限値を `YYYY-MM-DD` 形式で表示
  - 編集モード: date picker で入力、`T00:00:00+09:00` 変換で JST 安全性維持
- **ManualTaskDetailPane**: 担当者・期限のインライン編集UI追加
  - ペンアイコンクリックでインライン編集フォーム表示
  - 保存/キャンセルボタン付き
- テストモック更新（inbox-3pane.test.tsx）

## Test plan

- [x] typecheck 通過 (3/3)
- [x] test 通過 (177/177)
- [x] build 成功 (3/3)
- [x] lint 通過（変更ファイル）
- [ ] 受信箱の引き継ぎメモ編集で期限を設定・表示できることを確認
- [ ] 手動タスク詳細で担当者・期限をインライン編集できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)