### PR TITLE
feat: LINE・手入力タスクにワークフローステップとメモを追加

### DIFF
--- a/apps/api/src/lib/schemas.ts
+++ b/apps/api/src/lib/schemas.ts
@@ -1,0 +1,11 @@
+import { WORKFLOW_STEP_STATUSES } from "@hr-system/shared";
+import { z } from "zod";
+
+export const workflowStepStatusSchema = z.enum(WORKFLOW_STEP_STATUSES);
+
+export const workflowStepsSchema = z.object({
+  salaryListReflection: workflowStepStatusSchema,
+  smartHRReflection: workflowStepStatusSchema,
+  noticeExecution: workflowStepStatusSchema,
+  laborLawyerShare: workflowStepStatusSchema,
+});

--- a/apps/api/src/routes/chat-messages.ts
+++ b/apps/api/src/routes/chat-messages.ts
@@ -5,7 +5,6 @@ import {
   type ChatCategory,
   RESPONSE_STATUSES,
   TASK_PRIORITIES,
-  WORKFLOW_STEP_STATUSES,
   type WorkflowSteps,
 } from "@hr-system/shared";
 import { FieldPath, FieldValue, Timestamp } from "firebase-admin/firestore";
@@ -14,6 +13,7 @@ import { z } from "zod";
 import { clearCache, getCached, setCache, TTL } from "../lib/cache.js";
 import { notFound } from "../lib/errors.js";
 import { parsePagination } from "../lib/pagination.js";
