### PR TITLE
feat: タスク一覧をテーブルビューに変更

### DIFF
--- a/apps/web/src/__tests__/task-board-interaction.test.tsx
+++ b/apps/web/src/__tests__/task-board-interaction.test.tsx
@@ -30,11 +30,21 @@ vi.mock("@/lib/constants", () => ({
     responded: "対応済",
     not_required: "対応不要",
   },
+  RESPONSE_STATUS_BADGE_COLORS: {
+    unresponded: "bg-red-100 text-red-800",
+    in_progress: "bg-yellow-100 text-yellow-800",
+    responded: "bg-green-100 text-green-800",
+    not_required: "bg-gray-100 text-gray-600",
+  },
 }));
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
   formatDateTimeJST: (d: string) => new Date(d).toLocaleString("ja-JP"),
+  formatDateJST: (d: string) => {
+    const date = new Date(d);
+    return `${String(date.getMonth() + 1).padStart(2, "0")}/${String(date.getDate()).padStart(2, "0")}`;
+  },
 }));
 
 vi.mock("next/link", () => ({
@@ -49,6 +59,8 @@ vi.mock("next/link", () => ({
 vi.mock("lucide-react", () => ({
   MessageSquareText: () => React.createElement("span", { "data-testid": "icon-gchat" }),
   MessageCircle: () => React.createElement("span", { "data-testid": "icon-line" }),
+  ClipboardEdit: () => React.createElement("span", { "data-testid": "icon-manual" }),
+  Clock: () => React.createElement("span", { "data-testid": "icon-clock" }),
   ArrowLeft: () => React.createElement("span", { "data-testid": "icon-arrow-left" }),
   ArrowUpRight: () => React.createElement("span", { "data-testid": "icon-arrow-up-right" }),
   Calendar: () => React.createElement("span", { "data-testid": "icon-calendar" }),
@@ -100,7 +112,7 @@ function renderToHtml(element: React.ReactElement): string {
 // --- テスト ---
 
 describe("TaskList onSelect コールバック", () => {
-  it("各タスクにクリック可能なボタンが描画される", () => {
+  it("各タスクにクリック可能な行が描画される", () => {
     const html = renderToHtml(
       React.createElement(TaskList, {
         tasks: [
@@ -111,9 +123,9 @@ describe("TaskList onSelect コールバック", () => {
         onSelect: mockOnSelect,
       }),
     );
-    // 2つのボタンが存在
-    const buttonCount = (html.match(/<button/g) || []).length;
-    expect(buttonCount).toBe(2);
+    // tbody 内に 2つの tr が存在（thead 1 + tbody 2）
+    const trCount = (html.match(/<tr[ >]/g) || []).length;
+    expect(trCount).toBe(3);
   });
 
   it("gchat タスクの複合ID形式が正しい（source-id）", () => {

--- a/apps/web/src/__tests__/task-board.test.tsx
+++ b/apps/web/src/__tests__/task-board.test.tsx
@@ -26,11 +26,21 @@ vi.mock("@/lib/constants", () => ({
     responded: "対応済",
     not_required: "対応不要",
   },
+  RESPONSE_STATUS_BADGE_COLORS: {
+    unresponded: "bg-red-100 text-red-800",
+    in_progress: "bg-yellow-100 text-yellow-800",
+    responded: "bg-green-100 text-green-800",
+    not_required: "bg-gray-100 text-gray-600",
+  },
 }));
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
   formatDateTimeJST: (d: string) => new Date(d).toLocaleString("ja-JP"),
+  formatDateJST: (d: string) => {
+    const date = new Date(d);
+    return `${String(date.getMonth() + 1).padStart(2, "0")}/${String(date.getDate()).padStart(2, "0")}`;
+  },
 }));
 
 vi.mock("next/link", () => ({
@@ -45,6 +55,8 @@ vi.mock("next/link", () => ({
 vi.mock("lucide-react", () => ({
   MessageSquareText: () => React.createElement("span", { "data-testid": "icon-gchat" }),
   MessageCircle: () => React.createElement("span", { "data-testid": "icon-line" }),
+  ClipboardEdit: () => React.createElement("span", { "data-testid": "icon-manual" }),
+  Clock: () => React.createElement("span", { "data-testid": "icon-clock" }),
   ArrowLeft: () => React.createElement("span", { "data-testid": "icon-arrow-left" }),
   ArrowUpRight: () => React.createElement("span", { "data-testid": "icon-arrow-up-right" }),
   Calendar: () => React.createElement("span", { "data-testid": "icon-calendar" }),
@@ -158,7 +170,7 @@ describe("TaskList", () => {
     expect(html).toContain('data-testid="icon-line"');
   });
 
-  it("タスクがボタン要素で描画され、選択時にハイライトされる", () => {
+  it("タスクがテーブル行で描画され、選択時にハイライトされる", () => {
     const html = renderToHtml(
       React.createElement(TaskList, {
         tasks: [makeTask({ id: "msg-42", source: "gchat" })],
@@ -166,9 +178,8 @@ describe("TaskList", () => {
         onSelect: mockOnSelect,
       }),
     );
-    expect(html).toContain("button");
+    expect(html).toContain("<tr");
     expect(html).toContain("bg-accent");
-    // 注: 実際のクリックイベントテストは task-board-interaction.test.tsx を参照
   });
 
   it("selectedId に一致するタスクがハイライトされる", () => {
@@ -182,7 +193,7 @@ describe("TaskList", () => {
     expect(html).toContain("bg-accent");
   });
 
-  it("critical タスクに赤い border-l が表示される", () => {
+  it("critical タスクに赤い背景が表示される", () => {
     const html = renderToHtml(
       React.createElement(TaskList, {
         tasks: [makeTask({ taskPriority: "critical" })],
@@ -190,8 +201,7 @@ describe("TaskList", () => {
         onSelect: mockOnSelect,
       }),
     );
-    expect(html).toContain("border-l-4");
-    expect(html).toContain("border-l-red-500");
+    expect(html).toContain("bg-red-50");
   });
 
   it("LINE タスクにグループ名が表示される", () => {
@@ -225,7 +235,7 @@ describe("TaskList", () => {
         onSelect: mockOnSelect,
       }),
     );
-    expect(text).toContain("担当: 佐藤花子");
+    expect(text).toContain("佐藤花子");
   });
 
   it("対応状況ラベルが表示される", () => {

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -175,7 +175,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
 
   return (
     <div className="-m-6 flex h-[calc(100vh-52px)] flex-col">
-      <TaskBoardContent tasks={paged} initialSelectedId={selectedId}>
+      <TaskBoardContent tasks={paged} initialSelectedId={selectedId} pageOffset={offset}>
         <div className="mb-2 flex items-center justify-between">
           <div className="flex items-center gap-3">
             <h1 className="text-lg font-bold tracking-tight">タスク一覧</h1>

--- a/apps/web/src/app/(protected)/task-board/task-board-content.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-board-content.tsx
@@ -42,6 +42,7 @@ import { TaskList } from "./task-list";
 interface Props {
   tasks: TaskItem[];
   initialSelectedId: string | null;
+  pageOffset?: number;
   children: React.ReactNode;
 }
 
@@ -56,7 +57,7 @@ export const useSelectTask = () => useContext(SelectTaskContext);
  * タスク選択時に Server Action 経由で詳細データを取得し、受信箱と同等の
  * DetailPane を表示する。
  */
-export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) {
+export function TaskBoardContent({ tasks, initialSelectedId, pageOffset = 0, children }: Props) {
   const router = useRouter();
   const [selectedId, setSelectedId] = useState(initialSelectedId);
   const [chatDetail, setChatDetail] = useState<ChatMessageDetail | null>(null);
@@ -162,27 +163,26 @@ export function TaskBoardContent({ tasks, initialSelectedId, children }: Props) 
         {children}
       </div>
 
-      {/* メインエリア: リスト + 詳細ペイン */}
+      {/* メインエリア: テーブル + 詳細ペイン */}
       <div className="flex flex-1 overflow-hidden">
-        {/* 左: タスク一覧 (選択中はモバイルで非表示、lg ではリスト幅を固定) */}
+        {/* テーブル一覧 (選択中はモバイルで非表示) */}
         <div
           className={cn(
-            "overflow-y-auto",
-            selectedTask
-              ? "hidden md:block md:w-[320px] md:flex-shrink-0 md:border-r md:border-border/60"
-              : "flex-1",
+            "flex-1 overflow-y-auto",
+            selectedTask && "hidden md:block md:border-r md:border-border/60",
           )}
         >
           <TaskList
             tasks={tasks}
             selectedId={selectedTask ? selectedId : null}
             onSelect={setSelectedId}
+            pageOffset={pageOffset}
           />
         </div>
 
         {/* 右: 詳細ペイン（タスク選択時のみ表示） */}
         {selectedTask && (
-          <div className="flex flex-1 overflow-hidden">
+          <div className="flex w-full md:w-[420px] md:flex-shrink-0 overflow-hidden">
             {isPending || !hasDetail ? (
               <div className="flex flex-1 items-center justify-center">
                 <div className="text-center">

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -3,7 +3,7 @@
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { ClipboardEdit, Clock, MessageCircle, MessageSquareText } from "lucide-react";
 import { TaskPriorityDot } from "@/components/task-priority-selector";
-import { RESPONSE_STATUS_DOT_COLORS, RESPONSE_STATUS_LABELS } from "@/lib/constants";
+import { RESPONSE_STATUS_BADGE_COLORS, RESPONSE_STATUS_LABELS } from "@/lib/constants";
 import { cn, formatDateJST, formatDateTimeJST } from "@/lib/utils";
 import { taskCompositeId } from "./task-composite-id";
 
@@ -21,14 +21,28 @@ export interface TaskItem {
   createdAt: string;
 }
 
+const SOURCE_LABELS: Record<TaskItem["source"], string> = {
+  gchat: "Chat",
+  line: "LINE",
+  manual: "手入力",
+};
+
+const SOURCE_ICONS: Record<TaskItem["source"], React.ReactNode> = {
+  gchat: <MessageSquareText size={12} className="text-muted-foreground" />,
+  line: <MessageCircle size={12} className="text-emerald-500" />,
+  manual: <ClipboardEdit size={12} className="text-blue-500" />,
+};
+
 export function TaskList({
   tasks,
   selectedId,
   onSelect,
+  pageOffset = 0,
 }: {
   tasks: TaskItem[];
   selectedId: string | null;
   onSelect: (id: string | null) => void;
+  pageOffset?: number;
 }) {
   if (tasks.length === 0) {
     return (
@@ -39,78 +53,130 @@ export function TaskList({
   }
 
   return (
-    <div className="divide-y divide-border/40">
-      {tasks.map((task) => {
-        const isCritical = task.taskPriority === "critical";
-        const compositeId = taskCompositeId(task);
-        const isSelected = compositeId === selectedId;
+    <div className="overflow-x-auto">
+      <table className="w-full min-w-[900px] text-xs">
+        <thead className="sticky top-0 z-10 bg-slate-50 border-b border-border/60">
+          <tr>
+            <th className="w-10 px-2 py-2.5 text-center font-semibold text-muted-foreground">No</th>
+            <th className="w-20 px-2 py-2.5 text-left font-semibold text-muted-foreground">
+              発生日
+            </th>
+            <th className="w-14 px-2 py-2.5 text-center font-semibold text-muted-foreground">
+              優先度
+            </th>
+            <th className="min-w-[200px] px-2 py-2.5 text-left font-semibold text-muted-foreground">
+              タスク内容
+            </th>
+            <th className="w-16 px-2 py-2.5 text-center font-semibold text-muted-foreground">
+              ソース
+            </th>
+            <th className="w-24 px-2 py-2.5 text-left font-semibold text-muted-foreground">
+              割り振り
+            </th>
+            <th className="w-20 px-2 py-2.5 text-center font-semibold text-muted-foreground">
+              ステータス
+            </th>
+            <th className="w-20 px-2 py-2.5 text-left font-semibold text-muted-foreground">期限</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-border/30">
+          {tasks.map((task, index) => {
+            const isCritical = task.taskPriority === "critical";
+            const compositeId = taskCompositeId(task);
+            const isSelected = compositeId === selectedId;
 
-        return (
-          <button
-            key={compositeId}
-            type="button"
-            onClick={() => onSelect(isSelected ? null : compositeId)}
-            className={cn(
-              "block w-full text-left px-5 py-3 transition-colors hover:bg-accent/50",
-              isCritical && "border-l-4 border-l-red-500 bg-red-50/50 hover:bg-red-50",
-              isSelected && !isCritical && "bg-accent",
-              isSelected && isCritical && "bg-red-100/70",
-            )}
-          >
-            <div className="flex items-center gap-2">
-              {/* 対応状況ドット */}
-              <span
+            return (
+              <tr
+                key={compositeId}
+                tabIndex={0}
+                aria-selected={isSelected}
+                onClick={() => onSelect(isSelected ? null : compositeId)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelect(isSelected ? null : compositeId);
+                  }
+                }}
                 className={cn(
-                  "h-2 w-2 flex-shrink-0 rounded-full",
-                  RESPONSE_STATUS_DOT_COLORS[task.responseStatus],
+                  "cursor-pointer transition-colors hover:bg-accent/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+                  isCritical && "bg-red-50/60 hover:bg-red-50",
+                  isSelected && !isCritical && "bg-accent",
+                  isSelected && isCritical && "bg-red-100/70",
                 )}
-              />
-              {/* 優先度 */}
-              <TaskPriorityDot priority={task.taskPriority} />
-              {/* 送信者名 */}
-              <span className={cn("text-xs font-medium", isCritical && "text-red-800")}>
-                {task.senderName}
-              </span>
-              {/* ソースアイコン */}
-              {task.source === "gchat" ? (
-                <MessageSquareText size={12} className="text-muted-foreground" />
-              ) : task.source === "line" ? (
-                <MessageCircle size={12} className="text-emerald-500" />
-              ) : (
-                <ClipboardEdit size={12} className="text-blue-500" />
-              )}
-              {task.groupName && (
-                <span className="text-xs text-muted-foreground">@ {task.groupName}</span>
-              )}
-              {/* 対応状況 */}
-              <span className="ml-auto text-xs text-muted-foreground">
-                {RESPONSE_STATUS_LABELS[task.responseStatus]}
-              </span>
-              <span className="text-xs text-muted-foreground">
-                {formatDateTimeJST(task.createdAt)}
-              </span>
-            </div>
+              >
+                {/* No */}
+                <td className="px-2 py-2.5 text-center tabular-nums text-muted-foreground">
+                  {pageOffset + index + 1}
+                </td>
 
-            {/* タスク概要 or メッセージ */}
-            <p
-              className={cn(
-                "mt-1 line-clamp-2 text-xs",
-                isCritical ? "text-red-700" : "text-muted-foreground",
-              )}
-            >
-              {task.taskSummary || task.content}
-            </p>
+                {/* 発生日 */}
+                <td className="px-2 py-2.5 whitespace-nowrap tabular-nums text-muted-foreground">
+                  {formatDateTimeJST(task.createdAt)}
+                </td>
 
-            {/* 担当者・期限 */}
-            {(task.assignees || task.deadline) && (
-              <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
-                {task.assignees && <span>担当: {task.assignees}</span>}
-                {task.deadline && <DeadlineBadge deadline={task.deadline} />}
-              </div>
-            )}
-          </button>
-        );
-      })}
+                {/* 優先度 */}
+                <td className="px-2 py-2.5 text-center">
+                  <TaskPriorityDot priority={task.taskPriority} />
+                </td>
+
+                {/* タスク内容 */}
+                <td className="px-2 py-2.5">
+                  <div className="flex items-center gap-1.5">
+                    <span className={cn("font-medium", isCritical && "text-red-800")}>
+                      {task.senderName}
+                    </span>
+                    {task.groupName && (
+                      <span className="text-muted-foreground">@ {task.groupName}</span>
+                    )}
+                  </div>
+                  <p
+                    className={cn(
+                      "mt-0.5 line-clamp-2 leading-relaxed",
+                      isCritical ? "text-red-700" : "text-muted-foreground",
+                    )}
+                  >
+                    {task.taskSummary || task.content}
+                  </p>
+                </td>
+
+                {/* ソース */}
+                <td className="px-2 py-2.5 text-center">
+                  <span className="inline-flex items-center gap-1">
+                    {SOURCE_ICONS[task.source]}
+                    <span className="text-muted-foreground">{SOURCE_LABELS[task.source]}</span>
+                  </span>
+                </td>
+
+                {/* 割り振り */}
+                <td className="px-2 py-2.5 text-muted-foreground">
+                  {task.assignees || <span className="text-muted-foreground/40">—</span>}
+                </td>
+
+                {/* ステータス */}
+                <td className="px-2 py-2.5 text-center">
+                  <span
+                    className={cn(
+                      "inline-block rounded-full px-2 py-0.5 text-[10px] font-medium",
+                      RESPONSE_STATUS_BADGE_COLORS[task.responseStatus],
+                    )}
+                  >
+                    {RESPONSE_STATUS_LABELS[task.responseStatus]}
+                  </span>
+                </td>
+
+                {/* 期限 */}
+                <td className="px-2 py-2.5 whitespace-nowrap">
+                  {task.deadline ? (
+                    <DeadlineBadge deadline={task.deadline} />
+                  ) : (
+                    <span className="text-muted-foreground/40">—</span>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- タスク一覧をカード型リストビューからスプレッドシート風テーブルビューに変更
- 列構成: No / 発生日 / 優先度 / タスク内容 / ソース / 割り振り / ステータス / 期限
- 詳細パネル（右側420px）はそのまま維持、テーブルとの併用表示

## Changes
- `task-list.tsx`: `<button>` カード → `<table>` + `<tr>` テーブル行に全面書き換え
- `task-board-content.tsx`: レイアウト調整（左パネル固定幅320px → flex-1テーブル、右パネル420px固定）
- `page.tsx`: pageOffset プロパティを追加（テーブルの連番表示用）
- テスト2ファイル: テーブル構造に合わせてアサーション更新、lucide-reactモック追加

## Test plan
- [x] typecheck: 全パッケージ通過
- [x] lint: エラーなし
- [x] test: web 14ファイル 174テスト全通過
- [ ] ブラウザで確認: テーブル表示、行クリック→詳細パネル、フィルタリング、ページネーション

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)