### PR TITLE
feat: 全テーブルヘッダーをスティッキー固定化 (#317)

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/table-view.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/table-view.tsx
@@ -190,7 +190,7 @@ export function TableView({
   return (
     <div className="overflow-x-auto rounded-xl border border-border/60 bg-card shadow-sm">
       <table className="min-w-full border-collapse">
-        <thead>
+        <thead className="sticky top-0 z-10">
           <tr className="border-b border-border/60 bg-muted/50">
             <th className="px-2 py-2 text-center text-xs font-semibold text-muted-foreground">
               No

--- a/apps/web/src/components/confusion-matrix-table.tsx
+++ b/apps/web/src/components/confusion-matrix-table.tsx
@@ -45,7 +45,7 @@ export function ConfusionMatrixTable({
   return (
     <div className="overflow-x-auto">
       <table className="w-full text-xs">
-        <thead>
+        <thead className="sticky top-0 z-10 bg-background">
           <tr>
             <th className="px-2 py-1.5 text-left font-medium text-muted-foreground">
               修正前 \ 修正後

--- a/apps/web/src/components/ui/table.tsx
+++ b/apps/web/src/components/ui/table.tsx
@@ -17,7 +17,13 @@ function Table({ className, ...props }: React.ComponentProps<"table">) {
 }
 
 function TableHeader({ className, ...props }: React.ComponentProps<"thead">) {
-  return <thead data-slot="table-header" className={cn("[&_tr]:border-b", className)} {...props} />;
+  return (
+    <thead
+      data-slot="table-header"
+      className={cn("sticky top-0 z-10 bg-background [&_tr]:border-b", className)}
+      {...props}
+    />
+  );
 }
 
 function TableBody({ className, ...props }: React.ComponentProps<"tbody">) {


### PR DESCRIPTION
## Summary
- shadcn/ui `TableHeader` コンポーネントに `sticky top-0 z-10 bg-background` を追加（tasks, drafts, admin/users, admin/spaces に一括適用）
- chat-messages `table-view.tsx` の `<thead>` に sticky 追加
- confusion-matrix-table の `<thead>` に sticky + bg-background 追加
- `/task-board` は既に適用済みのためスキップ

Closes #317

## Test plan
- [x] typecheck 11パッケージ全パス
- [x] lint エラー0件
- [x] テスト 201件全パス
- [ ] 各テーブルページでスクロール時にヘッダーが固定されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)