+import { workflowStepsSchema } from "../lib/schemas.js";
 import { toISO, toISOOrNull } from "../lib/serialize.js";
 
 const listQuerySchema = z.object({
@@ -741,22 +741,13 @@ chatMessageRoutes.patch(
 // ---------------------------------------------------------------------------
 // PATCH /api/chat-messages/:id/workflow — 「作成案」ワークフロー管理フィールド更新
 // ---------------------------------------------------------------------------
-const workflowStepStatusSchema = z.enum(WORKFLOW_STEP_STATUSES);
-
 const patchWorkflowSchema = z.object({
   taskPriority: z.enum(TASK_PRIORITIES).nullable().optional(),
   taskSummary: z.string().max(500).nullable().optional(),
   assignees: z.string().max(200).nullable().optional(),
   deadline: z.string().datetime({ offset: true }).nullable().optional(),
   notes: z.string().max(2000).nullable().optional(),
-  workflowSteps: z
-    .object({
-      salaryListReflection: workflowStepStatusSchema,
-      noticeExecution: workflowStepStatusSchema,
-      laborLawyerShare: workflowStepStatusSchema,
-      smartHRReflection: workflowStepStatusSchema,
-    })
-    .optional(),
+  workflowSteps: workflowStepsSchema.optional(),
 });
 
 chatMessageRoutes.patch("/:id/workflow", zValidator("json", patchWorkflowSchema), async (c) => {

--- a/apps/api/src/routes/line-messages.ts
+++ b/apps/api/src/routes/line-messages.ts
@@ -1,12 +1,13 @@
 import { zValidator } from "@hono/zod-validator";
 import { collections } from "@hr-system/db";
 import { RESPONSE_STATUSES, TASK_PRIORITIES } from "@hr-system/shared";
-import { Timestamp } from "firebase-admin/firestore";
+import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { Hono } from "hono";
 import { z } from "zod";
 import { clearCache, getCached, setCache, TTL } from "../lib/cache.js";
 import { notFound } from "../lib/errors.js";
 import { parsePagination } from "../lib/pagination.js";
+import { workflowStepsSchema } from "../lib/schemas.js";
 import { toISO } from "../lib/serialize.js";
 
 const listQuerySchema = z.object({
@@ -64,6 +65,8 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
         assignees: (msg.assignees as string) ?? null,
         deadline: msg.deadline ? toISO(msg.deadline as FirebaseFirestore.Timestamp) : null,
         responseStatus: (msg.responseStatus as string) ?? "unresponded",
+        workflowSteps: (msg.workflowSteps as Record<string, unknown>) ?? null,
+        notes: (msg.notes as string) ?? null,
         createdAt: toISO(msg.createdAt as FirebaseFirestore.Timestamp),
       };
     });
@@ -105,6 +108,8 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
       assignees: (msg.assignees as string) ?? null,
       deadline: msg.deadline ? toISO(msg.deadline as FirebaseFirestore.Timestamp) : null,
       responseStatus: (msg.responseStatus as string) ?? "unresponded",
+      workflowSteps: (msg.workflowSteps as Record<string, unknown>) ?? null,
+      notes: (msg.notes as string) ?? null,
       createdAt: toISO(msg.createdAt as FirebaseFirestore.Timestamp),
     };
   });
@@ -283,14 +288,21 @@ lineMessageRoutes.patch(
 // ---------------------------------------------------------------------------
 // PATCH /api/line-messages/:id/workflow — 担当者・期限更新
 // ---------------------------------------------------------------------------
-const updateWorkflowSchema = z.object({
-  assignees: z.string().nullable().optional(),
-  deadline: z.string().datetime({ offset: true }).nullable().optional(),
-});
+const updateWorkflowSchema = z
+  .object({
+    assignees: z.string().nullable().optional(),
+    deadline: z.string().datetime({ offset: true }).nullable().optional(),
+    notes: z.string().max(2000).nullable().optional(),
+    workflowSteps: workflowStepsSchema.optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: "更新するフィールドを1つ以上指定してください",
+  });
 
 lineMessageRoutes.patch("/:id/workflow", zValidator("json", updateWorkflowSchema), async (c) => {
   const id = c.req.param("id");
   const body = c.req.valid("json");
+  const actor = c.get("user");
   const actorRole = c.get("actorRole");
 
   if (!actorRole || !["hr_staff", "hr_manager", "ceo"].includes(actorRole)) {
@@ -307,6 +319,14 @@ lineMessageRoutes.patch("/:id/workflow", zValidator("json", updateWorkflowSchema
   }
   if ("deadline" in body) {
     updates.deadline = body.deadline ? Timestamp.fromDate(new Date(body.deadline)) : null;
+  }
+  if (body.notes !== undefined) {
+    updates.notes = body.notes;
+  }
+  if (body.workflowSteps !== undefined) {
+    updates.workflowSteps = body.workflowSteps;
+    updates.workflowUpdatedBy = actor.email;
+    updates.workflowUpdatedAt = FieldValue.serverTimestamp();
   }
 
   if (Object.keys(updates).length > 0) {

--- a/apps/api/src/routes/manual-tasks.ts
+++ b/apps/api/src/routes/manual-tasks.ts
@@ -7,6 +7,7 @@ import { Hono } from "hono";
 import { z } from "zod";
 import { forbidden, notFound } from "../lib/errors.js";
 import { parsePagination } from "../lib/pagination.js";
+import { workflowStepsSchema } from "../lib/schemas.js";
 import { toISO, toISOOrNull } from "../lib/serialize.js";
 
 const createSchema = z.object({
@@ -26,6 +27,8 @@ const updateSchema = z
     responseStatus: z.enum(RESPONSE_STATUSES),
     assignees: z.string().max(200).nullable(),
     deadline: z.string().datetime({ offset: true }).nullable(),
+    notes: z.string().max(2000).nullable(),
+    workflowSteps: workflowStepsSchema,
   })
   .partial()
   .refine((data) => Object.keys(data).length > 0, {
@@ -48,6 +51,8 @@ function serialize(id: string, data: ManualTask) {
     responseStatus: data.responseStatus,
     assignees: data.assignees,
     deadline: toISOOrNull(data.deadline),
+    workflowSteps: data.workflowSteps ?? null,
+    notes: data.notes ?? null,
     createdBy: data.createdBy,
     createdByName: data.createdByName,
     createdAt: toISO(data.createdAt),
@@ -151,6 +156,12 @@ app.patch("/:id", zValidator("json", updateSchema), async (c) => {
   if (body.assignees !== undefined) updateData.assignees = body.assignees;
   if (body.deadline !== undefined)
     updateData.deadline = body.deadline ? Timestamp.fromDate(new Date(body.deadline)) : null;
+  if (body.notes !== undefined) updateData.notes = body.notes;
+  if (body.workflowSteps !== undefined) {
+    updateData.workflowSteps = body.workflowSteps;
+    updateData.workflowUpdatedBy = user.email;
+    updateData.workflowUpdatedAt = FieldValue.serverTimestamp();
+  }
 
   await docRef.update(updateData);
 

--- a/apps/web/src/__tests__/api-contract.test.ts
+++ b/apps/web/src/__tests__/api-contract.test.ts
@@ -30,6 +30,8 @@ import type {
   EmployeeSummary,
   IntentDetail,
   IntentSummary,
+  LineMessageSummary,
+  ManualTaskSummary,
 } from "../lib/types";
 
 // ---------------------------------------------------------------------------
@@ -479,5 +481,102 @@ describe("EmployeeDetail 契約", () => {
       },
     };
     expect(withSalary.currentSalary).not.toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 契約テスト: LineMessageSummary — workflowSteps / notes 対応
+// ---------------------------------------------------------------------------
+
+describe("LineMessageSummary 契約", () => {
+  const sampleLineMessage: LineMessageSummary = {
+    id: "line-001",
+    groupId: "group-001",
+    groupName: "有川チーム",
+    senderUserId: "U1234567890",
+    senderName: "佐藤 花子",
+    content: "給与変更をお願いします",
+    contentUrl: null,
+    lineMessageType: "text",
+    taskPriority: "medium",
+    assignees: null,
+    deadline: null,
+    responseStatus: "unresponded",
+    workflowSteps: null,
+    notes: null,
+    createdAt: "2026-03-01T09:00:00.000Z",
+  };
+
+  it("workflowSteps と notes フィールドが存在すること", () => {
+    expect(hasAllKeys(sampleLineMessage, ["workflowSteps", "notes"])).toBe(true);
+  });
+
+  it("workflowSteps が null 許容で WorkflowSteps 型を受け付けること", () => {
+    expect(sampleLineMessage.workflowSteps).toBeNull();
+
+    const withSteps: LineMessageSummary = {
+      ...sampleLineMessage,
+      workflowSteps: {
+        salaryListReflection: "completed",
+        smartHRReflection: "undetermined",
+        noticeExecution: "undetermined",
+        laborLawyerShare: "not_required",
+      },
+    };
+    expect(withSteps.workflowSteps).not.toBeNull();
+    expect(withSteps.workflowSteps?.salaryListReflection).toBe("completed");
+  });
+
+  it("notes が null 許容で string を受け付けること", () => {
+    expect(sampleLineMessage.notes).toBeNull();
+    const withNotes: LineMessageSummary = { ...sampleLineMessage, notes: "テストメモ" };
+    expect(withNotes.notes).toBe("テストメモ");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 契約テスト: ManualTaskSummary — workflowSteps / notes 対応
+// ---------------------------------------------------------------------------
+
+describe("ManualTaskSummary 契約", () => {
+  const sampleManualTask: ManualTaskSummary = {
+    id: "manual-001",
+    title: "手入力タスク",
+    content: "詳細メモ",
+    taskPriority: "high",
+    responseStatus: "unresponded",
+    assignees: null,
+    deadline: null,
+    workflowSteps: null,
+    notes: null,
+    createdBy: "admin@example.com",
+    createdByName: "管理者",
+    createdAt: "2026-03-01T09:00:00.000Z",
+    updatedAt: "2026-03-01T09:00:00.000Z",
+  };
+
+  it("workflowSteps と notes フィールドが存在すること", () => {
+    expect(hasAllKeys(sampleManualTask, ["workflowSteps", "notes"])).toBe(true);
+  });
+
+  it("workflowSteps が null 許容で WorkflowSteps 型を受け付けること", () => {
+    expect(sampleManualTask.workflowSteps).toBeNull();
+
+    const withSteps: ManualTaskSummary = {
+      ...sampleManualTask,
+      workflowSteps: {
+        salaryListReflection: "undetermined",
+        smartHRReflection: "completed",
+        noticeExecution: "pending",
+        laborLawyerShare: "undetermined",
+      },
+    };
+    expect(withSteps.workflowSteps).not.toBeNull();
+  });
+
+  it("notes が null 許容で string を受け付けること", () => {
+    expect(sampleManualTask.notes).toBeNull();
+    const withNotes: ManualTaskSummary = { ...sampleManualTask, notes: "手入力メモ" };
+    expect(withNotes.notes).toBe("手入力メモ");
   });
 });

--- a/apps/web/src/__tests__/task-board.test.tsx
+++ b/apps/web/src/__tests__/task-board.test.tsx
@@ -365,17 +365,61 @@ describe("TaskList", () => {
     expect(html).toContain("ー");
   });
 
-  it("LINE タスクではワークフローステップがダッシュ表示される", () => {
+  it("LINE タスクでもワークフローステップボタンが表示される", () => {
     const html = renderToHtml(
       React.createElement(TaskList, {
-        tasks: [makeTask({ source: "line", workflowSteps: null })],
+        tasks: [
+          makeTask({
+            source: "line",
+            workflowSteps: {
+              salaryListReflection: "completed",
+              smartHRReflection: "undetermined",
+              noticeExecution: "undetermined",
+              laborLawyerShare: "undetermined",
+            },
+          }),
+        ],
         selectedId: null,
         onSelect: mockOnSelect,
       }),
     );
-    // ボタンではなくダッシュ（button タグが ❶❷❸❹ 列に存在しない）
-    // LINE の場合、ワークフローステップのボタンは描画されない
-    expect(html).not.toContain("bg-emerald-50");
+    // completed ステップの ✓ が表示される（ボタンとして）
+    expect(html).toContain("✓");
+    expect(html).toContain("<button");
+  });
+
+  it("手入力タスクでもワークフローステップボタンが表示される", () => {
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [
+          makeTask({
+            source: "manual",
+            workflowSteps: {
+              salaryListReflection: "undetermined",
+              smartHRReflection: "undetermined",
+              noticeExecution: "completed",
+              laborLawyerShare: "undetermined",
+            },
+          }),
+        ],
+        selectedId: null,
+        onSelect: mockOnSelect,
+      }),
+    );
+    expect(html).toContain("✓");
+    expect(html).toContain("<button");
+  });
+
+  it("LINE タスクでもメモ textarea が表示される", () => {
+    const html = renderToHtml(
+      React.createElement(TaskList, {
+        tasks: [makeTask({ source: "line", notes: "LINEメモ" })],
+        selectedId: null,
+        onSelect: mockOnSelect,
+      }),
+    );
+    expect(html).toContain("LINEメモ");
+    expect(html).toContain("<textarea");
   });
 
   it("gchat タスクにメモ textarea が表示される", () => {

--- a/apps/web/src/app/(protected)/task-board/actions.ts
+++ b/apps/web/src/app/(protected)/task-board/actions.ts
@@ -19,6 +19,7 @@ import type {
   ChatMessageDetail,
   LineMessageDetail,
   ManualTaskSummary,
+  WorkflowSteps,
   WorkflowUpdateRequest,
 } from "@/lib/types";
 
@@ -147,6 +148,25 @@ export async function updateLineDeadlineFromTaskBoard(messageId: string, deadlin
   await requireAccess();
   await updateLineWorkflow(messageId, { deadline });
   revalidatePath("/inbox");
+  revalidatePath("/task-board");
+}
+
+export async function updateLineWorkflowFromTaskBoard(
+  messageId: string,
+  body: { workflowSteps?: WorkflowSteps; notes?: string | null },
+) {
+  await requireAccess();
+  await updateLineWorkflow(messageId, body);
+  revalidatePath("/inbox");
+  revalidatePath("/task-board");
+}
+
+export async function updateManualWorkflowFromTaskBoard(
+  id: string,
+  body: { workflowSteps?: WorkflowSteps; notes?: string | null },
+) {
+  await requireAccess();
+  await updateManualTask(id, body);
   revalidatePath("/task-board");
 }
 

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -121,8 +121,8 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         groupName: msg.groupName,
         chatUrl: null,
         category: null,
-        workflowSteps: null,
-        notes: null,
+        workflowSteps: msg.workflowSteps ?? null,
+        notes: msg.notes ?? null,
         createdAt: msg.createdAt,
       });
     }
@@ -143,8 +143,8 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         groupName: null,
         chatUrl: null,
         category: null,
-        workflowSteps: null,
-        notes: null,
+        workflowSteps: task.workflowSteps ?? null,
+        notes: task.notes ?? null,
         createdAt: task.createdAt,
       });
     }

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -11,7 +11,11 @@ import {
 } from "@/lib/constants";
 import { cn, formatDateJST, formatDateTimeJST } from "@/lib/utils";
 import { DEFAULT_STEPS, nextStepStatus, STEP_CONFIG, STEP_KEYS } from "@/lib/workflow-steps";
-import { updateWorkflowFromTaskBoard } from "./actions";
+import {
+  updateLineWorkflowFromTaskBoard,
+  updateManualWorkflowFromTaskBoard,
+  updateWorkflowFromTaskBoard,
+} from "./actions";
 import { taskCompositeId } from "./task-composite-id";
 
 export interface TaskItem {
@@ -159,8 +163,6 @@ function TaskRow({
   const isCritical = task.taskPriority === "critical";
   const compositeId = taskCompositeId(task);
   const isSelected = compositeId === selectedId;
-  const isGchat = task.source === "gchat";
-
   const [isPending, startTransition] = useTransition();
   const [localSteps, setLocalSteps] = useState<WorkflowSteps>(
     task.workflowSteps ?? { ...DEFAULT_STEPS },
@@ -174,12 +176,30 @@ function TaskRow({
     setSavedNotes(task.notes ?? "");
   }, [task.workflowSteps, task.notes]);
 
+  const saveWorkflow = async (body: { workflowSteps?: WorkflowSteps; notes?: string | null }) => {
+    switch (task.source) {
+      case "gchat":
+        await updateWorkflowFromTaskBoard(task.id, body);
+        break;
+      case "line":
+        await updateLineWorkflowFromTaskBoard(task.id, body);
+        break;
+      case "manual":
+        await updateManualWorkflowFromTaskBoard(task.id, body);
+        break;
+      default: {
+        const _exhaustive: never = task.source;
+        throw new Error(`Unknown source: ${_exhaustive}`);
+      }
+    }
+  };
+
   const handleStep = (key: keyof WorkflowSteps) => {
     const next = nextStepStatus(localSteps[key]);
     const newSteps = { ...localSteps, [key]: next };
     setLocalSteps(newSteps);
     startTransition(async () => {
-      await updateWorkflowFromTaskBoard(task.id, { workflowSteps: newSteps });
+      await saveWorkflow({ workflowSteps: newSteps });
     });
   };
 
@@ -187,7 +207,7 @@ function TaskRow({
     if (localNotes === savedNotes) return;
     setSavedNotes(localNotes);
     startTransition(async () => {
-      await updateWorkflowFromTaskBoard(task.id, { notes: localNotes || null });
+      await saveWorkflow({ notes: localNotes || null });
     });
   };
 
@@ -323,39 +343,31 @@ function TaskRow({
       {/* ❶〜❹ ワークフローステップ */}
       {STEP_KEYS.map((key) => (
         <td key={key} className="px-1 py-2.5 text-center">
-          {isGchat ? (
-            <button
-              type="button"
-              onClick={(e) => {
-                e.stopPropagation();
-                handleStep(key);
-              }}
-              disabled={isPending}
-              className={`w-8 cursor-pointer rounded px-1 py-0.5 text-xs transition-opacity hover:opacity-80 ${STEP_CONFIG[localSteps[key]].cls}`}
-            >
-              {STEP_CONFIG[localSteps[key]].label}
-            </button>
-          ) : (
-            <span className="text-muted-foreground/40">—</span>
-          )}
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              handleStep(key);
+            }}
+            disabled={isPending}
+            className={`w-8 cursor-pointer rounded px-1 py-0.5 text-xs transition-opacity hover:opacity-80 ${STEP_CONFIG[localSteps[key]].cls}`}
+          >
+            {STEP_CONFIG[localSteps[key]].label}
+          </button>
         </td>
       ))}
 
       {/* メモ */}
       <td className="px-2 py-1">
-        {isGchat ? (
-          <textarea
-            rows={1}
-            value={localNotes}
-            onChange={(e) => setLocalNotes(e.target.value)}
-            onBlur={handleNotesBlur}
-            onClick={(e) => e.stopPropagation()}
-            placeholder="メモ"
-            className="w-full resize-none rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-foreground/80 placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
-          />
-        ) : (
-          <span className="text-muted-foreground/40">—</span>
-        )}
+        <textarea
+          rows={1}
+          value={localNotes}
+          onChange={(e) => setLocalNotes(e.target.value)}
+          onBlur={handleNotesBlur}
+          onClick={(e) => e.stopPropagation()}
+          placeholder="メモ"
+          className="w-full resize-none rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-foreground/80 placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
+        />
       </td>
     </tr>
   );

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -28,6 +28,7 @@ import type {
   SyncStatus,
   TestClassificationResult,
   TimelinePoint,
+  WorkflowSteps,
   WorkflowUpdateRequest,
 } from "@/lib/types";
 
@@ -495,7 +496,12 @@ export function updateLineTaskPriority(id: string, taskPriority: TaskPriority | 
 
 export function updateLineWorkflow(
   id: string,
-  body: { assignees?: string | null; deadline?: string | null },
+  body: {
+    assignees?: string | null;
+    deadline?: string | null;
+    notes?: string | null;
+    workflowSteps?: WorkflowSteps;
+  },
 ) {
   return request<{ success: boolean }>(`/api/line-messages/${encodeURIComponent(id)}/workflow`, {
     method: "PATCH",
@@ -553,6 +559,8 @@ export function updateManualTask(
     taskPriority?: TaskPriority;
     responseStatus?: ResponseStatus;
     assignees?: string | null;
+    notes?: string | null;
+    workflowSteps?: WorkflowSteps;
   },
 ) {
   return request<ManualTaskSummary>(`/api/manual-tasks/${encodeURIComponent(id)}`, {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -360,6 +360,8 @@ export interface LineMessageSummary {
   assignees: string | null;
   deadline: string | null;
   responseStatus: ResponseStatus;
+  workflowSteps: WorkflowSteps | null;
+  notes: string | null;
   createdAt: string;
 }
 
@@ -387,6 +389,8 @@ export interface ManualTaskSummary {
   responseStatus: ResponseStatus;
   assignees: string | null;
   deadline: string | null;
+  workflowSteps: WorkflowSteps | null;
+  notes: string | null;
   createdBy: string;
   createdByName: string;
   createdAt: string;

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -309,6 +309,14 @@ export interface LineMessage {
   responseStatusUpdatedBy: string | null;
   /** 対応状況の最終更新日時 */
   responseStatusUpdatedAt: Timestamp | null;
+  /** ワークフローステップ（❶❷❸❹） */
+  workflowSteps?: WorkflowSteps | null;
+  /** メモ */
+  notes?: string | null;
+  /** ワークフロー最終更新者 */
+  workflowUpdatedBy?: string | null;
+  /** ワークフロー最終更新日時 */
+  workflowUpdatedAt?: Timestamp | null;
   /** 生ペイロード（将来の再解析用） */
   rawPayload: Record<string, unknown>;
   createdAt: Timestamp;
@@ -360,6 +368,14 @@ export interface ManualTask {
   assignees: string | null;
   /** 期限（任意） */
   deadline: Timestamp | null;
+  /** ワークフローステップ（❶❷❸❹） */
+  workflowSteps?: WorkflowSteps | null;
+  /** メモ */
+  notes?: string | null;
+  /** ワークフロー最終更新者 */
+  workflowUpdatedBy?: string | null;
+  /** ワークフロー最終更新日時 */
+  workflowUpdatedAt?: Timestamp | null;
   /** 作成者メール */
   createdBy: string;
   /** 作成者表示名 */


### PR DESCRIPTION
## Summary
- LINE・手入力タスクでもワークフローステップ（❶SS反映 ❷SmartHR ❸通知締結 ❹社労士共有）とメモが使えるように全5層を拡張
- workflowSteps Zodスキーマの3重複を `apps/api/src/lib/schemas.ts` に共通化
- `Timestamp.now()` → `FieldValue.serverTimestamp()` に統一（クロックスキュー防止）
- `saveWorkflow` dispatch を exhaustive switch に変更（将来のソース追加時にコンパイルエラーで検知）

## Test plan
- [x] TDD: Red→Green→Refactor で実装（契約テスト6件 + UIテスト3件追加）
- [x] typecheck 11/11 通過
- [x] lint 7/7 通過
- [x] test 348件全通過（api 169 + web 179）
- [ ] 本番デプロイ後、LINE/手入力タスクでステップ切替とメモ保存を動作確認

Closes #284

🤖 Generated with [Claude Code](https://claude.com/claude-code)