### PR TITLE
fix: 手動タスク作成後のタスク自動選択が動作しない問題を修正

### DIFF
--- a/apps/web/src/app/(protected)/task-board/manual-task-form.tsx
+++ b/apps/web/src/app/(protected)/task-board/manual-task-form.tsx
@@ -4,7 +4,6 @@ import type { TaskPriority } from "@hr-system/shared";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import { Calendar as CalendarIcon, Plus, Users } from "lucide-react";
-import { useRouter } from "next/navigation";
 import { useRef, useState, useTransition } from "react";
 import { TaskPrioritySelector } from "@/components/task-priority-selector";
 import { Button } from "@/components/ui/button";
@@ -22,9 +21,10 @@ import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover
 import { useAssigneeSuggestions } from "@/hooks/use-assignee-suggestions";
 import { cn } from "@/lib/utils";
 import { createManualTaskAction } from "./actions";
+import { useSelectTask } from "./task-board-content";
 
 export function ManualTaskCreateButton() {
-  const router = useRouter();
+  const selectTask = useSelectTask();
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [priority, setPriority] = useState<TaskPriority>("medium");
@@ -112,15 +112,7 @@ export function ManualTaskCreateButton() {
         deadline: deadline ? `${format(deadline, "yyyy-MM-dd")}T00:00:00+09:00` : null,
       });
       handleClose();
-
-      // 作成されたタスクを自動選択（詳細パネルを開く）
-      const url = new URL(window.location.href);
-      const currentSource = url.searchParams.get("source");
-      if (currentSource && currentSource !== "all" && currentSource !== "manual") {
-        url.searchParams.delete("source");
-      }
-      url.searchParams.set("id", `manual-${result.id}`);
-      router.push(url.pathname + url.search);
+      selectTask(`manual-${result.id}`);
     });
   };
 

--- a/apps/web/src/app/(protected)/task-board/task-board-content.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-board-content.tsx
@@ -3,7 +3,15 @@
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { Loader2, X } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useCallback, useEffect, useRef, useState, useTransition } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  useTransition,
+} from "react";
 import { AssigneesField, DeadlineField } from "@/components/inline-edit-field";
 import { LineMessageDetailPane } from "@/components/line-message-detail-pane";
 import { ChatMessageDetailPane } from "@/components/message-detail-pane";
@@ -37,10 +45,14 @@ interface Props {
   children: React.ReactNode;
 }
 
+/** 子コンポーネントからタスク選択を操作するための Context */
+const SelectTaskContext = createContext<(id: string) => void>(() => {});
+export const useSelectTask = () => useContext(SelectTaskContext);
+
 /**
  * タスクボードのメインコンテンツ（クライアントコンポーネント）。
  *
- * 選択状態を useState で管理し、URL 同期は history.replaceState で行う。
+ * 選択状態を useState で管理し、URL 同期は router.replace で行う。
  * タスク選択時に Server Action 経由で詳細データを取得し、受信箱と同等の
  * DetailPane を表示する。
  */
@@ -139,7 +151,7 @@ export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) 
   const hasDetail = chatDetail || lineDetail || isManualTask;
 
   return (
-    <>
+    <SelectTaskContext.Provider value={setSelectedId}>
       {/* フィルターヘッダー（選択中はモバイルで非表示） */}
       <div
         className={cn(
@@ -218,7 +230,7 @@ export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) 
           </div>
         )}
       </div>
-    </>
+    </SelectTaskContext.Provider>
   );
 }
 


### PR DESCRIPTION
## Summary

- `startTransition` 内で `router.push` が `revalidatePath` の再レンダーと競合し、ナビゲーションが無視されていた
- `SelectTaskContext` を導入し、`setSelectedId` を直接呼び出す方式に変更
- URL同期は既存の `router.replace` effectが自動で処理

## Test plan

- [x] typecheck 通過 (11/11)
- [x] lint 通過 (7/7)
- [x] test 通過 (174テスト)
- [ ] 手動タスク作成後、詳細パネルが自動で開くこと
- [ ] タスク削除後にエラーが出ないこと（#271 の修正が維持されていること）

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)