### PR TITLE
feat: タスクボードにAIカテゴリタグ表示とカテゴリフィルタを追加

### DIFF
--- a/apps/web/src/__tests__/task-board-interaction.test.tsx
+++ b/apps/web/src/__tests__/task-board-interaction.test.tsx
@@ -35,6 +35,18 @@ vi.mock("@/lib/constants", () => ({
     responded: "bg-green-100 text-green-800",
     not_required: "bg-gray-100 text-gray-600",
   },
+  CATEGORY_LABELS: {
+    salary: "給与・社保",
+    retirement: "退職・休職",
+    hiring: "入社・採用",
+    contract: "契約変更",
+    transfer: "施設・異動",
+    foreigner: "外国人・ビザ",
+    training: "研修・監査",
+    health_check: "健康診断",
+    attendance: "勤怠・休暇",
+    other: "その他",
+  },
 }));
 
 vi.mock("@/lib/utils", () => ({
@@ -85,6 +97,7 @@ function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
     deadline: null,
     groupName: null,
     chatUrl: null,
+    category: null,
     createdAt: "2026-03-01T09:00:00Z",
     ...overrides,
   };

--- a/apps/web/src/__tests__/task-board.test.tsx
+++ b/apps/web/src/__tests__/task-board.test.tsx
@@ -31,6 +31,18 @@ vi.mock("@/lib/constants", () => ({
     responded: "bg-green-100 text-green-800",
     not_required: "bg-gray-100 text-gray-600",
   },
+  CATEGORY_LABELS: {
+    salary: "給与・社保",
+    retirement: "退職・休職",
+    hiring: "入社・採用",
+    contract: "契約変更",
+    transfer: "施設・異動",
+    foreigner: "外国人・ビザ",
+    training: "研修・監査",
+    health_check: "健康診断",
+    attendance: "勤怠・休暇",
+    other: "その他",
+  },
 }));
 
 vi.mock("@/lib/utils", () => ({
@@ -90,6 +102,7 @@ function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
     deadline: null,
     groupName: null,
     chatUrl: null,
+    category: null,
     createdAt: "2026-03-01T09:00:00Z",
     ...overrides,
   };
@@ -269,5 +282,29 @@ describe("TaskList", () => {
     expect(html).toContain("記事のコピー");
     expect(html).toContain("URL");
     expect(html).toContain(">タスク<");
+  });
+
+  it("カテゴリがある場合にバッジが表示される", () => {
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ category: "salary" })],
+        selectedId: null,
+        onSelect: mockOnSelect,
+      }),
+    );
+    expect(html).toContain("給与・社保");
+  });
+
+  it("カテゴリが null の場合はダッシュが表示される", () => {
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ category: null })],
+        selectedId: null,
+        onSelect: mockOnSelect,
+      }),
+    );
+    expect(html).toContain("カテゴリ");
+    // カテゴリ列にダッシュ（バッジなし）
+    expect(html).not.toContain("給与・社保");
   });
 });

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -1,7 +1,9 @@
-import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
+import type { ChatCategory, ResponseStatus, TaskPriority } from "@hr-system/shared";
+import { CHAT_CATEGORIES } from "@hr-system/shared";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { getChatMessages, getLineMessages, getManualTasks } from "@/lib/api";
+import { CATEGORY_LABELS } from "@/lib/constants";
 import { ManualTaskCreateButton } from "./manual-task-form";
 import { TaskBoardContent } from "./task-board-content";
 import type { TaskItem } from "./task-list";
@@ -30,6 +32,11 @@ const STATUS_TABS: { value: ResponseStatus | "all"; label: string }[] = [
   { value: "responded", label: "対応済" },
 ];
 
+const CATEGORY_TABS: { value: ChatCategory | "all"; label: string }[] = [
+  { value: "all", label: "すべて" },
+  ...CHAT_CATEGORIES.map((c) => ({ value: c, label: CATEGORY_LABELS[c] ?? c })),
+];
+
 const PRIORITY_ORDER: Record<TaskPriority, number> = {
   critical: 0,
   high: 1,
@@ -44,6 +51,7 @@ interface Props {
     priority?: string;
     source?: string;
     status?: string;
+    category?: string;
     page?: string;
     id?: string;
   }>;
@@ -54,6 +62,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
   const priorityFilter = (params.priority as TaskPriority | undefined) ?? undefined;
   const sourceFilter: Source = (params.source as Source) ?? "all";
   const statusFilter = (params.status as ResponseStatus | undefined) ?? undefined;
+  const categoryFilter = (params.category as ChatCategory | undefined) ?? undefined;
   const page = Math.max(1, Number(params.page) || 1);
   const selectedId = params.id ?? null;
 
@@ -87,6 +96,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         deadline: msg.intent?.deadline ?? null,
         groupName: null,
         chatUrl: `https://chat.google.com/room/${msg.spaceId}/${msg.googleMessageId}`,
+        category: msg.intent?.category ?? null,
         createdAt: msg.createdAt,
       });
     }
@@ -107,6 +117,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         deadline: msg.deadline ?? null,
         groupName: msg.groupName,
         chatUrl: null,
+        category: null,
         createdAt: msg.createdAt,
       });
     }
@@ -126,6 +137,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         deadline: task.deadline,
         groupName: null,
         chatUrl: null,
+        category: null,
         createdAt: task.createdAt,
       });
     }
