### PR TITLE
feat: LINEメッセージにカテゴリフィルター追加

### DIFF
--- a/apps/api/src/routes/line-messages.ts
+++ b/apps/api/src/routes/line-messages.ts
@@ -1,6 +1,6 @@
 import { zValidator } from "@hono/zod-validator";
 import { collections } from "@hr-system/db";
-import { RESPONSE_STATUSES, TASK_PRIORITIES } from "@hr-system/shared";
+import { CHAT_CATEGORIES, RESPONSE_STATUSES, TASK_PRIORITIES } from "@hr-system/shared";
 import { FieldValue, Timestamp } from "firebase-admin/firestore";
 import { Hono } from "hono";
 import { z } from "zod";
@@ -13,10 +13,32 @@ import { toISO } from "../lib/serialize.js";
 const listQuerySchema = z.object({
   groupId: z.string().optional(),
   responseStatus: z.enum(RESPONSE_STATUSES).optional(),
+  category: z.enum(CHAT_CATEGORIES).optional(),
   hasTaskPriority: z.enum(["true"]).optional(),
   limit: z.string().optional(),
   offset: z.string().optional(),
 });
+
+function serialize(id: string, msg: Record<string, unknown>) {
+  return {
+    id,
+    groupId: msg.groupId as string,
+    groupName: (msg.groupName as string) ?? null,
+    senderUserId: msg.senderUserId as string,
+    senderName: msg.senderName as string,
+    content: msg.content as string,
+    contentUrl: (msg.contentUrl as string) ?? null,
+    lineMessageType: msg.lineMessageType as string,
+    taskPriority: (msg.taskPriority as string) ?? null,
+    assignees: (msg.assignees as string) ?? null,
+    deadline: msg.deadline ? toISO(msg.deadline as FirebaseFirestore.Timestamp) : null,
+    responseStatus: (msg.responseStatus as string) ?? "unresponded",
+    category: (msg.category as string) ?? null,
+    workflowSteps: (msg.workflowSteps as Record<string, unknown>) ?? null,
+    notes: (msg.notes as string) ?? null,
+    createdAt: toISO(msg.createdAt as FirebaseFirestore.Timestamp),
+  };
+}
 
 export const lineMessageRoutes = new Hono();
 
@@ -24,7 +46,8 @@ export const lineMessageRoutes = new Hono();
 // GET /api/line-messages — LINE メッセージ一覧
 // ---------------------------------------------------------------------------
 lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
-  const { groupId, responseStatus, hasTaskPriority, limit, offset } = c.req.valid("query");
+  const { groupId, responseStatus, category, hasTaskPriority, limit, offset } =
+    c.req.valid("query");
   const { limit: lim, offset: off } = parsePagination({ limit, offset });
   const actorRole = c.get("actorRole");
 
@@ -40,6 +63,7 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
     ]) as FirebaseFirestore.Query;
     if (groupId) tpQuery = tpQuery.where("groupId", "==", groupId);
     if (responseStatus) tpQuery = tpQuery.where("responseStatus", "==", responseStatus);
+    if (category) tpQuery = tpQuery.where("category", "==", category);
 
     const tpSnap = await tpQuery.limit(500).get();
     const allDocs = tpSnap.docs.sort((a, b) => {
@@ -50,29 +74,8 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
     const paged = allDocs.slice(off, off + lim);
     const hasMore = off + lim < allDocs.length;
 
-    const data = paged.map((doc) => {
-      const msg = doc.data() as Record<string, unknown>;
-      return {
-        id: doc.id,
-        groupId: msg.groupId as string,
-        groupName: (msg.groupName as string) ?? null,
-        senderUserId: msg.senderUserId as string,
-        senderName: msg.senderName as string,
-        content: msg.content as string,
-        contentUrl: (msg.contentUrl as string) ?? null,
-        lineMessageType: msg.lineMessageType as string,
-        taskPriority: (msg.taskPriority as string) ?? null,
-        assignees: (msg.assignees as string) ?? null,
-        deadline: msg.deadline ? toISO(msg.deadline as FirebaseFirestore.Timestamp) : null,
-        responseStatus: (msg.responseStatus as string) ?? "unresponded",
-        workflowSteps: (msg.workflowSteps as Record<string, unknown>) ?? null,
-        notes: (msg.notes as string) ?? null,
-        createdAt: toISO(msg.createdAt as FirebaseFirestore.Timestamp),
-      };
-    });
-
     return c.json({
-      data,
+      data: paged.map((doc) => serialize(doc.id, doc.data() as Record<string, unknown>)),
       pagination: { limit: lim, offset: off, hasMore },
     });
   }
@@ -85,6 +88,9 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
   if (responseStatus) {
     query = query.where("responseStatus", "==", responseStatus);
   }
+  if (category) {
+    query = query.where("category", "==", category);
+  }
 
   const snapshot = await query
     .limit(lim + 1)
@@ -93,29 +99,8 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
   const hasMore = snapshot.docs.length > lim;
   const docs = snapshot.docs.slice(0, lim);
 
-  const data = docs.map((doc) => {
-    const msg = doc.data() as Record<string, unknown>;
-    return {
-      id: doc.id,
-      groupId: msg.groupId as string,
-      groupName: (msg.groupName as string) ?? null,
-      senderUserId: msg.senderUserId as string,
-      senderName: msg.senderName as string,
-      content: msg.content as string,
-      contentUrl: (msg.contentUrl as string) ?? null,
-      lineMessageType: msg.lineMessageType as string,
-      taskPriority: (msg.taskPriority as string) ?? null,
-      assignees: (msg.assignees as string) ?? null,
-      deadline: msg.deadline ? toISO(msg.deadline as FirebaseFirestore.Timestamp) : null,
-      responseStatus: (msg.responseStatus as string) ?? "unresponded",
-      workflowSteps: (msg.workflowSteps as Record<string, unknown>) ?? null,
-      notes: (msg.notes as string) ?? null,
-      createdAt: toISO(msg.createdAt as FirebaseFirestore.Timestamp),
-    };
-  });
-
   return c.json({
-    data,
+    data: docs.map((doc) => serialize(doc.id, doc.data() as Record<string, unknown>)),
     pagination: { limit: lim, offset: off, hasMore },
   });
 });
