### PR TITLE
fix: Google Chat検索URLの文字列切断を自然な区切りに改善 (#302)

### DIFF
--- a/apps/web/src/__tests__/utils.test.ts
+++ b/apps/web/src/__tests__/utils.test.ts
@@ -1,19 +1,88 @@
 import { describe, expect, it } from "vitest";
-import { buildMessageSearchUrl } from "../lib/utils";
+import { buildMessageSearchUrl, buildSearchQuery } from "../lib/utils";
 
-describe("buildMessageSearchUrl", () => {
-  it("本文の先頭30文字でエンコードした検索URLを生成する", () => {
-    const url = buildMessageSearchUrl("給与変更をお願いします。詳細は添付の通りです。");
-    expect(url).toBe(
-      "https://mail.google.com/chat/u/0/#search/%E7%B5%A6%E4%B8%8E%E5%A4%89%E6%9B%B4%E3%82%92%E3%81%8A%E9%A1%98%E3%81%84%E3%81%97%E3%81%BE%E3%81%99%E3%80%82%E8%A9%B3%E7%B4%B0%E3%81%AF%E6%B7%BB%E4%BB%98%E3%81%AE%E9%80%9A%E3%82%8A%E3%81%A7%E3%81%99%E3%80%82/cmembership=1",
+describe("buildSearchQuery", () => {
+  it("句点で区切られた最初の文を返す", () => {
+    expect(buildSearchQuery("給与変更をお願いします。詳細は添付の通りです。")).toBe(
+      "給与変更をお願いします",
     );
   });
 
-  it("30文字を超える場合は先頭30文字のみ使用する", () => {
-    const longContent = "a".repeat(50);
-    const url = buildMessageSearchUrl(longContent);
-    expect(url).toContain(encodeURIComponent("a".repeat(30)));
-    expect(url).not.toContain(encodeURIComponent("a".repeat(31)));
+  it("改行で区切られた最初の行を返す", () => {
+    expect(buildSearchQuery("1行目の内容\n2行目の内容")).toBe("1行目の内容");
+  });
+
+  it("句点がなく25文字以内ならそのまま返す", () => {
+    expect(buildSearchQuery("短いメッセージ")).toBe("短いメッセージ");
+  });
+
+  it("読点で区切って最初の節を返す（句点なし・25文字超え）", () => {
+    // 句点がなく25文字を超える場合、読点で区切る
+    expect(
+      buildSearchQuery("社労士事務所の担当者について、予定に対して別の配置をしたためです"),
+    ).toBe("社労士事務所の担当者について");
+  });
+
+  it("読点もなく25文字を超える場合、末尾ひらがな（助詞）を除去する", () => {
+    // 「別の配置をしたためで」→末尾の「ためで」を除去→「別の配置をし」→末尾の「をし」も除去→問題
+    // 実際には25文字で切ってから末尾ひらがなを除去
+    const long = "@社労士事務所：担当者 予定に対して別の配置をしたためです";
+    const result = buildSearchQuery(long);
+    // 末尾がひらがなで終わらない（助詞で切れない）
+    expect(result).not.toMatch(/[ぁ-ん]$/);
+    expect(result.length).toBeLessThanOrEqual(25);
+  });
+
+  it("25文字で切った結果が全てひらがなの場合はそのまま返す（フォールバック）", () => {
+    const allHiragana = "あ".repeat(30);
+    const result = buildSearchQuery(allHiragana);
+    // replace結果が空→フォールバックでslicedをそのまま返す
+    expect(result).toBe("あ".repeat(25));
+  });
+
+  it("空文字列の場合は空文字列を返す", () => {
+    expect(buildSearchQuery("")).toBe("");
+  });
+
+  it("空白のみの場合は空文字列を返す", () => {
+    expect(buildSearchQuery("   ")).toBe("");
+  });
+
+  it("ユーザー報告のケース: 中途半端な助詞で切れない", () => {
+    // 「@社労士事務所：担当者 予定に対して別の配置をしたためで」←こうならない
+    const content =
+      "@社労士事務所：担当者 予定に対して別の配置をしたためです。次の手配をお願いします。";
+    const result = buildSearchQuery(content);
+    // 句点で切れるので「@社労士事務所：担当者 予定に対して別の配置をしたためです」だが25文字超え
+    // → 読点がないので25文字で切って末尾ひらがな除去
+    expect(result).not.toMatch(/[ぁ-ん]$/);
+  });
+
+  it("maxLen パラメータをカスタマイズできる", () => {
+    const result = buildSearchQuery("短い文章ですが長さを制限します", 10);
+    expect(result.length).toBeLessThanOrEqual(10);
+  });
+
+  it("英数字のみの場合はそのまま切断（ひらがな除去が影響しない）", () => {
+    const result = buildSearchQuery("a".repeat(50));
+    expect(result).toBe("a".repeat(25));
+  });
+
+  it("！で区切る", () => {
+    expect(buildSearchQuery("大変です！すぐ対応してください")).toBe("大変です");
+  });
+
+  it("？で区切る", () => {
+    expect(buildSearchQuery("これは何ですか？確認お願いします")).toBe("これは何ですか");
+  });
+});
+
+describe("buildMessageSearchUrl", () => {
+  it("検索URLを生成する", () => {
+    const url = buildMessageSearchUrl("短いテスト");
+    expect(url).toBe(
+      `https://mail.google.com/chat/u/0/#search/${encodeURIComponent("短いテスト")}/cmembership=1`,
+    );
   });
 
   it("空文字列の場合は空文字列を返す", () => {

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -35,9 +35,32 @@ export function formatDate(iso: string): string {
   return `${yyyy}/${mm}/${dd}`;
 }
 
+/**
+ * メッセージ本文から Google Chat 検索クエリを生成する。
+ * Google Chat は形態素解析ベースで検索するため、文の途中（助詞など）で
+ * 切ると不完全なトークンとなり検索がヒットしない。
+ * 句読点・読点で自然に区切り、超過時は末尾ひらがな（助詞）を除去する。
+ */
+export function buildSearchQuery(content: string, maxLen = 25): string {
+  const trimmed = content.trim();
+  if (!trimmed) return "";
+
+  // 1. 最初の文（句点・改行区切り）
+  const firstSentence = trimmed.split(/[。！？\n]/)[0] ?? trimmed;
+  if (firstSentence.length <= maxLen) return firstSentence;
+
+  // 2. 最初の節（読点区切り）
+  const firstClause = firstSentence.split(/[、,]/)[0] ?? firstSentence;
+  if (firstClause.length <= maxLen) return firstClause;
+
+  // 3. maxLen文字で切って末尾ひらがな（助詞・助動詞）を除去
+  const sliced = firstClause.slice(0, maxLen);
+  return sliced.replace(/[ぁ-ん]+$/, "") || sliced;
+}
+
 /** メッセージ本文の先頭部分で Google Chat 内検索するURL */
 export function buildMessageSearchUrl(content: string): string {
-  const query = content.trim().slice(0, 30);
+  const query = buildSearchQuery(content);
   if (!query) return "";
   return `https://mail.google.com/chat/u/0/#search/${encodeURIComponent(query)}/cmembership=1`;
 }


### PR DESCRIPTION
## Summary
- `buildMessageSearchUrl` の固定30文字切断を、自然な区切り位置での切断に改善
- 句読点（。！？）→ 読点（、,）→ 末尾ひらがな除去の3段階ヒューリスティック
- `buildSearchQuery` を新設し、検索クエリ生成ロジックを分離

## 背景
Google Chatは形態素解析ベースで検索しており、「別の配置をしたためで」のように文の途中で切ると不完全なトークンが生成され検索がヒットしない。「別の配置をしたため」のように自然な区切りで切ればヒットする。

## Test plan
- [x] typecheck 全パス
- [x] lint エラー0件  
- [x] テスト 192件全パス（`buildSearchQuery` 12件追加）
- [ ] 実際のGoogle Chat検索で「句点区切り」「読点区切り」「末尾ひらがな除去」の各パスを確認

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)