@@ -138,6 +150,9 @@ export default async function TaskBoardPage({ searchParams }: Props) {
   }
   if (statusFilter) {
     filtered = filtered.filter((t) => t.responseStatus === statusFilter);
+  }
+  if (categoryFilter) {
+    filtered = filtered.filter((t) => t.category === categoryFilter);
   }
 
   // 優先度順 → 日時降順でソート
@@ -159,16 +174,19 @@ export default async function TaskBoardPage({ searchParams }: Props) {
     priority?: string;
     source?: string;
     status?: string;
+    category?: string;
     page?: string;
   }) {
     const sp = new URLSearchParams();
     const p = "priority" in overrides ? overrides.priority : params.priority;
     const src = "source" in overrides ? overrides.source : params.source;
     const s = "status" in overrides ? overrides.status : params.status;
+    const cat = "category" in overrides ? overrides.category : params.category;
     const pg = "page" in overrides ? overrides.page : params.page;
     if (p && p !== "all") sp.set("priority", p);
     if (src && src !== "all") sp.set("source", src);
     if (s && s !== "all") sp.set("status", s);
+    if (cat && cat !== "all") sp.set("category", cat);
     if (pg && pg !== "1") sp.set("page", pg);
     // フィルター切替時は選択を維持
     if (params.id) sp.set("id", params.id);
@@ -248,6 +266,26 @@ export default async function TaskBoardPage({ searchParams }: Props) {
                   })}
                   className={`inline-flex items-center rounded-lg px-2.5 py-1 text-xs font-medium transition-colors ${
                     isActive ? "bg-slate-700 text-white" : "text-slate-500 hover:bg-slate-100"
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+          </div>
+          <span className="text-slate-300">|</span>
+          <div className="flex flex-wrap gap-1">
+            {CATEGORY_TABS.map((tab) => {
+              const isActive = tab.value === "all" ? !categoryFilter : categoryFilter === tab.value;
+              return (
+                <Link
+                  key={tab.value}
+                  href={buildUrl({
+                    category: tab.value === "all" ? undefined : tab.value,
+                    page: "1",
+                  })}
+                  className={`inline-flex items-center rounded-lg px-2.5 py-1 text-xs font-medium transition-colors ${
+                    isActive ? "bg-slate-600 text-white" : "text-slate-500 hover:bg-slate-100"
                   }`}
                 >
                   {tab.label}

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -3,7 +3,11 @@
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { ClipboardEdit, Clock, ExternalLink, MessageCircle, MessageSquareText } from "lucide-react";
 import { TaskPriorityDot } from "@/components/task-priority-selector";
-import { RESPONSE_STATUS_BADGE_COLORS, RESPONSE_STATUS_LABELS } from "@/lib/constants";
+import {
+  CATEGORY_LABELS,
+  RESPONSE_STATUS_BADGE_COLORS,
+  RESPONSE_STATUS_LABELS,
+} from "@/lib/constants";
 import { cn, formatDateJST, formatDateTimeJST } from "@/lib/utils";
 import { taskCompositeId } from "./task-composite-id";
 
@@ -19,6 +23,7 @@ export interface TaskItem {
   deadline: string | null;
   groupName: string | null;
   chatUrl: string | null;
+  category: string | null;
   createdAt: string;
 }
 
@@ -55,7 +60,7 @@ export function TaskList({
 
   return (
     <div className="overflow-x-auto">
-      <table className="w-full min-w-[1100px] text-xs">
+      <table className="w-full min-w-[1200px] text-xs">
         <thead className="sticky top-0 z-10 bg-slate-50 border-b border-border/60">
           <tr>
             <th className="w-10 px-2 py-2.5 text-center font-semibold text-muted-foreground">No</th>
@@ -76,6 +81,9 @@ export function TaskList({
             </th>
             <th className="w-16 px-2 py-2.5 text-center font-semibold text-muted-foreground">
               ソース
+            </th>
+            <th className="w-20 px-2 py-2.5 text-center font-semibold text-muted-foreground">
+              カテゴリ
             </th>
             <th className="w-24 px-2 py-2.5 text-left font-semibold text-muted-foreground">
               割り振り
@@ -186,6 +194,17 @@ export function TaskList({
                     {SOURCE_ICONS[task.source]}
                     <span className="text-muted-foreground">{SOURCE_LABELS[task.source]}</span>
                   </span>
+                </td>
+
+                {/* カテゴリ */}
+                <td className="px-2 py-2.5 text-center">
+                  {task.category ? (
+                    <span className="inline-block rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-700">
+                      {CATEGORY_LABELS[task.category] ?? task.category}
+                    </span>
+                  ) : (
+                    <span className="text-muted-foreground/40">—</span>
+                  )}
                 </td>
 
                 {/* 割り振り */}


### PR DESCRIPTION
## Summary
- テーブルにカテゴリバッジ列を追加（ソース列の後）
- 10カテゴリのフィルタUI追加（既存のソース・ステータスフィルタと同列）
- ChatMessage の `intent.category` から自動マッピング、LINE・手入力タスクは「—」表示
- `TaskItem` に `category: string | null` フィールド追加

Closes #278

## Test plan
- [x] 全161テスト通過（apps/web）
- [x] typecheck 全通過
- [x] カテゴリバッジ表示テスト追加
- [x] カテゴリ null 時のダッシュ表示テスト追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)