### PR TITLE
fix: Google Chat検索URLに日付フィルタを追加 (#304)

### DIFF
--- a/apps/web/src/__tests__/utils.test.ts
+++ b/apps/web/src/__tests__/utils.test.ts
@@ -102,4 +102,23 @@ describe("buildMessageSearchUrl", () => {
     const url = buildMessageSearchUrl("テスト");
     expect(url).toContain("/chat/u/0/");
   });
+
+  it("createdAt が指定された場合 after:/before: で日付絞り込みが追加される", () => {
+    const url = buildMessageSearchUrl("テスト", "2026-03-10T05:00:00Z");
+    // after:2026/03/09 before:2026/03/11
+    expect(url).toContain("after%3A2026%2F03%2F09");
+    expect(url).toContain("before%3A2026%2F03%2F11");
+  });
+
+  it("createdAt なしの場合は日付フィルタなし（後方互換）", () => {
+    const url = buildMessageSearchUrl("テスト");
+    expect(url).not.toContain("after");
+    expect(url).not.toContain("before");
+  });
+
+  it("不正な createdAt は無視される", () => {
+    const url = buildMessageSearchUrl("テスト", "invalid-date");
+    expect(url).not.toContain("after");
+    expect(url).not.toContain("before");
+  });
 });

--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -73,8 +73,8 @@ export default async function ChatMessageDetailPage({ params }: Props) {
             </span>
           )}
         </div>
-        {buildMessageSearchUrl(msg.content) && (
-          <ChatOpenButton url={buildMessageSearchUrl(msg.content)} />
+        {buildMessageSearchUrl(msg.content, msg.createdAt) && (
+          <ChatOpenButton url={buildMessageSearchUrl(msg.content, msg.createdAt)} />
         )}
       </div>
 

--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -182,13 +182,13 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
                 <time className="font-mono text-xs text-muted-foreground tabular-nums">
                   {formatDateTime(msg.createdAt)}
                 </time>
-                {buildMessageSearchUrl(msg.content) && (
+                {buildMessageSearchUrl(msg.content, msg.createdAt) && (
                   <button
                     type="button"
                     onClick={(e) => {
                       e.stopPropagation();
                       window.open(
-                        buildMessageSearchUrl(msg.content),
+                        buildMessageSearchUrl(msg.content, msg.createdAt),
                         "_blank",
                         "noopener,noreferrer,width=1400,height=900",
                       );

--- a/apps/web/src/app/(protected)/chat-messages/table-view.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/table-view.tsx
@@ -77,7 +77,7 @@ function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
     });
   };
 
-  const chatUrl = buildMessageSearchUrl(msg.content);
+  const chatUrl = buildMessageSearchUrl(msg.content, msg.createdAt);
 
   return (
     <tr

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -293,13 +293,13 @@ function TaskRow({
 
       {/* チャットURL（検索で別ウィンドウを開く） */}
       <td className="px-2 py-2.5 text-center">
-        {task.source === "gchat" && buildMessageSearchUrl(task.content) ? (
+        {task.source === "gchat" && buildMessageSearchUrl(task.content, task.createdAt) ? (
           <button
             type="button"
             onClick={(e) => {
               e.stopPropagation();
               window.open(
-                buildMessageSearchUrl(task.content),
+                buildMessageSearchUrl(task.content, task.createdAt),
                 "_blank",
                 "noopener,noreferrer,width=1400,height=900",
               );

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -58,9 +58,25 @@ export function buildSearchQuery(content: string, maxLen = 25): string {
   return sliced.replace(/[ぁ-ん]+$/, "") || sliced;
 }
 
-/** メッセージ本文の先頭部分で Google Chat 内検索するURL */
-export function buildMessageSearchUrl(content: string): string {
+/**
+ * メッセージ本文 + 日付で Google Chat 内検索するURL を生成する。
+ * createdAt が指定された場合、after:/before: 演算子で前後1日に絞り込む。
+ */
+export function buildMessageSearchUrl(content: string, createdAt?: string): string {
   const query = buildSearchQuery(content);
   if (!query) return "";
-  return `https://mail.google.com/chat/u/0/#search/${encodeURIComponent(query)}/cmembership=1`;
+
+  let searchTerms = query;
+  if (createdAt) {
+    const d = new Date(createdAt);
+    if (!Number.isNaN(d.getTime())) {
+      const before = new Date(d.getTime() + 24 * 60 * 60 * 1000);
+      const after = new Date(d.getTime() - 24 * 60 * 60 * 1000);
+      const fmt = (dt: Date) =>
+        `${dt.getUTCFullYear()}/${String(dt.getUTCMonth() + 1).padStart(2, "0")}/${String(dt.getUTCDate()).padStart(2, "0")}`;
+      searchTerms = `${query} after:${fmt(after)} before:${fmt(before)}`;
+    }
+  }
+
+  return `https://mail.google.com/chat/u/0/#search/${encodeURIComponent(searchTerms)}/cmembership=1`;
 }


### PR DESCRIPTION
## Summary
- `buildMessageSearchUrl` に `createdAt` パラメータを追加（後方互換: オプショナル）
- Google Chat検索演算子 `after:` `before:` で前後1日の日付絞り込みを追加
- 全呼び出し元（task-list, table-view, message-card, detail page）に `createdAt` を渡すよう更新

## 背景
#302 で文字列切断を改善したが、句読点・読点がないメッセージでは短いクエリになり検索結果が多すぎる問題が残っていた。日付フィルタ追加で検索精度を大幅に向上。

## Test plan
- [x] typecheck 11パッケージ全パス
- [x] lint エラー0件
- [x] テスト 195件全パス（日付フィルタテスト3件追加）
- [ ] 実際のGoogle Chatで日付フィルタ付き検索が正しく絞り込めることを確認

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)