### PR TITLE
feat: 受信箱カテゴリフィルター & 手入力タスクカテゴリ選択

### DIFF
--- a/apps/api/src/routes/manual-tasks.ts
+++ b/apps/api/src/routes/manual-tasks.ts
@@ -1,7 +1,7 @@
 import { zValidator } from "@hono/zod-validator";
 import type { ManualTask } from "@hr-system/db";
 import { collections } from "@hr-system/db";
-import { RESPONSE_STATUSES, TASK_PRIORITIES } from "@hr-system/shared";
+import { CHAT_CATEGORIES, RESPONSE_STATUSES, TASK_PRIORITIES } from "@hr-system/shared";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -15,6 +15,7 @@ const createSchema = z.object({
   content: z.string().max(2000).optional().default(""),
   taskPriority: z.enum(TASK_PRIORITIES),
   responseStatus: z.enum(RESPONSE_STATUSES).optional().default("unresponded"),
+  category: z.enum(CHAT_CATEGORIES).nullable().optional().default(null),
   assignees: z.string().max(200).nullable().optional().default(null),
   deadline: z.string().datetime({ offset: true }).nullable().optional().default(null),
 });
@@ -25,6 +26,7 @@ const updateSchema = z
     content: z.string().max(2000),
     taskPriority: z.enum(TASK_PRIORITIES),
     responseStatus: z.enum(RESPONSE_STATUSES),
+    category: z.enum(CHAT_CATEGORIES).nullable(),
     assignees: z.string().max(200).nullable(),
     deadline: z.string().datetime({ offset: true }).nullable(),
     notes: z.string().max(2000).nullable(),
@@ -38,6 +40,7 @@ const updateSchema = z
 const listQuerySchema = z.object({
   taskPriority: z.enum(TASK_PRIORITIES).optional(),
   responseStatus: z.enum(RESPONSE_STATUSES).optional(),
+  category: z.enum(CHAT_CATEGORIES).optional(),
   limit: z.string().optional(),
   offset: z.string().optional(),
 });