@@ -212,6 +197,7 @@ lineMessageRoutes.get("/:id", async (c) => {
     assignees: msg.assignees ?? null,
     deadline: msg.deadline ? toISO(msg.deadline) : null,
     responseStatus: msg.responseStatus ?? "unresponded",
+    category: msg.category ?? null,
     responseStatusUpdatedBy: msg.responseStatusUpdatedBy ?? null,
     responseStatusUpdatedAt: msg.responseStatusUpdatedAt
       ? toISO(msg.responseStatusUpdatedAt)
@@ -294,6 +280,7 @@ const updateWorkflowSchema = z
     deadline: z.string().datetime({ offset: true }).nullable().optional(),
     notes: z.string().max(2000).nullable().optional(),
     workflowSteps: workflowStepsSchema.optional(),
+    category: z.enum(CHAT_CATEGORIES).nullable().optional(),
   })
   .refine((data) => Object.keys(data).length > 0, {
     message: "更新するフィールドを1つ以上指定してください",
@@ -327,6 +314,9 @@ lineMessageRoutes.patch("/:id/workflow", zValidator("json", updateWorkflowSchema
     updates.workflowSteps = body.workflowSteps;
     updates.workflowUpdatedBy = actor.email;
     updates.workflowUpdatedAt = FieldValue.serverTimestamp();
+  }
+  if (body.category !== undefined) {
+    updates.category = body.category;
   }
 
   if (Object.keys(updates).length > 0) {

--- a/apps/web/src/__tests__/api-contract.test.ts
+++ b/apps/web/src/__tests__/api-contract.test.ts
@@ -502,6 +502,7 @@ describe("LineMessageSummary 契約", () => {
     assignees: null,
     deadline: null,
     responseStatus: "unresponded",
+    category: null,
     workflowSteps: null,
     notes: null,
     createdAt: "2026-03-01T09:00:00.000Z",
@@ -509,6 +510,12 @@ describe("LineMessageSummary 契約", () => {
 
   it("workflowSteps と notes フィールドが存在すること", () => {
     expect(hasAllKeys(sampleLineMessage, ["workflowSteps", "notes"])).toBe(true);
+  });
+
+  it("category が null 許容で string を受け付けること", () => {
+    expect(sampleLineMessage.category).toBeNull();
+    const withCategory: LineMessageSummary = { ...sampleLineMessage, category: "salary" };
+    expect(withCategory.category).toBe("salary");
   });
 
   it("workflowSteps が null 許容で WorkflowSteps 型を受け付けること", () => {

--- a/apps/web/src/app/(protected)/inbox/page.tsx
+++ b/apps/web/src/app/(protected)/inbox/page.tsx
@@ -106,7 +106,12 @@ export default async function InboxPage({ searchParams }: Props) {
     selectedChatMessage = selectedResult;
   } else {
     const [msgResult, countResult, selectedResult] = await Promise.all([
-      getLineMessages({ responseStatus: activeStatus, limit: PAGE_SIZE, offset }),
+      getLineMessages({
+        responseStatus: activeStatus,
+        category: activeCategory,
+        limit: PAGE_SIZE,
+        offset,
+      }),
       getLineInboxCounts(),
       selectedId
         ? getLineMessage(selectedId).catch((err) => {
@@ -199,35 +204,30 @@ export default async function InboxPage({ searchParams }: Props) {
             );
           })}
 
-          {/* カテゴリフィルター（Google Chat のみ） */}
-          {source === "gchat" && (
-            <>
-              <span className="mx-1 h-4 w-px bg-slate-200" />
-              <div className="flex flex-wrap gap-1">
-                {CATEGORY_OPTIONS.map((opt) => {
-                  const isActive =
-                    opt.value === "all" ? !activeCategory : activeCategory === opt.value;
-                  return (
-                    <Link
-                      key={opt.value}
-                      href={buildUrl({
-                        category: opt.value === "all" ? undefined : opt.value,
-                        page: "1",
-                        id: undefined,
-                      })}
-                      className={`rounded-full px-2.5 py-1 text-[10px] font-medium transition-colors ${
-                        isActive
-                          ? "bg-slate-700 text-white"
-                          : "bg-slate-100 text-slate-600 hover:bg-slate-200"
-                      }`}
-                    >
-                      {opt.label}
-                    </Link>
-                  );
-                })}
-              </div>
-            </>
-          )}
+          {/* カテゴリフィルター */}
+          <span className="mx-1 h-4 w-px bg-slate-200" />
+          <div className="flex flex-wrap gap-1">
+            {CATEGORY_OPTIONS.map((opt) => {
+              const isActive = opt.value === "all" ? !activeCategory : activeCategory === opt.value;
+              return (
+                <Link
+                  key={opt.value}
+                  href={buildUrl({
+                    category: opt.value === "all" ? undefined : opt.value,
+                    page: "1",
+                    id: undefined,
+                  })}
+                  className={`rounded-full px-2.5 py-1 text-[10px] font-medium transition-colors ${
+                    isActive
+                      ? "bg-slate-700 text-white"
+                      : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                  }`}
+                >
+                  {opt.label}
+                </Link>
+              );
+            })}
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/app/(protected)/task-board/actions.ts
+++ b/apps/web/src/app/(protected)/task-board/actions.ts
@@ -154,7 +154,7 @@ export async function updateLineDeadlineFromTaskBoard(messageId: string, deadlin
 
 export async function updateLineWorkflowFromTaskBoard(
   messageId: string,
-  body: { workflowSteps?: WorkflowSteps; notes?: string | null },
+  body: { workflowSteps?: WorkflowSteps; notes?: string | null; category?: string | null },
 ) {
   await requireAccess();
   await updateLineWorkflow(messageId, body);

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -115,7 +115,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         deadline: msg.deadline ?? null,
         groupName: msg.groupName,
         chatUrl: null,
-        category: null,
+        category: msg.category ?? null,
         workflowSteps: msg.workflowSteps ?? null,
         notes: msg.notes ?? null,
         createdAt: msg.createdAt,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -443,6 +443,7 @@ export function getOverridePatterns() {
 export interface LineMessageListParams {
   groupId?: string;
   responseStatus?: ResponseStatus;
+  category?: string;
   hasTaskPriority?: boolean;
   limit?: number;
   offset?: number;
@@ -452,6 +453,7 @@ export function getLineMessages(params?: LineMessageListParams) {
   const sp = new URLSearchParams();
   if (params?.groupId) sp.set("groupId", params.groupId);
   if (params?.responseStatus) sp.set("responseStatus", params.responseStatus);
+  if (params?.category) sp.set("category", params.category);
   if (params?.hasTaskPriority) sp.set("hasTaskPriority", "true");
   if (params?.limit) sp.set("limit", String(params.limit));
   if (params?.offset) sp.set("offset", String(params.offset));
@@ -501,6 +503,7 @@ export function updateLineWorkflow(
     deadline?: string | null;
     notes?: string | null;
     workflowSteps?: WorkflowSteps;
+    category?: string | null;
   },
 ) {
   return request<{ success: boolean }>(`/api/line-messages/${encodeURIComponent(id)}/workflow`, {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -360,6 +360,7 @@ export interface LineMessageSummary {
   assignees: string | null;
   deadline: string | null;
   responseStatus: ResponseStatus;
+  category: string | null;
   workflowSteps: WorkflowSteps | null;
   notes: string | null;
   createdAt: string;

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -161,6 +161,14 @@
       ]
     },
     {
+      "collectionGroup": "line_messages",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "category", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "manual_tasks",
       "queryScope": "COLLECTION",
       "fields": [

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -303,6 +303,8 @@ export interface LineMessage {
   assignees: string | null;
   /** 期限（ISO 8601 datetime） */
   deadline: Timestamp | null;
+  /** カテゴリ（手動選択） */
+  category?: ChatCategory | null;
   /** 対応状況（受信箱管理用） */
   responseStatus: "unresponded" | "in_progress" | "responded" | "not_required";
   /** 対応状況の最終更新者 */


### PR DESCRIPTION
## Summary
- DB型→APIスキーマ→Web型の全レイヤーにLINEメッセージのcategoryフィールドを貫通追加
- 受信箱・タスクボードでLINEメッセージのカテゴリフィルタリングが可能に
- serialize関数抽出によるDRY改善、Firestore複合インデックス追加

Closes #292

## Test plan
- [x] typecheck全パス（11パッケージ）
- [x] lint エラー0件
- [x] テスト全パス（web 180件 + api 169件）
- [ ] 受信箱でLINE選択時にカテゴリフィルターが表示されること
- [ ] カテゴリ選択でLINEメッセージが正しくフィルタリングされること
- [ ] タスクボードでLINEメッセージのcategoryが表示されること
- [ ] `firebase deploy --only firestore:indexes` でインデックスをデプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)