### PR TITLE
feat: 手動タスク作成後に作成タスクを自動選択

### DIFF
--- a/apps/web/src/app/(protected)/task-board/manual-task-form.tsx
+++ b/apps/web/src/app/(protected)/task-board/manual-task-form.tsx
@@ -4,6 +4,7 @@ import type { TaskPriority } from "@hr-system/shared";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import { Calendar as CalendarIcon, Plus, Users } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useRef, useState, useTransition } from "react";
 import { TaskPrioritySelector } from "@/components/task-priority-selector";
 import { Button } from "@/components/ui/button";
@@ -23,6 +24,7 @@ import { cn } from "@/lib/utils";
 import { createManualTaskAction } from "./actions";
 
 export function ManualTaskCreateButton() {
+  const router = useRouter();
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [priority, setPriority] = useState<TaskPriority>("medium");
@@ -102,7 +104,7 @@ export function ManualTaskCreateButton() {
     if (!title) return;
 
     startTransition(async () => {
-      await createManualTaskAction({
+      const result = await createManualTaskAction({
         title,
         content: (formData.get("content") as string) || "",
         taskPriority: priority,
@@ -110,6 +112,15 @@ export function ManualTaskCreateButton() {
         deadline: deadline ? `${format(deadline, "yyyy-MM-dd")}T00:00:00+09:00` : null,
       });
       handleClose();
+
+      // 作成されたタスクを自動選択（詳細パネルを開く）
+      const url = new URL(window.location.href);
+      const currentSource = url.searchParams.get("source");
+      if (currentSource && currentSource !== "all" && currentSource !== "manual") {
+        url.searchParams.delete("source");
+      }
+      url.searchParams.set("id", `manual-${result.id}`);
+      router.push(url.pathname + url.search);
     });
   };
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -533,6 +533,7 @@ export function createManualTask(body: {
   taskPriority: TaskPriority;
   responseStatus?: ResponseStatus;
   assignees?: string | null;
+  deadline?: string | null;
 }) {
   return request<ManualTaskSummary>("/api/manual-tasks", {
     method: "POST",


### PR DESCRIPTION
## Summary

- 手動タスク作成後、作成されたタスクの詳細パネルを自動で開く（`router.push` で `?id=manual-{id}` に遷移）
- ソースフィルターが chat/line のみの場合、自動で「すべて」に切替えて新タスクが表示されるようにする
- `lib/api.ts` の `createManualTask` 型定義に欠落していた `deadline` フィールドを追加

## Test plan

- [x] typecheck 通過 (11/11)
- [x] lint 通過 (7/7)
- [x] test 通過 (174テスト)
- [ ] 手動タスク作成後、詳細パネルが自動で開くこと
- [ ] ソースフィルターが「Google Chat」等の場合、作成後に「すべて」に切り替わること

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)