### PR TITLE
fix: ユーザー削除を物理削除+確認ダイアログに変更 (#300)

### DIFF
--- a/apps/api/src/routes/admin-users.ts
+++ b/apps/api/src/routes/admin-users.ts
@@ -117,7 +117,7 @@ adminUserRoutes.patch("/:id", zValidator("json", updateUserSchema), async (c) =>
   return c.json({ success: true });
 });
 
-// DELETE /api/admin/users/:id — ユーザー無効化（論理削除）
+// DELETE /api/admin/users/:id — ユーザー物理削除
 adminUserRoutes.delete("/:id", async (c) => {
   requireAdmin(c);
   const id = c.req.param("id");
@@ -127,10 +127,9 @@ adminUserRoutes.delete("/:id", async (c) => {
   const doc = await docRef.get();
   if (!doc.exists) throw notFound("AllowedUser", id);
 
-  await docRef.update({
-    isActive: false,
-    updatedAt: FieldValue.serverTimestamp(),
-  });
+  const email = doc.data()?.email;
+
+  await docRef.delete();
 
   await collections.auditLogs.add({
     eventType: "user_removed",
@@ -138,7 +137,7 @@ adminUserRoutes.delete("/:id", async (c) => {
     entityId: id,
     actorEmail: actor.email,
     actorRole: c.get("actorRole"),
-    details: { email: doc.data()?.email },
+    details: { email },
     createdAt: FieldValue.serverTimestamp() as never,
   });
 

--- a/apps/web/src/app/(protected)/admin/users/user-actions.tsx
+++ b/apps/web/src/app/(protected)/admin/users/user-actions.tsx
@@ -27,7 +27,9 @@ import {
 
 export function UserActions({ user }: { user: AdminUser }) {
   const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [deleting, setDeleting] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
 
   async function handleSaveDisplayName() {
@@ -40,6 +42,18 @@ export function UserActions({ user }: { user: AdminUser }) {
     await updateDisplayNameAction(user.id, newName);
     setSaving(false);
     setEditOpen(false);
+  }
+
+  async function handleDelete() {
+    setDeleting(true);
+    try {
+      await removeUserAction(user.id);
+      setDeleteOpen(false);
+    } catch {
+      alert("削除に失敗しました。もう一度お試しください。");
+    } finally {
+      setDeleting(false);
+    }
   }
 
   return (
@@ -78,7 +92,7 @@ export function UserActions({ user }: { user: AdminUser }) {
             </DropdownMenuItem>
           )}
           <DropdownMenuSeparator />
-          <DropdownMenuItem className="text-destructive" onClick={() => removeUserAction(user.id)}>
+          <DropdownMenuItem className="text-destructive" onClick={() => setDeleteOpen(true)}>
             <Trash2 className="mr-2 h-4 w-4" />
             削除
           </DropdownMenuItem>
@@ -119,6 +133,26 @@ export function UserActions({ user }: { user: AdminUser }) {
               </Button>
             </DialogFooter>
           </form>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <DialogContent className="sm:max-w-sm" aria-describedby={undefined}>
+          <DialogHeader>
+            <DialogTitle>ユーザーを削除</DialogTitle>
+          </DialogHeader>
+          <p className="text-sm text-muted-foreground">
+            <span className="font-medium text-foreground">{user.email}</span>{" "}
+            を削除します。この操作は取り消せません。
+          </p>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setDeleteOpen(false)}>
+              キャンセル
+            </Button>
+            <Button type="button" variant="destructive" disabled={deleting} onClick={handleDelete}>
+              {deleting ? "削除中..." : "削除する"}
+            </Button>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
     </>


### PR DESCRIPTION
## Summary
- DELETE APIを論理削除（`isActive: false`）から**物理削除**（`doc.delete()`）に変更
- 削除ボタンに**確認ダイアログ**を追加（メールアドレス表示、取り消し不可の警告）
- エラー時のalert通知を追加

Closes #300

## Test plan
- [x] typecheck パス（web + api）
- [x] lint パス
- [x] テスト 27件パス
- [ ] ユーザー削除で確認ダイアログが表示されること
- [ ] 確認後にユーザーが一覧から消えること
- [ ] キャンセルで削除されないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)