@@ -49,6 +52,7 @@ function serialize(id: string, data: ManualTask) {
     content: data.content,
     taskPriority: data.taskPriority,
     responseStatus: data.responseStatus,
+    category: data.category ?? null,
     assignees: data.assignees,
     deadline: toISOOrNull(data.deadline),
     workflowSteps: data.workflowSteps ?? null,
@@ -64,7 +68,7 @@ const app = new Hono();
 
 // GET /api/manual-tasks
 app.get("/", zValidator("query", listQuerySchema), async (c) => {
-  const { taskPriority, responseStatus } = c.req.valid("query");
+  const { taskPriority, responseStatus, category } = c.req.valid("query");
   const { limit, offset } = parsePagination(c.req.query());
 
   let query = collections.manualTasks.orderBy(
@@ -73,6 +77,7 @@ app.get("/", zValidator("query", listQuerySchema), async (c) => {
   ) as FirebaseFirestore.Query<ManualTask>;
   if (taskPriority) query = query.where("taskPriority", "==", taskPriority);
   if (responseStatus) query = query.where("responseStatus", "==", responseStatus);
+  if (category) query = query.where("category", "==", category);
 
   const [countSnap, docsSnap] = await Promise.all([
     query.count().get(),
@@ -100,6 +105,7 @@ app.post("/", zValidator("json", createSchema), async (c) => {
     content: data.content,
     taskPriority: data.taskPriority,
     responseStatus: data.responseStatus,
+    category: data.category,
     assignees: data.assignees,
     deadline: data.deadline ? Timestamp.fromDate(new Date(data.deadline)) : null,
     createdBy: user.email,
@@ -153,6 +159,7 @@ app.patch("/:id", zValidator("json", updateSchema), async (c) => {
   if (body.content !== undefined) updateData.content = body.content;
   if (body.taskPriority !== undefined) updateData.taskPriority = body.taskPriority;
   if (body.responseStatus !== undefined) updateData.responseStatus = body.responseStatus;
+  if (body.category !== undefined) updateData.category = body.category;
   if (body.assignees !== undefined) updateData.assignees = body.assignees;
   if (body.deadline !== undefined)
     updateData.deadline = body.deadline ? Timestamp.fromDate(new Date(body.deadline)) : null;

--- a/apps/web/src/__tests__/api-contract.test.ts
+++ b/apps/web/src/__tests__/api-contract.test.ts
@@ -545,6 +545,7 @@ describe("ManualTaskSummary 契約", () => {
     content: "詳細メモ",
     taskPriority: "high",
     responseStatus: "unresponded",
+    category: null,
     assignees: null,
     deadline: null,
     workflowSteps: null,

--- a/apps/web/src/app/(protected)/inbox/page.tsx
+++ b/apps/web/src/app/(protected)/inbox/page.tsx
@@ -1,4 +1,5 @@
-import type { ResponseStatus } from "@hr-system/shared";
+import type { ChatCategory, ResponseStatus } from "@hr-system/shared";
+
 import { ChevronLeft, ChevronRight, MessageCircle, MessageSquareText } from "lucide-react";
 import Link from "next/link";
 import {
@@ -10,6 +11,7 @@ import {
   getLineMessage,
   getLineMessages,
 } from "@/lib/api";
+import { CATEGORY_OPTIONS } from "@/lib/constants";
 import type { ChatMessageDetail, LineMessageDetail } from "@/lib/types";
 import { Inbox3Pane } from "./inbox-3pane";
 import { LineInbox3Pane } from "./line-inbox-3pane";
@@ -20,6 +22,7 @@ interface Props {
   searchParams: Promise<{
     source?: string;
     status?: string;
+    category?: string;
     page?: string;
     id?: string;
   }>;
@@ -44,18 +47,27 @@ export default async function InboxPage({ searchParams }: Props) {
   const params = await searchParams;
   const source: Source = params.source === "line" ? "line" : "gchat";
   const activeStatus = (params.status as ResponseStatus | undefined) ?? undefined;
+  const activeCategory = (params.category as ChatCategory | undefined) ?? undefined;
   const page = Math.max(1, Number(params.page) || 1);
   const offset = (page - 1) * PAGE_SIZE;
   const selectedId = params.id ?? null;
 
-  function buildUrl(overrides: { source?: string; status?: string; page?: string; id?: string }) {
+  function buildUrl(overrides: {
+    source?: string;
+    status?: string;
+    category?: string;
+    page?: string;
+    id?: string;
+  }) {
     const sp = new URLSearchParams();
     const src = "source" in overrides ? overrides.source : params.source;
     const s = "status" in overrides ? overrides.status : params.status;
+    const cat = "category" in overrides ? overrides.category : params.category;
     const p = overrides.page;
     const id = "id" in overrides ? overrides.id : params.id;
     if (src && src !== "gchat") sp.set("source", src);
     if (s && s !== "all") sp.set("status", s);
+    if (cat && cat !== "all") sp.set("category", cat);
     if (p && p !== "1") sp.set("page", p);
     if (id) sp.set("id", id);
     const qs = sp.toString();
@@ -73,7 +85,12 @@ export default async function InboxPage({ searchParams }: Props) {
 
   if (source === "gchat") {
     const [msgResult, countResult, selectedResult] = await Promise.all([
-      getChatMessages({ responseStatus: activeStatus, limit: PAGE_SIZE, offset }),
+      getChatMessages({
+        responseStatus: activeStatus,
+        category: activeCategory,
+        limit: PAGE_SIZE,
+        offset,
+      }),
       getInboxCounts(),
       selectedId
         ? getChatMessage(selectedId).catch((err) => {
@@ -136,6 +153,7 @@ export default async function InboxPage({ searchParams }: Props) {
                 href={buildUrl({
                   source: tab.value,
                   status: undefined,
+                  category: undefined,
                   page: "1",
                   id: undefined,
                 })}
@@ -150,8 +168,8 @@ export default async function InboxPage({ searchParams }: Props) {
           })}
         </div>
 
-        {/* ステータスタブ */}
-        <div className="flex flex-wrap gap-1.5">
+        {/* ステータスタブ + カテゴリフィルター */}
+        <div className="flex flex-wrap items-center gap-1.5">
           {STATUS_TABS.map((tab) => {
             const isActive = tab.value === "all" ? !activeStatus : activeStatus === tab.value;
             const count = getCount(tab.value);
@@ -180,6 +198,36 @@ export default async function InboxPage({ searchParams }: Props) {
               </Link>
             );
           })}
+
+          {/* カテゴリフィルター（Google Chat のみ） */}
+          {source === "gchat" && (
+            <>
+              <span className="mx-1 h-4 w-px bg-slate-200" />
+              <div className="flex flex-wrap gap-1">
+                {CATEGORY_OPTIONS.map((opt) => {
+                  const isActive =
+                    opt.value === "all" ? !activeCategory : activeCategory === opt.value;
+                  return (
+                    <Link
+                      key={opt.value}
+                      href={buildUrl({
+                        category: opt.value === "all" ? undefined : opt.value,
+                        page: "1",
+                        id: undefined,
+                      })}
+                      className={`rounded-full px-2.5 py-1 text-[10px] font-medium transition-colors ${
+                        isActive
+                          ? "bg-slate-700 text-white"
+                          : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                      }`}
+                    >
+                      {opt.label}
+                    </Link>
+                  );
+                })}
+              </div>
+            </>
+          )}
         </div>
       </div>
 

--- a/apps/web/src/app/(protected)/task-board/actions.ts
+++ b/apps/web/src/app/(protected)/task-board/actions.ts
@@ -87,6 +87,7 @@ export async function createManualTaskAction(body: {
   content?: string;
   taskPriority: TaskPriority;
   responseStatus?: ResponseStatus;
+  category?: string | null;
   assignees?: string | null;
   deadline?: string | null;
 }): Promise<ManualTaskSummary> {

--- a/apps/web/src/app/(protected)/task-board/manual-task-form.tsx
+++ b/apps/web/src/app/(protected)/task-board/manual-task-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import type { TaskPriority } from "@hr-system/shared";
+import type { ChatCategory, TaskPriority } from "@hr-system/shared";
+import { CHAT_CATEGORIES } from "@hr-system/shared";
 import { format } from "date-fns";
 import { ja } from "date-fns/locale";
 import { Calendar as CalendarIcon, Plus, Users } from "lucide-react";
@@ -19,6 +20,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { useAssigneeSuggestions } from "@/hooks/use-assignee-suggestions";
+import { CATEGORY_LABELS } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { createManualTaskAction } from "./actions";
 import { useSelectTask } from "./task-board-content";
@@ -28,6 +30,7 @@ export function ManualTaskCreateButton() {
   const [open, setOpen] = useState(false);
   const [isPending, startTransition] = useTransition();
   const [priority, setPriority] = useState<TaskPriority>("medium");
+  const [category, setCategory] = useState<ChatCategory | null>(null);
   const [deadline, setDeadline] = useState<Date | undefined>(undefined);
   const [calendarOpen, setCalendarOpen] = useState(false);
   const [assigneeValue, setAssigneeValue] = useState("");
@@ -45,6 +48,7 @@ export function ManualTaskCreateButton() {
 
   function resetForm() {
     setPriority("medium");
+    setCategory(null);
     setDeadline(undefined);
     setAssigneeValue("");
     setShowSuggestions(false);
@@ -108,6 +112,7 @@ export function ManualTaskCreateButton() {
         title,
         content: (formData.get("content") as string) || "",
         taskPriority: priority,
+        category,
         assignees: assigneeValue.trim() || null,
         deadline: deadline ? `${format(deadline, "yyyy-MM-dd")}T00:00:00+09:00` : null,
       });
@@ -278,10 +283,31 @@ export function ManualTaskCreateButton() {
               </div>
             </div>
 
-            {/* 優先度 */}
-            <div className="space-y-1.5">
-              <Label>優先度</Label>
-              <TaskPrioritySelector value={priority} onChange={(p) => setPriority(p ?? "medium")} />
+            {/* カテゴリ + 優先度（2カラム） */}
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5">
+                <Label htmlFor="task-category">カテゴリ</Label>
+                <select
+                  id="task-category"
+                  value={category ?? ""}
+                  onChange={(e) => setCategory((e.target.value || null) as ChatCategory | null)}
+                  className="border-input h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs transition-[color,box-shadow] focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:outline-none focus-visible:ring-[3px]"
+                >
+                  <option value="">未分類</option>
+                  {CHAT_CATEGORIES.map((c) => (
+                    <option key={c} value={c}>
+                      {CATEGORY_LABELS[c] ?? c}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div className="space-y-1.5">
+                <Label>優先度</Label>
+                <TaskPrioritySelector
+                  value={priority}
+                  onChange={(p) => setPriority(p ?? "medium")}
+                />
+              </div>
             </div>
 
             <DialogFooter>

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -1,9 +1,9 @@
 import type { ChatCategory, ResponseStatus, TaskPriority } from "@hr-system/shared";
-import { CHAT_CATEGORIES } from "@hr-system/shared";
+
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { getChatMessages, getLineMessages, getManualTasks } from "@/lib/api";
-import { CATEGORY_LABELS } from "@/lib/constants";
+import { CATEGORY_OPTIONS } from "@/lib/constants";
 import { FilterSelect } from "./filter-select";
 import { ManualTaskCreateButton } from "./manual-task-form";
 import { TaskBoardContent } from "./task-board-content";
@@ -31,11 +31,6 @@ const STATUS_TABS: { value: ResponseStatus | "all"; label: string }[] = [
   { value: "unresponded", label: "未対応" },
   { value: "in_progress", label: "対応中" },
   { value: "responded", label: "対応済" },
-];
-
-const CATEGORY_TABS: { value: ChatCategory | "all"; label: string }[] = [
-  { value: "all", label: "すべて" },
-  ...CHAT_CATEGORIES.map((c) => ({ value: c, label: CATEGORY_LABELS[c] ?? c })),
 ];
 
 const PRIORITY_ORDER: Record<TaskPriority, number> = {
@@ -142,7 +137,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         deadline: task.deadline,
         groupName: null,
         chatUrl: null,
-        category: null,
+        category: task.category ?? null,
         workflowSteps: task.workflowSteps ?? null,
         notes: task.notes ?? null,
         createdAt: task.createdAt,
@@ -235,7 +230,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
               searchParams={filterParams}
             />
             <FilterSelect
-              options={CATEGORY_TABS}
+              options={CATEGORY_OPTIONS}
               currentValue={categoryFilter ?? "all"}
               paramKey="category"
               searchParams={filterParams}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -514,6 +514,7 @@ export function updateLineWorkflow(
 export interface ManualTaskListParams {
   taskPriority?: TaskPriority;
   responseStatus?: ResponseStatus;
+  category?: string;
   limit?: number;
   offset?: number;
 }
@@ -522,6 +523,7 @@ export function getManualTasks(params?: ManualTaskListParams) {
   const sp = new URLSearchParams();
   if (params?.taskPriority) sp.set("taskPriority", params.taskPriority);
   if (params?.responseStatus) sp.set("responseStatus", params.responseStatus);
+  if (params?.category) sp.set("category", params.category);
   if (params?.limit) sp.set("limit", String(params.limit));
   if (params?.offset) sp.set("offset", String(params.offset));
   const qs = sp.toString();
@@ -542,6 +544,7 @@ export function createManualTask(body: {
   content?: string;
   taskPriority: TaskPriority;
   responseStatus?: ResponseStatus;
+  category?: string | null;
   assignees?: string | null;
   deadline?: string | null;
 }) {

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -1,4 +1,5 @@
-import type { ResponseStatus } from "@hr-system/shared";
+import type { ChatCategory, ResponseStatus } from "@hr-system/shared";
+import { CHAT_CATEGORIES } from "@hr-system/shared";
 
 /** カテゴリ日本語ラベル */
 export const CATEGORY_LABELS: Record<string, string> = {
@@ -37,6 +38,12 @@ export const RESPONSE_STATUS_DOT_COLORS: Record<ResponseStatus, string> = {
   responded: "bg-green-500",
   not_required: "bg-gray-400",
 };
+
+/** カテゴリフィルター選択肢（"すべて" + 10カテゴリ） */
+export const CATEGORY_OPTIONS: { value: ChatCategory | "all"; label: string }[] = [
+  { value: "all", label: "すべて" },
+  ...CHAT_CATEGORIES.map((c) => ({ value: c, label: CATEGORY_LABELS[c] ?? c })),
+];
 
 /** 金額フォーマット */
 export function formatCurrency(n: number): string {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -387,6 +387,7 @@ export interface ManualTaskSummary {
   content: string;
   taskPriority: TaskPriority;
   responseStatus: ResponseStatus;
+  category: string | null;
   assignees: string | null;
   deadline: string | null;
   workflowSteps: WorkflowSteps | null;

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -159,6 +159,14 @@
         { "fieldPath": "responseStatus", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "manual_tasks",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -364,6 +364,8 @@ export interface ManualTask {
   taskPriority: TaskPriority;
   /** 対応状況 */
   responseStatus: ResponseStatus;
+  /** カテゴリ（手動選択） */
+  category?: ChatCategory | null;
   /** 担当者（自由入力） */
   assignees: string | null;
   /** 期限（任意） */


### PR DESCRIPTION
## Summary
- 受信箱（Google Chat）に10カテゴリのフィルターUI追加（ピル形式、ステータスタブの右側に配置）
- 手入力タスク作成フォームにカテゴリドロップダウンを追加
- ManualTask の全レイヤー（DB型→APIスキーマ→Web型→UI）にcategoryフィールドを貫通追加
- `CATEGORY_OPTIONS` を `constants.ts` に集約し、inbox/task-boardの重複を解消
- Firestore複合インデックス（manual_tasks: category + createdAt DESC）追加

Closes #290
Closes #291

## Test plan
- [x] typecheck全パス（11パッケージ）
- [x] lint エラー0件
- [x] テスト179件全パス
- [ ] 受信箱でGoogle Chat選択時にカテゴリフィルターが表示されること
- [ ] カテゴリ選択でメッセージが正しくフィルタリングされること
- [ ] LINE選択時にカテゴリフィルターが非表示であること
- [ ] 手入力タスク作成フォームでカテゴリが選択・保存されること
- [ ] タスクボードのカテゴリフィルターで手入力タスクが正しくフィルタリングされること
- [ ] `firebase deploy --only firestore:indexes` でインデックスをデプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)