### PR TITLE
fix: DialogContent の aria-describedby 警告を修正

### DIFF
--- a/apps/web/src/app/(protected)/admin/users/user-actions.tsx
+++ b/apps/web/src/app/(protected)/admin/users/user-actions.tsx
@@ -86,7 +86,7 @@ export function UserActions({ user }: { user: AdminUser }) {
       </DropdownMenu>
 
       <Dialog open={editOpen} onOpenChange={setEditOpen}>
-        <DialogContent className="sm:max-w-sm">
+        <DialogContent className="sm:max-w-sm" aria-describedby={undefined}>
           <DialogHeader>
             <DialogTitle>表示名を編集</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
## Summary

- `DialogContent` に `aria-describedby={undefined}` を追加し、Description 未使用時のコンソール警告を解消

## Test plan

- [x] typecheck 通過
- [x] lint 通過
- [ ] ダイアログ表示時にコンソール警告が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)