### PR TITLE
fix: タスクボードのフィルターUIをドロップダウンに最適化 (#285)

### DIFF
--- a/apps/web/src/app/(protected)/task-board/filter-select.tsx
+++ b/apps/web/src/app/(protected)/task-board/filter-select.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+
+interface FilterOption {
+  value: string;
+  label: string;
+}
+
+export function FilterSelect({
+  options,
+  currentValue,
+  buildUrl,
+  className,
+}: {
+  options: FilterOption[];
+  currentValue: string;
+  buildUrl: (value: string) => string;
+  className?: string;
+}) {
+  const router = useRouter();
+
+  return (
+    <select
+      value={currentValue}
+      onChange={(e) => router.push(buildUrl(e.target.value))}
+      className={`rounded-md border border-slate-200 bg-white px-2 py-1 text-xs font-medium text-slate-700 outline-none transition-colors hover:border-slate-300 focus:border-slate-400 focus:ring-1 focus:ring-slate-300 ${className ?? ""}`}
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -4,6 +4,7 @@ import { ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { getChatMessages, getLineMessages, getManualTasks } from "@/lib/api";
 import { CATEGORY_LABELS } from "@/lib/constants";
+import { FilterSelect } from "./filter-select";
 import { ManualTaskCreateButton } from "./manual-task-form";
 import { TaskBoardContent } from "./task-board-content";
 import type { TaskItem } from "./task-list";
@@ -203,102 +204,34 @@ export default async function TaskBoardPage({ searchParams }: Props) {
   return (
     <div className="-m-6 flex h-[calc(100vh-52px)] flex-col">
       <TaskBoardContent tasks={paged} initialSelectedId={selectedId} pageOffset={offset}>
-        <div className="mb-2 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <h1 className="text-lg font-bold tracking-tight">タスク一覧</h1>
-            <ManualTaskCreateButton />
+        <div className="flex items-center gap-3">
+          <h1 className="text-base font-bold tracking-tight">タスク一覧</h1>
+          <ManualTaskCreateButton />
+          <div className="flex items-center gap-2">
+            <FilterSelect
+              options={PRIORITY_TABS}
+              currentValue={priorityFilter ?? "all"}
+              buildUrl={(v) => buildUrl({ priority: v === "all" ? undefined : v, page: "1" })}
+            />
+            <FilterSelect
+              options={SOURCE_TABS}
+              currentValue={sourceFilter}
+              buildUrl={(v) => buildUrl({ source: v === "all" ? undefined : v, page: "1" })}
+            />
+            <FilterSelect
+              options={STATUS_TABS}
+              currentValue={statusFilter ?? "all"}
+              buildUrl={(v) => buildUrl({ status: v === "all" ? undefined : v, page: "1" })}
+            />
+            <FilterSelect
+              options={CATEGORY_TABS}
+              currentValue={categoryFilter ?? "all"}
+              buildUrl={(v) => buildUrl({ category: v === "all" ? undefined : v, page: "1" })}
+            />
           </div>
-          <span className="text-xs text-muted-foreground">
+          <span className="ml-auto text-xs tabular-nums text-muted-foreground">
             {totalCount}件{criticalCount > 0 && ` (極高 ${criticalCount}件)`}
           </span>
-        </div>
-
-        {/* フィルター: 優先度 */}
-        <div className="mb-2 flex flex-wrap gap-1.5">
-          {PRIORITY_TABS.map((tab) => {
-            const isActive = tab.value === "all" ? !priorityFilter : priorityFilter === tab.value;
-            return (
-              <Link
-                key={tab.value}
-                href={buildUrl({
-                  priority: tab.value === "all" ? undefined : tab.value,
-                  page: "1",
-                })}
-                className={`inline-flex items-center rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
-                  isActive
-                    ? tab.value === "critical"
-                      ? "bg-red-600 text-white"
-                      : "bg-slate-900 text-white"
-                    : "border border-slate-200 bg-white text-slate-600 hover:bg-slate-100"
-                }`}
-              >
-                {tab.label}
-              </Link>
-            );
-          })}
-        </div>
-
-        {/* フィルター: ソース + ステータス */}
-        <div className="flex flex-wrap items-center gap-3">
-          <div className="flex gap-1">
-            {SOURCE_TABS.map((tab) => {
-              const isActive = sourceFilter === tab.value;
-              return (
-                <Link
-                  key={tab.value}
-                  href={buildUrl({
-                    source: tab.value === "all" ? undefined : tab.value,
-                    page: "1",
-                  })}
-                  className={`inline-flex items-center rounded-lg px-2.5 py-1 text-xs font-medium transition-colors ${
-                    isActive ? "bg-slate-800 text-white" : "text-slate-500 hover:bg-slate-100"
-                  }`}
-                >
-                  {tab.label}
-                </Link>
-              );
-            })}
-          </div>
-          <span className="text-slate-300">|</span>
-          <div className="flex gap-1">
-            {STATUS_TABS.map((tab) => {
-              const isActive = tab.value === "all" ? !statusFilter : statusFilter === tab.value;
-              return (
-                <Link
-                  key={tab.value}
-                  href={buildUrl({
-                    status: tab.value === "all" ? undefined : tab.value,
-                    page: "1",
-                  })}
-                  className={`inline-flex items-center rounded-lg px-2.5 py-1 text-xs font-medium transition-colors ${
-                    isActive ? "bg-slate-700 text-white" : "text-slate-500 hover:bg-slate-100"
-                  }`}
-                >
-                  {tab.label}
-                </Link>
-              );
-            })}
-          </div>
-          <span className="text-slate-300">|</span>
-          <div className="flex flex-wrap gap-1">
-            {CATEGORY_TABS.map((tab) => {
-              const isActive = tab.value === "all" ? !categoryFilter : categoryFilter === tab.value;
-              return (
-                <Link
-                  key={tab.value}
-                  href={buildUrl({
-                    category: tab.value === "all" ? undefined : tab.value,
-                    page: "1",
-                  })}
-                  className={`inline-flex items-center rounded-lg px-2.5 py-1 text-xs font-medium transition-colors ${
-                    isActive ? "bg-slate-600 text-white" : "text-slate-500 hover:bg-slate-100"
-                  }`}
-                >
-                  {tab.label}
-                </Link>
-              );
-            })}
-          </div>
         </div>
       </TaskBoardContent>
 


### PR DESCRIPTION
## Summary
- フィルターUI（優先度・ソース・ステータス・カテゴリ）を3行のピル型タブ → 1行のドロップダウン4つに圧縮
- テーブル表示領域を約100px拡大
- `FilterSelect` Client Componentを追加（ネイティブ`<select>` + `router.push`）、page.tsx の Server Component データ取得ロジックは維持

Closes #285

## 変更ファイル（2ファイル, +62/-93行）
| ファイル | 変更内容 |
|---------|---------| 
| `task-board/filter-select.tsx` | 新規: ネイティブselect + router.push のClient Component |
| `task-board/page.tsx` | フィルターUIをドロップダウン1行に置換 |

## Test plan
- [x] `pnpm typecheck` — 11/11 成功
- [x] `pnpm lint` — エラーなし
- [x] `pnpm test` — 166テスト全通過
- [ ] ブラウザで4つのドロップダウンが1行に収まることを確認
- [ ] 各フィルター変更でURLパラメータが正しく更新されることを確認
- [ ] フィルター組み合わせ（優先度+ステータス等）が正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)