### PR TITLE
feat: 全メッセージ種別で担当者・期限をインライン編集可能にする

### DIFF
--- a/apps/api/src/routes/line-messages.ts
+++ b/apps/api/src/routes/line-messages.ts
@@ -1,6 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 import { collections } from "@hr-system/db";
 import { RESPONSE_STATUSES, TASK_PRIORITIES } from "@hr-system/shared";
+import { Timestamp } from "firebase-admin/firestore";
 import { Hono } from "hono";
 import { z } from "zod";
 import { clearCache, getCached, setCache, TTL } from "../lib/cache.js";
@@ -57,6 +58,8 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
       contentUrl: (msg.contentUrl as string) ?? null,
       lineMessageType: msg.lineMessageType as string,
       taskPriority: (msg.taskPriority as string) ?? null,
+      assignees: (msg.assignees as string) ?? null,
+      deadline: msg.deadline ? toISO(msg.deadline as FirebaseFirestore.Timestamp) : null,
       responseStatus: (msg.responseStatus as string) ?? "unresponded",
       createdAt: toISO(msg.createdAt as FirebaseFirestore.Timestamp),
     };
@@ -157,6 +160,8 @@ lineMessageRoutes.get("/:id", async (c) => {
     contentUrl: msg.contentUrl ?? null,
     lineMessageType: msg.lineMessageType,
     taskPriority: msg.taskPriority ?? null,
+    assignees: msg.assignees ?? null,
+    deadline: msg.deadline ? toISO(msg.deadline) : null,
     responseStatus: msg.responseStatus ?? "unresponded",
     responseStatusUpdatedBy: msg.responseStatusUpdatedBy ?? null,
     responseStatusUpdatedAt: msg.responseStatusUpdatedAt
@@ -230,3 +235,39 @@ lineMessageRoutes.patch(
     return c.json({ success: true });
   },
 );
+
+// ---------------------------------------------------------------------------
+// PATCH /api/line-messages/:id/workflow — 担当者・期限更新
+// ---------------------------------------------------------------------------
+const updateWorkflowSchema = z.object({
+  assignees: z.string().nullable().optional(),
+  deadline: z.string().datetime({ offset: true }).nullable().optional(),
+});
+
+lineMessageRoutes.patch("/:id/workflow", zValidator("json", updateWorkflowSchema), async (c) => {
+  const id = c.req.param("id");
+  const body = c.req.valid("json");
+  const actorRole = c.get("actorRole");
+
+  if (!actorRole || !["hr_staff", "hr_manager", "ceo"].includes(actorRole)) {
+    return c.json({ error: "Forbidden" }, 403);
+  }
+
+  const docRef = collections.lineMessages.doc(id);
+  const docSnap = await docRef.get();
+  if (!docSnap.exists) throw notFound("LineMessage", id);
+
+  const updates: Record<string, unknown> = {};
+  if ("assignees" in body) {
+    updates.assignees = body.assignees ?? null;
+  }
+  if ("deadline" in body) {
+    updates.deadline = body.deadline ? Timestamp.fromDate(new Date(body.deadline)) : null;
+  }
+
+  if (Object.keys(updates).length > 0) {
+    await docRef.update(updates);
+  }
+
+  return c.json({ success: true });
+});

--- a/apps/web/src/__tests__/inbox-3pane.test.tsx
+++ b/apps/web/src/__tests__/inbox-3pane.test.tsx
@@ -64,6 +64,10 @@ vi.mock("lucide-react", () => ({
   MessageSquare: () => React.createElement("span", { "data-testid": "icon-message-square" }),
   Paperclip: () => React.createElement("span", { "data-testid": "icon-paperclip" }),
   X: () => React.createElement("span", { "data-testid": "icon-x" }),
+  Users: () => React.createElement("span", { "data-testid": "icon-users" }),
+  Calendar: () => React.createElement("span", { "data-testid": "icon-calendar" }),
+  Pencil: () => React.createElement("span", { "data-testid": "icon-pencil" }),
+  Check: () => React.createElement("span", { "data-testid": "icon-check" }),
 }));
 
 vi.mock("@/components/ui/tabs", () => ({
@@ -119,6 +123,8 @@ vi.mock("../app/(protected)/inbox/actions", () => ({
   updateResponseStatusAction: vi.fn(),
   updateTaskPriorityAction: vi.fn(),
   updateWorkflowAction: vi.fn(),
+  updateChatAssigneesAction: vi.fn(),
+  updateChatDeadlineAction: vi.fn(),
 }));
 
 vi.mock("@/components/chat/attachment-list", () => ({

--- a/apps/web/src/app/(protected)/inbox/actions.ts
+++ b/apps/web/src/app/(protected)/inbox/actions.ts
@@ -6,6 +6,7 @@ import { requireAccess } from "@/lib/access-control";
 import {
   updateLineResponseStatus,
   updateLineTaskPriority,
+  updateLineWorkflow,
   updateResponseStatus,
   updateWorkflow,
 } from "@/lib/api";
@@ -57,6 +58,36 @@ export async function updateLineTaskPriorityAction(
 ) {
   await requireAccess();
   await updateLineTaskPriority(messageId, taskPriority);
+  revalidatePath("/inbox");
+  revalidatePath("/task-board");
+}
+
+export async function updateChatAssigneesAction(chatMessageId: string, assignees: string | null) {
+  await requireAccess();
+  await updateWorkflow(chatMessageId, { assignees });
+  revalidatePath("/inbox");
+  revalidatePath("/chat-messages");
+  revalidatePath("/task-board");
+}
+
+export async function updateChatDeadlineAction(chatMessageId: string, deadline: string | null) {
+  await requireAccess();
+  await updateWorkflow(chatMessageId, { deadline });
+  revalidatePath("/inbox");
+  revalidatePath("/chat-messages");
+  revalidatePath("/task-board");
+}
+
+export async function updateLineAssigneesAction(messageId: string, assignees: string | null) {
+  await requireAccess();
+  await updateLineWorkflow(messageId, { assignees });
+  revalidatePath("/inbox");
+  revalidatePath("/task-board");
+}
+
+export async function updateLineDeadlineAction(messageId: string, deadline: string | null) {
+  await requireAccess();
+  await updateLineWorkflow(messageId, { deadline });
   revalidatePath("/inbox");
   revalidatePath("/task-board");
 }

--- a/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
@@ -8,6 +8,8 @@ import { CATEGORY_LABELS, RESPONSE_STATUS_DOT_COLORS } from "@/lib/constants";
 import type { ChatMessageDetail, ChatMessageSummary } from "@/lib/types";
 import { cn, formatDateTimeJST } from "@/lib/utils";
 import {
+  updateChatAssigneesAction,
+  updateChatDeadlineAction,
   updateResponseStatusAction,
   updateTaskPriorityAction,
   updateWorkflowAction,
@@ -106,6 +108,10 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
           onUpdateResponseStatus={updateResponseStatusAction}
           onUpdateTaskPriority={updateTaskPriorityAction}
           onUpdateWorkflow={updateWorkflowAction}
+          assignees={selectedMessage.intent?.assignees ?? null}
+          deadline={selectedMessage.intent?.deadline ?? null}
+          onUpdateAssignees={updateChatAssigneesAction}
+          onUpdateDeadline={updateChatDeadlineAction}
           extraContent={
             selectedMessage.intent && (
               <div className="mt-4">

--- a/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
@@ -6,7 +6,12 @@ import { TaskPriorityDot } from "@/components/task-priority-selector";
 import { RESPONSE_STATUS_DOT_COLORS } from "@/lib/constants";
 import type { LineMessageDetail, LineMessageSummary } from "@/lib/types";
 import { cn, formatDateTimeJST } from "@/lib/utils";
-import { updateLineResponseStatusAction, updateLineTaskPriorityAction } from "./actions";
+import {
+  updateLineAssigneesAction,
+  updateLineDeadlineAction,
+  updateLineResponseStatusAction,
+  updateLineTaskPriorityAction,
+} from "./actions";
 import { useSelectMessage } from "./use-select-message";
 
 interface LineInbox3PaneProps {
@@ -100,6 +105,8 @@ export function LineInbox3Pane({ messages, selectedMessage, selectedId }: LineIn
           onClose={() => selectMessage(null)}
           onUpdateResponseStatus={updateLineResponseStatusAction}
           onUpdateTaskPriority={updateLineTaskPriorityAction}
+          onUpdateAssignees={updateLineAssigneesAction}
+          onUpdateDeadline={updateLineDeadlineAction}
         />
       ) : (
         <div className="hidden flex-1 items-center justify-center md:flex">

--- a/apps/web/src/app/(protected)/task-board/actions.ts
+++ b/apps/web/src/app/(protected)/task-board/actions.ts
@@ -10,6 +10,7 @@ import {
   getLineMessage,
   updateLineResponseStatus,
   updateLineTaskPriority,
+  updateLineWorkflow,
   updateManualTask,
   updateResponseStatus,
   updateWorkflow,
@@ -129,5 +130,44 @@ export async function updateLineTaskPriorityFromTaskBoard(
   await requireAccess();
   await updateLineTaskPriority(messageId, taskPriority);
   revalidatePath("/inbox");
+  revalidatePath("/task-board");
+}
+
+export async function updateLineAssigneesFromTaskBoard(
+  messageId: string,
+  assignees: string | null,
+) {
+  await requireAccess();
+  await updateLineWorkflow(messageId, { assignees });
+  revalidatePath("/inbox");
+  revalidatePath("/task-board");
+}
+
+export async function updateLineDeadlineFromTaskBoard(messageId: string, deadline: string | null) {
+  await requireAccess();
+  await updateLineWorkflow(messageId, { deadline });
+  revalidatePath("/inbox");
+  revalidatePath("/task-board");
+}
+
+export async function updateChatAssigneesFromTaskBoard(
+  chatMessageId: string,
+  assignees: string | null,
+) {
+  await requireAccess();
+  await updateWorkflow(chatMessageId, { assignees });
+  revalidatePath("/inbox");
+  revalidatePath("/chat-messages");
+  revalidatePath("/task-board");
+}
+
+export async function updateChatDeadlineFromTaskBoard(
+  chatMessageId: string,
+  deadline: string | null,
+) {
+  await requireAccess();
+  await updateWorkflow(chatMessageId, { deadline });
+  revalidatePath("/inbox");
+  revalidatePath("/chat-messages");
   revalidatePath("/task-board");
 }

--- a/apps/web/src/app/(protected)/task-board/task-board-content.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-board-content.tsx
@@ -15,6 +15,10 @@ import {
   deleteManualTaskAction,
   fetchChatMessageDetailAction,
   fetchLineMessageDetailAction,
+  updateChatAssigneesFromTaskBoard,
+  updateChatDeadlineFromTaskBoard,
+  updateLineAssigneesFromTaskBoard,
+  updateLineDeadlineFromTaskBoard,
   updateLineResponseStatusFromTaskBoard,
   updateLineTaskPriorityFromTaskBoard,
   updateManualTaskAction,
@@ -154,6 +158,10 @@ export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) 
                 onUpdateResponseStatus={updateResponseStatusFromTaskBoard}
                 onUpdateTaskPriority={updateTaskPriorityFromTaskBoard}
                 onUpdateWorkflow={updateWorkflowFromTaskBoard}
+                assignees={chatDetail.intent?.assignees ?? null}
+                deadline={chatDetail.intent?.deadline ?? null}
+                onUpdateAssignees={updateChatAssigneesFromTaskBoard}
+                onUpdateDeadline={updateChatDeadlineFromTaskBoard}
                 extraContent={
                   chatDetail.intent && (
                     <div className="mt-4">
@@ -174,6 +182,8 @@ export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) 
                 onClose={handleClose}
                 onUpdateResponseStatus={updateLineResponseStatusFromTaskBoard}
                 onUpdateTaskPriority={updateLineTaskPriorityFromTaskBoard}
+                onUpdateAssignees={updateLineAssigneesFromTaskBoard}
+                onUpdateDeadline={updateLineDeadlineFromTaskBoard}
               />
             ) : isManualTask && selectedTask ? (
               <ManualTaskDetailPane task={selectedTask} onClose={handleClose} />

--- a/apps/web/src/components/inline-edit-field.tsx
+++ b/apps/web/src/components/inline-edit-field.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import type { LucideIcon } from "lucide-react";
+import { Calendar, Check, Loader2, Pencil, Users, X } from "lucide-react";
+import { useEffect, useRef, useState, useTransition } from "react";
+import { cn } from "@/lib/utils";
+
+interface InlineEditFieldProps {
+  icon: LucideIcon;
+  label: string;
+  value: string | null;
+  placeholder: string;
+  type: "text" | "date";
+  onSave: (value: string | null) => Promise<void>;
+}
+
+/**
+ * インライン編集フィールド。
+ * 通常時はラベル+値を表示し、クリックで編集モードに切り替わる。
+ * 担当者・期限の編集に使用する共通コンポーネント。
+ */
+export function InlineEditField({
+  icon: Icon,
+  label,
+  value,
+  placeholder,
+  type,
+  onSave,
+}: InlineEditFieldProps) {
+  const [editing, setEditing] = useState(false);
+  const [localValue, setLocalValue] = useState(value ?? "");
+  const [isPending, startTransition] = useTransition();
+  const [showSaved, setShowSaved] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+
+  useEffect(() => {
+    return () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+    };
+  }, []);
+
+  const displayValue = type === "date" && value ? value.slice(0, 10) : value;
+
+  function handleSave() {
+    setEditing(false);
+    const newValue = localValue.trim() || null;
+    const saveValue = type === "date" && newValue ? `${newValue}T00:00:00+09:00` : newValue;
+
+    startTransition(async () => {
+      await onSave(saveValue);
+      setShowSaved(true);
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => setShowSaved(false), 1500);
+    });
+  }
+
+  function handleCancel() {
+    setEditing(false);
+    setLocalValue(type === "date" && value ? value.slice(0, 10) : (value ?? ""));
+  }
+
+  if (editing) {
+    return (
+      <div className="flex items-center gap-2">
+        <Icon className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+        <span className="w-14 flex-shrink-0 text-xs text-muted-foreground">{label}</span>
+        <form
+          className="flex flex-1 items-center gap-1"
+          onSubmit={(e) => {
+            e.preventDefault();
+            handleSave();
+          }}
+        >
+          <input
+            type={type}
+            value={localValue}
+            onChange={(e) => setLocalValue(e.target.value)}
+            placeholder={placeholder}
+            className="min-w-0 flex-1 rounded border border-border bg-background px-2 py-1 text-xs focus:outline-none focus:ring-1 focus:ring-[var(--gradient-from)]"
+          />
+          <button
+            type="submit"
+            className="rounded px-1.5 py-0.5 text-xs font-medium text-[var(--gradient-from)] hover:bg-accent"
+          >
+            保存
+          </button>
+          <button
+            type="button"
+            onClick={handleCancel}
+            className="rounded p-0.5 text-muted-foreground hover:bg-accent"
+          >
+            <X className="h-3.5 w-3.5" />
+          </button>
+        </form>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className="h-3.5 w-3.5 flex-shrink-0 text-muted-foreground" />
+      <span className="w-14 flex-shrink-0 text-xs text-muted-foreground">{label}</span>
+      <button
+        type="button"
+        onClick={() => {
+          setLocalValue(type === "date" && value ? value.slice(0, 10) : (value ?? ""));
+          setEditing(true);
+        }}
+        className={cn(
+          "group flex min-w-0 flex-1 items-center gap-1.5 rounded px-1.5 py-1 text-xs transition-colors hover:bg-accent",
+          isPending && "pointer-events-none opacity-50",
+        )}
+      >
+        {isPending ? (
+          <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />
+        ) : displayValue ? (
+          <span className="truncate font-medium">{displayValue}</span>
+        ) : (
+          <span className="truncate text-muted-foreground/50 italic">{placeholder}</span>
+        )}
+        <Pencil className="ml-auto h-3 w-3 flex-shrink-0 text-muted-foreground/0 transition-colors group-hover:text-muted-foreground" />
+      </button>
+      {showSaved && (
+        <span className="flex items-center gap-0.5 text-xs text-emerald-600">
+          <Check className="h-3 w-3" />
+        </span>
+      )}
+    </div>
+  );
+}
+
+/** 担当者フィールド */
+export function AssigneesField({
+  value,
+  onSave,
+}: {
+  value: string | null;
+  onSave: (v: string | null) => Promise<void>;
+}) {
+  return (
+    <InlineEditField
+      icon={Users}
+      label="担当者"
+      value={value}
+      placeholder="未設定"
+      type="text"
+      onSave={onSave}
+    />
+  );
+}
+
+/** 期限フィールド */
+export function DeadlineField({
+  value,
+  onSave,
+}: {
+  value: string | null;
+  onSave: (v: string | null) => Promise<void>;
+}) {
+  return (
+    <InlineEditField
+      icon={Calendar}
+      label="期限"
+      value={value}
+      placeholder="未設定"
+      type="date"
+      onSave={onSave}
+    />
+  );
+}

--- a/apps/web/src/components/line-message-detail-pane.tsx
+++ b/apps/web/src/components/line-message-detail-pane.tsx
@@ -2,6 +2,7 @@
 
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { X } from "lucide-react";
+import { AssigneesField, DeadlineField } from "@/components/inline-edit-field";
 import { ResponseStatusButtons } from "@/components/response-status-buttons";
 import { TaskPrioritySelector } from "@/components/task-priority-selector";
 import type { LineMessageDetail } from "@/lib/types";
@@ -12,6 +13,8 @@ interface LineMessageDetailPaneProps {
   onClose: () => void;
   onUpdateResponseStatus: (id: string, status: ResponseStatus) => Promise<void>;
   onUpdateTaskPriority: (id: string, priority: TaskPriority | null) => Promise<void>;
+  onUpdateAssignees: (id: string, assignees: string | null) => Promise<void>;
+  onUpdateDeadline: (id: string, deadline: string | null) => Promise<void>;
 }
 
 export function LineMessageDetailPane({
@@ -19,6 +22,8 @@ export function LineMessageDetailPane({
   onClose,
   onUpdateResponseStatus,
   onUpdateTaskPriority,
+  onUpdateAssignees,
+  onUpdateDeadline,
 }: LineMessageDetailPaneProps) {
   const responseStatus = message.responseStatus;
 
@@ -75,6 +80,15 @@ export function LineMessageDetailPane({
             value={message.taskPriority}
             onChange={(p) => onUpdateTaskPriority(message.id, p)}
           />
+        </div>
+
+        {/* 担当者・期限 */}
+        <div className="mt-4 space-y-2 rounded-lg border border-border/60 bg-muted/20 p-3">
+          <AssigneesField
+            value={message.assignees}
+            onSave={(v) => onUpdateAssignees(message.id, v)}
+          />
+          <DeadlineField value={message.deadline} onSave={(v) => onUpdateDeadline(message.id, v)} />
         </div>
 
         {/* メタ情報 */}

--- a/apps/web/src/components/message-detail-pane.tsx
+++ b/apps/web/src/components/message-detail-pane.tsx
@@ -4,6 +4,7 @@ import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { X } from "lucide-react";
 import type { ReactNode } from "react";
 import { AttachmentList } from "@/components/chat/attachment-list";
+import { AssigneesField, DeadlineField } from "@/components/inline-edit-field";
 import { ResponseStatusButtons } from "@/components/response-status-buttons";
 import { TaskPrioritySelector } from "@/components/task-priority-selector";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -25,6 +26,14 @@ export interface ChatMessageDetailPaneProps {
   onUpdateWorkflow: (id: string, body: WorkflowUpdateRequest) => Promise<void>;
   /** Optional slot rendered after the workflow section (e.g. HandoverForm) */
   extraContent?: ReactNode;
+  /** Assignees value from intent (for inline editing) */
+  assignees?: string | null;
+  /** Deadline value from intent (for inline editing) */
+  deadline?: string | null;
+  /** Save assignees callback */
+  onUpdateAssignees?: (id: string, assignees: string | null) => Promise<void>;
+  /** Save deadline callback */
+  onUpdateDeadline?: (id: string, deadline: string | null) => Promise<void>;
 }
 
 export function ChatMessageDetailPane({
@@ -34,6 +43,10 @@ export function ChatMessageDetailPane({
   onUpdateTaskPriority,
   onUpdateWorkflow,
   extraContent,
+  assignees,
+  deadline,
+  onUpdateAssignees,
+  onUpdateDeadline,
 }: ChatMessageDetailPaneProps) {
   const intent = message.intent as IntentDetail | null;
   const responseStatus = (intent?.responseStatus ?? "unresponded") as ResponseStatus;
@@ -105,6 +118,20 @@ export function ChatMessageDetailPane({
                 onChange={(p) => onUpdateTaskPriority(message.id, p)}
               />
             </div>
+
+            {/* 担当者・期限 */}
+            {onUpdateAssignees && onUpdateDeadline && (
+              <div className="mt-4 space-y-2 rounded-lg border border-border/60 bg-muted/20 p-3">
+                <AssigneesField
+                  value={assignees ?? null}
+                  onSave={(v) => onUpdateAssignees(message.id, v)}
+                />
+                <DeadlineField
+                  value={deadline ?? null}
+                  onSave={(v) => onUpdateDeadline(message.id, v)}
+                />
+              </div>
+            )}
 
             {/* ワークフロー */}
             {intent && (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -489,6 +489,16 @@ export function updateLineTaskPriority(id: string, taskPriority: TaskPriority | 
   );
 }
 
+export function updateLineWorkflow(
+  id: string,
+  body: { assignees?: string | null; deadline?: string | null },
+) {
+  return request<{ success: boolean }>(`/api/line-messages/${encodeURIComponent(id)}/workflow`, {
+    method: "PATCH",
+    body: JSON.stringify(body),
+  });
+}
+
 // --- Manual Tasks ---
 
 export interface ManualTaskListParams {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -357,6 +357,8 @@ export interface LineMessageSummary {
   contentUrl: string | null;
   lineMessageType: string;
   taskPriority: TaskPriority | null;
+  assignees: string | null;
+  deadline: string | null;
   responseStatus: ResponseStatus;
   createdAt: string;
 }

--- a/apps/worker/src/pipeline/process-line-message.ts
+++ b/apps/worker/src/pipeline/process-line-message.ts
@@ -82,6 +82,8 @@ export async function processLineEvent(event: LineWebhookEvent): Promise<void> {
     lineMessageType: message.type,
     rawPayload: event as unknown as Record<string, unknown>,
     taskPriority: null,
+    assignees: null,
+    deadline: null,
     responseStatus: "unresponded",
     responseStatusUpdatedBy: null,
     responseStatusUpdatedAt: null,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -299,6 +299,10 @@ export interface LineMessage {
   lineMessageType: string;
   /** タスク優先度 */
   taskPriority: "critical" | "high" | "medium" | "low" | null;
+  /** 担当者（自由入力テキスト） */
+  assignees: string | null;
+  /** 期限（ISO 8601 datetime） */
+  deadline: Timestamp | null;
   /** 対応状況（受信箱管理用） */
   responseStatus: "unresponded" | "in_progress" | "responded" | "not_required";
   /** 対応状況の最終更新者 */


### PR DESCRIPTION
## Summary

- LINE メッセージに `assignees`/`deadline` フィールドを追加（DB型・API・Web型の全レイヤー）
- `PATCH /api/line-messages/:id/workflow` エンドポイントを新設
- `InlineEditField` 共通コンポーネントを新設（クリックで編集、保存フィードバック付き）
- LINE・Google Chat 両種別の詳細ペインに担当者・期限セクションを追加（受信箱・タスクボード共通）

## Test plan

- [x] typecheck 通過 (11/11)
- [x] lint 通過
- [x] test 通過 (177テスト)
- [x] build 成功 (7/7)
- [ ] 受信箱でLINEメッセージを選択し、担当者・期限が編集できることを確認
- [ ] 受信箱でGoogle Chatメッセージを選択し、担当者・期限が編集できることを確認
- [ ] タスクボードでも同様に編集できることを確認
- [ ] 保存後に値が反映されることを確認

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)