### PR TITLE
feat: LINEメッセージの自動カテゴリ分類を実装 (#320)

### DIFF
--- a/apps/worker/src/__tests__/line-webhook.test.ts
+++ b/apps/worker/src/__tests__/line-webhook.test.ts
@@ -18,14 +18,31 @@ vi.mock("@hr-system/db", () => ({
       where: vi.fn().mockReturnThis(),
       limit: vi.fn().mockReturnThis(),
       get: vi.fn().mockResolvedValue({ empty: true }),
-      add: vi.fn().mockResolvedValue({ id: "doc-1" }),
+      add: vi.fn().mockResolvedValue({ id: "doc-1", update: vi.fn().mockResolvedValue(undefined) }),
     },
   },
 }));
 
+vi.mock("@hr-system/ai", () => ({
+  classifyIntent: vi.fn().mockResolvedValue({
+    category: "attendance",
+    confidence: 0.92,
+    reasoning: "勤務表に関する相談",
+    classificationMethod: "regex",
+    regexPattern: "attendance_schedule",
+  }),
+}));
+
+vi.mock("../lib/classification-config.js", () => ({
+  getClassificationConfig: vi.fn().mockResolvedValue({}),
+}));
+
+import { classifyIntent } from "@hr-system/ai";
 import { collections } from "@hr-system/db";
 import { validateSignature } from "@line/bot-sdk";
 import { app } from "../app.js";
+
+const mockClassifyIntent = vi.mocked(classifyIntent);
 
 const mockValidateSignature = vi.mocked(validateSignature);
 
@@ -55,7 +72,10 @@ describe("LINE Webhook", () => {
     // lineMessages モックリセット
     const lm = collections.lineMessages;
     vi.mocked(lm.get).mockResolvedValue({ empty: true } as never);
-    vi.mocked(lm.add).mockResolvedValue({ id: "doc-1" } as never);
+    vi.mocked(lm.add).mockResolvedValue({
+      id: "doc-1",
+      update: vi.fn().mockResolvedValue(undefined),
+    } as never);
   });
 
   it("署名検証失敗で 401 を返す", async () => {
@@ -137,6 +157,43 @@ describe("LINE Webhook", () => {
 
     expect(res.status).toBe(200);
     expect(collections.lineMessages.add).not.toHaveBeenCalled();
+  });
+
+  it("テキストメッセージのカテゴリを自動分類して更新する", async () => {
+    const mockUpdate = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(collections.lineMessages.add).mockResolvedValue({
+      id: "doc-1",
+      update: mockUpdate,
+    } as never);
+
+    const event = createTextMessageEvent();
+    const res = await app.request("/line/webhook", {
+      method: "POST",
+      headers: { "x-line-signature": "valid", "Content-Type": "application/json" },
+      body: JSON.stringify({ events: [event] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(mockClassifyIntent).toHaveBeenCalledWith(
+      "来月の勤務表について相談です",
+      undefined,
+      expect.any(Object),
+    );
+    expect(mockUpdate).toHaveBeenCalledWith({ category: "attendance" });
+  });
+
+  it("カテゴリ分類が失敗してもメッセージ保存は成功する", async () => {
+    mockClassifyIntent.mockRejectedValueOnce(new Error("LLM unavailable"));
+
+    const event = createTextMessageEvent();
+    const res = await app.request("/line/webhook", {
+      method: "POST",
+      headers: { "x-line-signature": "valid", "Content-Type": "application/json" },
+      body: JSON.stringify({ events: [event] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(collections.lineMessages.add).toHaveBeenCalled();
   });
 
   it("不正な JSON で 200 を返す（リトライ不要）", async () => {

--- a/apps/worker/src/pipeline/process-line-message.ts
+++ b/apps/worker/src/pipeline/process-line-message.ts
@@ -1,5 +1,7 @@
+import { classifyIntent } from "@hr-system/ai";
 import { collections } from "@hr-system/db";
 import { Timestamp } from "firebase-admin/firestore";
+import { getClassificationConfig } from "../lib/classification-config.js";
 import { getGroupMemberProfile, getGroupSummary, getMessageContent } from "../lib/line-api.js";
 import { uploadLineMedia } from "../lib/storage.js";
 
@@ -71,13 +73,15 @@ export async function processLineEvent(event: LineWebhookEvent): Promise<void> {
     }
   }
 
-  await collections.lineMessages.add({
+  const textContent = message.text ?? "";
+
+  const docRef = await collections.lineMessages.add({
     groupId,
     groupName: groupName ?? null,
     lineMessageId,
     senderUserId: userId,
     senderName: senderName ?? "unknown",
-    content: message.text ?? "",
+    content: textContent,
     contentUrl,
     lineMessageType: message.type,
     rawPayload: event as unknown as Record<string, unknown>,
@@ -91,4 +95,18 @@ export async function processLineEvent(event: LineWebhookEvent): Promise<void> {
   });
 
   console.log(`[LineWorker] Saved message: ${lineMessageId} (group: ${groupId})`);
+
+  // カテゴリ自動分類（テキストメッセージのみ、best-effort）
+  if (message.type === "text" && textContent.length > 0) {
+    try {
+      const config = await getClassificationConfig();
+      const result = await classifyIntent(textContent, undefined, config);
+      await docRef.update({ category: result.category });
+      console.log(
+        `[LineWorker] Classified: ${lineMessageId} → ${result.category} (${result.classificationMethod}, confidence: ${result.confidence})`,
+      );
+    } catch (e) {
+      console.warn(`[LineWorker] Category classification failed (non-blocking): ${String(e)}`);
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- LINE Webhook 受信時に Google Chat と同じ `classifyIntent()` を呼び出し、10カテゴリの自動分類を実行
- 分類結果を `line_messages` ドキュメントの `category` フィールドに保存
- 分類はメッセージ保存後に best-effort で実行（失敗してもメッセージ保存に影響しない）

Closes #320

## Test plan
- [x] typecheck 11パッケージ全パス
- [x] lint エラー0件
- [x] テスト全パス（Worker 76テスト、新規2テスト追加）
- [x] カテゴリ分類が正しく呼ばれ、結果がFirestoreに保存されること
- [x] 分類失敗時もメッセージ保存が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)