### PR TITLE
fix: 手動タスク削除時のクライアントエラーを修正

### DIFF
--- a/apps/web/src/app/(protected)/task-board/task-board-content.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-board-content.tsx
@@ -2,6 +2,7 @@
 
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { Loader2, X } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
 import { AssigneesField, DeadlineField } from "@/components/inline-edit-field";
 import { LineMessageDetailPane } from "@/components/line-message-detail-pane";
@@ -44,6 +45,7 @@ interface Props {
  * DetailPane を表示する。
  */
 export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) {
+  const router = useRouter();
   const [selectedId, setSelectedId] = useState(initialSelectedId);
   const [chatDetail, setChatDetail] = useState<ChatMessageDetail | null>(null);
   const [lineDetail, setLineDetail] = useState<LineMessageDetail | null>(null);
@@ -54,7 +56,7 @@ export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) 
     ? (tasks.find((t) => taskCompositeId(t) === selectedId) ?? null)
     : null;
 
-  // URL 同期（ナビゲーションなし）— 初回マウントはスキップ
+  // URL 同期 — router.replace で Next.js 内部状態と整合性を保つ
   useEffect(() => {
     if (isInitialMount.current) {
       isInitialMount.current = false;
@@ -66,8 +68,8 @@ export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) 
     } else {
       url.searchParams.delete("id");
     }
-    window.history.replaceState(window.history.state ?? {}, "", url.toString());
-  }, [selectedId]);
+    router.replace(url.pathname + url.search, { scroll: false });
+  }, [selectedId, router]);
 
   // タスク選択時に詳細データを取得
   // biome-ignore lint/correctness/useExhaustiveDependencies: selectedTask 全体を依存にすると参照が毎レンダー変わり無限ループになるため id+source で制御


### PR DESCRIPTION
## Summary

- タスク作成時に `router.push` でURL遷移した後、削除時の `history.replaceState` でNext.js内部ナビゲーション状態が不整合になりクラッシュ
- URL同期を `history.replaceState` → `router.replace` に統一して解消

## Test plan

- [x] typecheck 通過 (11/11)
- [x] lint 通過 (7/7)
- [x] test 通過 (174テスト)
- [ ] 手動タスク作成 → 詳細パネル表示 → 削除でエラーが出ないこと

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)