### PR TITLE
fix: タスクボードの本番Server Componentsレンダリングエラーを修正

### DIFF
--- a/apps/web/src/__tests__/filter-select.test.ts
+++ b/apps/web/src/__tests__/filter-select.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { buildFilterUrl } from "../app/(protected)/task-board/filter-select";
+
+describe("buildFilterUrl", () => {
+  it("フィルターなしでallを選択するとクエリなしURLを返す", () => {
+    expect(buildFilterUrl({}, "priority", "all")).toBe("/task-board");
+  });
+
+  it("priorityをhighに変更するとクエリに反映される", () => {
+    expect(buildFilterUrl({}, "priority", "high")).toBe("/task-board?priority=high");
+  });
+
+  it("既存のsearchParamsが保持される", () => {
+    const url = buildFilterUrl({ source: "gchat", id: "msg-1" }, "priority", "high");
+    expect(url).toContain("source=gchat");
+    expect(url).toContain("priority=high");
+    expect(url).toContain("id=msg-1");
+  });
+
+  it("allに変更すると該当パラメータが除外される", () => {
+    const url = buildFilterUrl({ priority: "high", source: "gchat" }, "priority", "all");
+    expect(url).not.toContain("priority");
+    expect(url).toContain("source=gchat");
+  });
+
+  it("pageは常に1にリセットされクエリに含まれない", () => {
+    const url = buildFilterUrl({ page: "3" }, "status", "unresponded");
+    expect(url).not.toContain("page");
+    expect(url).toContain("status=unresponded");
+  });
+});

--- a/apps/web/src/app/(protected)/task-board/filter-select.tsx
+++ b/apps/web/src/app/(protected)/task-board/filter-select.tsx
@@ -7,15 +7,34 @@ interface FilterOption {
   label: string;
 }
 
+/** フィルター変更時のURL構築（テスト用にexport） */
+export function buildFilterUrl(
+  searchParams: Record<string, string>,
+  paramKey: string,
+  value: string,
+): string {
+  const sp = new URLSearchParams();
+  const merged = { ...searchParams, [paramKey]: value, page: "1" };
+  for (const [k, v] of Object.entries(merged)) {
+    if (v && v !== "all" && !(k === "page" && v === "1")) {
+      sp.set(k, v);
+    }
+  }
+  const qs = sp.toString();
+  return `/task-board${qs ? `?${qs}` : ""}`;
+}
+
 export function FilterSelect({
   options,
   currentValue,
-  buildUrl,
+  paramKey,
+  searchParams,
   className,
 }: {
   options: FilterOption[];
   currentValue: string;
-  buildUrl: (value: string) => string;
+  paramKey: string;
+  searchParams: Record<string, string>;
   className?: string;
 }) {
   const router = useRouter();
@@ -23,7 +42,7 @@ export function FilterSelect({
   return (
     <select
       value={currentValue}
-      onChange={(e) => router.push(buildUrl(e.target.value))}
+      onChange={(e) => router.push(buildFilterUrl(searchParams, paramKey, e.target.value))}
       className={`rounded-md border border-slate-200 bg-white px-2 py-1 text-xs font-medium text-slate-700 outline-none transition-colors hover:border-slate-300 focus:border-slate-400 focus:ring-1 focus:ring-slate-300 ${className ?? ""}`}
     >
       {options.map((opt) => (

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -177,6 +177,14 @@ export default async function TaskBoardPage({ searchParams }: Props) {
   const paged = filtered.slice(offset, offset + PAGE_SIZE);
   const hasMore = offset + PAGE_SIZE < totalCount;
 
+  // FilterSelect（Client Component）に渡すシリアライズ可能なsearchParams
+  const filterParams: Record<string, string> = {};
+  if (params.priority) filterParams.priority = params.priority;
+  if (params.source) filterParams.source = params.source;
+  if (params.status) filterParams.status = params.status;
+  if (params.category) filterParams.category = params.category;
+  if (params.id) filterParams.id = params.id;
+
   function buildUrl(overrides: {
     priority?: string;
     source?: string;
@@ -211,22 +219,26 @@ export default async function TaskBoardPage({ searchParams }: Props) {
             <FilterSelect
               options={PRIORITY_TABS}
               currentValue={priorityFilter ?? "all"}
-              buildUrl={(v) => buildUrl({ priority: v === "all" ? undefined : v, page: "1" })}
+              paramKey="priority"
+              searchParams={filterParams}
             />
             <FilterSelect
               options={SOURCE_TABS}
               currentValue={sourceFilter}
-              buildUrl={(v) => buildUrl({ source: v === "all" ? undefined : v, page: "1" })}
+              paramKey="source"
+              searchParams={filterParams}
             />
             <FilterSelect
               options={STATUS_TABS}
               currentValue={statusFilter ?? "all"}
-              buildUrl={(v) => buildUrl({ status: v === "all" ? undefined : v, page: "1" })}
+              paramKey="status"
+              searchParams={filterParams}
             />
             <FilterSelect
               options={CATEGORY_TABS}
               currentValue={categoryFilter ?? "all"}
-              buildUrl={(v) => buildUrl({ category: v === "all" ? undefined : v, page: "1" })}
+              paramKey="category"
+              searchParams={filterParams}
             />
           </div>
           <span className="ml-auto text-xs tabular-nums text-muted-foreground">


### PR DESCRIPTION
## Summary
- Server Component（task-board/page.tsx）からClient Component（FilterSelect）に`buildUrl`関数をpropsとして渡していたため、本番環境で`Functions cannot be passed directly to Client Components`エラー（Digest: 3691376371）が発生
- URL構築ロジックをClient Component側に移動し、シリアライズ可能な`paramKey`+`searchParams`を渡す方式に変更
- `buildFilterUrl`を純粋関数としてexportし、ユニットテスト5件を追加

## Test plan
- [x] TypeScript型チェック通過（11/11）
- [x] Biome lint エラーなし
- [x] 全テスト通過（171/171、FilterSelect新規5件含む）
- [ ] デプロイ後、タスクボードページが正常表示されることを確認
- [ ] フィルター切替（優先度/ソース/ステータス/カテゴリ）が正常動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)