### PR TITLE
fix: 検索クエリの改行正規化で短すぎるクエリを防止

### DIFF
--- a/apps/web/src/__tests__/utils.test.ts
+++ b/apps/web/src/__tests__/utils.test.ts
@@ -50,8 +50,8 @@ describe("buildSearchQuery", () => {
     );
   });
 
-  it("改行で区切られた最初の行を返す", () => {
-    expect(buildSearchQuery("1行目の内容\n2行目の内容")).toBe("1行目の内容");
+  it("改行はスペースに正規化して結合する", () => {
+    expect(buildSearchQuery("1行目の内容\n2行目の内容")).toBe("1行目の内容 2行目の内容");
   });
 
   it("句点がなく25文字以内ならそのまま返す", () => {
@@ -83,6 +83,14 @@ describe("buildSearchQuery", () => {
       "@社労士事務所：担当者 予定に対して別の配置をしたためです。次の手配をお願いします。";
     const result = buildSearchQuery(content);
     // 句点で切れるが25文字超え → 名詞境界で切断
+    expect(result).toBe("@社労士事務所：担当者 予定に対して別の配置");
+  });
+
+  it("改行区切りのメッセージでも名詞境界で切断する", () => {
+    const content =
+      "@社労士事務所：担当者\n予定に対して別の配置をしたためです。次の手配をお願いします。";
+    const result = buildSearchQuery(content);
+    // 改行→スペース正規化後、句点で切れるが25文字超え → 名詞境界で切断
     expect(result).toBe("@社労士事務所：担当者 予定に対して別の配置");
   });
 

--- a/apps/web/src/lib/utils.ts
+++ b/apps/web/src/lib/utils.ts
@@ -42,11 +42,12 @@ export function formatDate(iso: string): string {
  * 句読点・読点で自然に区切り、超過時は名詞境界（漢字/カタカナの直後）で切断する。
  */
 export function buildSearchQuery(content: string, maxLen = 25): string {
-  const trimmed = content.trim();
+  // 改行をスペースに正規化（チャットメッセージは宛先行＋本文の複数行構成が多い）
+  const trimmed = content.trim().replace(/\n+/g, " ");
   if (!trimmed) return "";
 
-  // 1. 最初の文（句点・改行区切り）
-  const firstSentence = trimmed.split(/[。！？\n]/)[0] ?? trimmed;
+  // 1. 最初の文（句点区切り）
+  const firstSentence = trimmed.split(/[。！？]/)[0] ?? trimmed;
   if (firstSentence.length <= maxLen) return firstSentence;
 
   // 2. 最初の節（読点区切り）


### PR DESCRIPTION
## Summary
- チャットメッセージの改行（`\n`）をスペースに正規化して検索クエリ生成
- `@社労士事務所：担当者\n予定に対して...` → `@社労士事務所：担当者 予定に対して別の配置` で検索
- 改行を文区切りとして扱っていたため、宛先行のみが返され検索精度が低下していた問題を修正

Closes #306

## Test plan
- [x] typecheck 11パッケージ全パス
- [x] lint エラー0件
- [x] テスト 201件全パス（新規1件追加）
- [x] 改行区切りメッセージで宛先+本文が結合されてクエリ生成されること
- [x] 句点・読点での分割が引き続き正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)