### PR TITLE
fix: タスクボードのテーブルヘッダーstickyが効かない問題を修正

### DIFF
--- a/apps/web/src/app/(protected)/task-board/task-board-content.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-board-content.tsx
@@ -168,7 +168,7 @@ export function TaskBoardContent({ tasks, initialSelectedId, pageOffset = 0, chi
         {/* テーブル一覧 (選択中はモバイルで非表示) */}
         <div
           className={cn(
-            "flex-1 overflow-y-auto",
+            "flex-1 overflow-auto",
             selectedTask && "hidden md:block md:border-r md:border-border/60",
           )}
         >

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -78,7 +78,7 @@ export function TaskList({
   }
 
   return (
-    <div className="overflow-x-auto">
+    <div>
       <table className="w-full min-w-[1500px] text-xs">
         <thead className="sticky top-0 z-10 bg-slate-50 border-b border-border/60">
           <tr>


### PR DESCRIPTION
## Summary
- `task-list.tsx` の `overflow-x-auto` が新しいスクロールコンテキストを作成し、`sticky top-0` を無効化していた
- 水平スクロールを親コンテナ `task-board-content.tsx` の `overflow-auto` に統合して修正

Closes #317

## Test plan
- [x] typecheck 11パッケージ全パス
- [x] lint エラー0件
- [x] テスト 201件全パス
- [ ] タスクボードでスクロール時にヘッダー行が固定されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)