### PR TITLE
fix: 担当者候補取得 /api/admin/users の 404 修正

### DIFF
--- a/apps/web/src/app/api/admin/users/route.ts
+++ b/apps/web/src/app/api/admin/users/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from "next/server";
+import { ApiError, getAdminUsers } from "@/lib/api";
+
+export async function GET() {
+  try {
+    const data = await getAdminUsers();
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof ApiError) {
+      return NextResponse.json({ error: e.message }, { status: e.status });
+    }
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

- `useAssigneeSuggestions` がクライアントサイドから `fetch("/api/admin/users")` を呼んでいたが、Next.js 側に対応する API route が存在せず 404 エラーになっていた
- 既存の `chat-spaces` route と同じプロキシパターンで Next.js API route を追加

## Test plan

- [x] typecheck 通過
- [x] lint 通過
- [ ] 担当者フィールドのフォーカス時に候補リストが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)