### PR TITLE
feat: 許可ドメインのガイド表示を追加 (#315)

### DIFF
--- a/apps/web/src/app/(protected)/admin/users/add-user-form.tsx
+++ b/apps/web/src/app/(protected)/admin/users/add-user-form.tsx
@@ -52,6 +52,9 @@ export function AddUserForm() {
           <div className="space-y-2">
             <Label htmlFor="email">メールアドレス</Label>
             <Input id="email" name="email" type="email" required placeholder="user@aozora-cg.com" />
+            <p className="text-xs text-muted-foreground">
+              aozora-cg.com / lend.aozora-cg.com のみ登録可能
+            </p>
           </div>
           <div className="space-y-2">
             <Label htmlFor="displayName">表示名</Label>

--- a/apps/web/src/app/login/page.tsx
+++ b/apps/web/src/app/login/page.tsx
@@ -124,7 +124,7 @@ export default async function LoginPage({
 
       {/* フッター注記 */}
       <p className="relative z-10 mt-6 text-xs text-muted-foreground">
-        アクセスには管理者による許可が必要です
+        aozora-cg.com / lend.aozora-cg.com アカウント + 管理者による許可が必要です
       </p>
     </main>
   );


### PR DESCRIPTION
## Summary
- ユーザー追加フォームのメール欄に許可ドメインのヒントテキスト追加
- ログインページのフッター注記に許可ドメイン情報を追加

Closes #315

## Test plan
- [x] typecheck パス
- [ ] ユーザー追加ダイアログにドメインヒントが表示される
- [ ] ログインページ下部にドメイン案内が表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)