### PR TITLE
feat: 受信箱に Google Chat + LINE 統合「すべて」タブを追加 (#323)

### DIFF
--- a/apps/web/src/app/(protected)/inbox/page.tsx
+++ b/apps/web/src/app/(protected)/inbox/page.tsx
@@ -1,6 +1,6 @@
 import type { ChatCategory, ResponseStatus } from "@hr-system/shared";
 
-import { ChevronLeft, ChevronRight, MessageCircle, MessageSquareText } from "lucide-react";
+import { ChevronLeft, ChevronRight, Inbox, MessageCircle, MessageSquareText } from "lucide-react";
 import Link from "next/link";
 import {
   ApiError,
@@ -12,11 +12,17 @@ import {
   getLineMessages,
 } from "@/lib/api";
 import { CATEGORY_OPTIONS } from "@/lib/constants";
-import type { ChatMessageDetail, LineMessageDetail } from "@/lib/types";
+import type {
+  ChatMessageDetail,
+  LineMessageDetail,
+  UnifiedMessageDetail,
+  UnifiedMessageSummary,
+} from "@/lib/types";
 import { Inbox3Pane } from "./inbox-3pane";
 import { LineInbox3Pane } from "./line-inbox-3pane";
+import { UnifiedInbox3Pane } from "./unified-inbox-3pane";
 
-type Source = "gchat" | "line";
+type Source = "all" | "gchat" | "line";
 
 interface Props {
   searchParams: Promise<{
@@ -29,6 +35,7 @@ interface Props {
 }
 
 const SOURCE_TABS: { value: Source; label: string; icon: typeof MessageSquareText }[] = [
+  { value: "all", label: "すべて", icon: Inbox },
   { value: "gchat", label: "Google Chat", icon: MessageSquareText },
   { value: "line", label: "LINE", icon: MessageCircle },
 ];
@@ -45,7 +52,8 @@ const PAGE_SIZE = 30;
 
 export default async function InboxPage({ searchParams }: Props) {
   const params = await searchParams;
-  const source: Source = params.source === "line" ? "line" : "gchat";
+  const source: Source =
+    params.source === "line" ? "line" : params.source === "gchat" ? "gchat" : "all";
   const activeStatus = (params.status as ResponseStatus | undefined) ?? undefined;
   const activeCategory = (params.category as ChatCategory | undefined) ?? undefined;
   const page = Math.max(1, Number(params.page) || 1);
@@ -65,7 +73,7 @@ export default async function InboxPage({ searchParams }: Props) {
     const cat = "category" in overrides ? overrides.category : params.category;
     const p = overrides.page;
     const id = "id" in overrides ? overrides.id : params.id;
-    if (src && src !== "gchat") sp.set("source", src);
+    if (src && src !== "all") sp.set("source", src);
     if (s && s !== "all") sp.set("status", s);
     if (cat && cat !== "all") sp.set("category", cat);
     if (p && p !== "1") sp.set("page", p);
@@ -74,7 +82,7 @@ export default async function InboxPage({ searchParams }: Props) {
     return `/inbox${qs ? `?${qs}` : ""}`;
   }
 
-  // ソース別のデータ取得
+  // --- データ取得 ---
   let gchatMessages: Awaited<ReturnType<typeof getChatMessages>> | null = null;
   let gchatCounts: Awaited<ReturnType<typeof getInboxCounts>> | null = null;
   let selectedChatMessage: ChatMessageDetail | null = null;
@@ -83,7 +91,38 @@ export default async function InboxPage({ searchParams }: Props) {
   let lineCounts: Awaited<ReturnType<typeof getLineInboxCounts>> | null = null;
   let selectedLineMessage: LineMessageDetail | null = null;
 
-  if (source === "gchat") {
+  if (source === "all") {
+    // 両ソースを並列取得
+    const halfLimit = Math.ceil(PAGE_SIZE / 2);
+    const halfOffset = (page - 1) * halfLimit;
+
+    const [gchatResult, lineResult, gchatCountResult, lineCountResult, chatSel, lineSel] =
+      await Promise.all([
+        getChatMessages({
+          responseStatus: activeStatus,
+          category: activeCategory,
+          limit: halfLimit,
+          offset: halfOffset,
+        }),
+        getLineMessages({
+          responseStatus: activeStatus,
+          category: activeCategory,
+          limit: halfLimit,
+          offset: halfOffset,
+        }),
+        getInboxCounts(),
+        getLineInboxCounts(),
+        selectedId ? getChatMessage(selectedId).catch(() => null) : Promise.resolve(null),
+        selectedId ? getLineMessage(selectedId).catch(() => null) : Promise.resolve(null),
+      ]);
+
+    gchatMessages = gchatResult;
+    lineMessages = lineResult;
+    gchatCounts = gchatCountResult;
+    lineCounts = lineCountResult;
+    selectedChatMessage = chatSel;
+    selectedLineMessage = lineSel;
+  } else if (source === "gchat") {
     const [msgResult, countResult, selectedResult] = await Promise.all([
       getChatMessages({
         responseStatus: activeStatus,
@@ -127,8 +166,27 @@ export default async function InboxPage({ searchParams }: Props) {
     selectedLineMessage = selectedResult;
   }
 
-  const counts = source === "gchat" ? gchatCounts!.counts : lineCounts!.counts;
-  const pagination = source === "gchat" ? gchatMessages!.pagination : lineMessages!.pagination;
+  // --- カウント・ページネーション算出 ---
+  let counts: { unresponded: number; in_progress: number; responded: number; not_required: number };
+  let hasMore: boolean;
+
+  if (source === "all") {
+    const gc = gchatCounts!.counts;
+    const lc = lineCounts!.counts;
+    counts = {
+      unresponded: gc.unresponded + lc.unresponded,
+      in_progress: gc.in_progress + lc.in_progress,
+      responded: gc.responded + lc.responded,
+      not_required: gc.not_required + lc.not_required,
+    };
+    hasMore = gchatMessages!.pagination.hasMore || lineMessages!.pagination.hasMore;
+  } else if (source === "gchat") {
+    counts = gchatCounts!.counts;
+    hasMore = gchatMessages!.pagination.hasMore;
+  } else {
+    counts = lineCounts!.counts;
+    hasMore = lineMessages!.pagination.hasMore;
+  }
 
   const totalActive =
     counts.unresponded + counts.in_progress + counts.responded + counts.not_required;
@@ -136,6 +194,30 @@ export default async function InboxPage({ searchParams }: Props) {
   function getCount(value: string): number {
     if (value === "all") return totalActive;
     return counts[value as keyof typeof counts] ?? 0;
+  }
+
+  // --- 統合ビュー用のデータ構築 ---
+  let unifiedMessages: UnifiedMessageSummary[] = [];
+  let unifiedSelected: UnifiedMessageDetail | null = null;
+
+  if (source === "all") {
+    const gchatTagged: UnifiedMessageSummary[] = (gchatMessages?.data ?? []).map((m) => ({
+      ...m,
+      source: "gchat" as const,
+    }));
+    const lineTagged: UnifiedMessageSummary[] = (lineMessages?.data ?? []).map((m) => ({
+      ...m,
+      source: "line" as const,
+    }));
+    unifiedMessages = [...gchatTagged, ...lineTagged].sort((a, b) =>
+      b.createdAt.localeCompare(a.createdAt),
+    );
+
+    if (selectedChatMessage) {
+      unifiedSelected = { ...selectedChatMessage, source: "gchat" as const };
+    } else if (selectedLineMessage) {
+      unifiedSelected = { ...selectedLineMessage, source: "line" as const };
+    }
   }
 
   return (
@@ -232,7 +314,13 @@ export default async function InboxPage({ searchParams }: Props) {
       </div>
 
       {/* 3ペインレイアウト */}
-      {source === "gchat" ? (
+      {source === "all" ? (
+        <UnifiedInbox3Pane
+          messages={unifiedMessages}
+          selectedMessage={unifiedSelected}
+          selectedId={selectedId}
+        />
+      ) : source === "gchat" ? (
         <Inbox3Pane
           messages={gchatMessages!.data}
           selectedMessage={selectedChatMessage}
@@ -263,12 +351,10 @@ export default async function InboxPage({ searchParams }: Props) {
             ページ {page}
           </span>
           <Link
-            href={pagination.hasMore ? buildUrl({ page: String(page + 1) }) : "#"}
-            aria-disabled={!pagination.hasMore}
+            href={hasMore ? buildUrl({ page: String(page + 1) }) : "#"}
+            aria-disabled={!hasMore}
             className={`inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors ${
-              !pagination.hasMore
-                ? "pointer-events-none text-slate-300"
-                : "text-slate-600 hover:bg-slate-100"
+              !hasMore ? "pointer-events-none text-slate-300" : "text-slate-600 hover:bg-slate-100"
             }`}
           >
             次へ

--- a/apps/web/src/app/(protected)/inbox/unified-inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/unified-inbox-3pane.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import type { ResponseStatus } from "@hr-system/shared";
+import { Image as ImageIcon, MessageSquare, Paperclip } from "lucide-react";
+import { CategoryBadge } from "@/components/category-badge";
+import { LineMessageDetailPane } from "@/components/line-message-detail-pane";
+import { ChatMessageDetailPane } from "@/components/message-detail-pane";
+import { TaskPriorityDot } from "@/components/task-priority-selector";
+import { RESPONSE_STATUS_DOT_COLORS } from "@/lib/constants";
+import type { UnifiedMessageDetail, UnifiedMessageSummary } from "@/lib/types";
+import { cn, formatDateTimeJST } from "@/lib/utils";
+import {
+  updateChatAssigneesAction,
+  updateChatDeadlineAction,
+  updateLineAssigneesAction,
+  updateLineDeadlineAction,
+  updateLineResponseStatusAction,
+  updateLineTaskPriorityAction,
+  updateResponseStatusAction,
+  updateTaskPriorityAction,
+  updateWorkflowAction,
+} from "./actions";
+import { HandoverForm } from "./handover-form";
+import { useSelectMessage } from "./use-select-message";
+
+interface UnifiedInbox3PaneProps {
+  messages: UnifiedMessageSummary[];
+  selectedMessage: UnifiedMessageDetail | null;
+  selectedId: string | null;
+}
+
+function GchatRow({ msg }: { msg: UnifiedMessageSummary & { source: "gchat" } }) {
+  const intent = msg.intent;
+  const responseStatus = (intent?.responseStatus ?? "unresponded") as ResponseStatus;
+  const category = intent?.category ?? "other";
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "h-2 w-2 flex-shrink-0 rounded-full",
+            RESPONSE_STATUS_DOT_COLORS[responseStatus],
+          )}
+        />
+        <span className="truncate text-xs font-medium">{msg.senderName}</span>
+        {msg.spaceDisplayName && (
+          <span className="truncate text-xs text-muted-foreground">@ {msg.spaceDisplayName}</span>
+        )}
+        <span className="ml-auto text-xs text-muted-foreground">
+          {formatDateTimeJST(msg.createdAt)}
+        </span>
+      </div>
+      <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{msg.content}</p>
+      <div className="mt-1.5 flex items-center gap-1.5">
+        <span className="rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700">Chat</span>
+        <CategoryBadge category={category} />
+        {intent?.confidenceScore != null && (
+          <span className="text-xs tabular-nums text-muted-foreground">
+            {(intent.confidenceScore * 100).toFixed(0)}%
+          </span>
+        )}
+        {msg.attachments.length > 0 && <Paperclip className="h-3 w-3 text-muted-foreground" />}
+        {intent?.taskPriority && <TaskPriorityDot priority={intent.taskPriority} />}
+      </div>
+    </>
+  );
+}
+
+function LineRow({ msg }: { msg: UnifiedMessageSummary & { source: "line" } }) {
+  const responseStatus = msg.responseStatus;
+
+  return (
+    <>
+      <div className="flex items-center gap-2">
+        <span
+          className={cn(
+            "h-2 w-2 flex-shrink-0 rounded-full",
+            RESPONSE_STATUS_DOT_COLORS[responseStatus],
+          )}
+        />
+        <span className="truncate text-xs font-medium">{msg.senderName}</span>
+        {msg.groupName && (
+          <span className="truncate text-xs text-muted-foreground">@ {msg.groupName}</span>
+        )}
+        <span className="ml-auto text-xs text-muted-foreground">
+          {formatDateTimeJST(msg.createdAt)}
+        </span>
+      </div>
+      <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">
+        {msg.lineMessageType === "image" ? (
+          <span className="inline-flex items-center gap-1">
+            <ImageIcon size={12} />
+            画像
+          </span>
+        ) : (
+          msg.content
+        )}
+      </p>
+      <div className="mt-1.5 flex items-center gap-1.5">
+        <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-xs text-emerald-700">LINE</span>
+        <CategoryBadge category={msg.category} />
+        {msg.lineMessageType !== "text" && (
+          <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+            {msg.lineMessageType}
+          </span>
+        )}
+        {msg.taskPriority && <TaskPriorityDot priority={msg.taskPriority} />}
+      </div>
+    </>
+  );
+}
+
+function DetailPane({ message, onClose }: { message: UnifiedMessageDetail; onClose: () => void }) {
+  if (message.source === "gchat") {
+    return (
+      <ChatMessageDetailPane
+        message={message}
+        onClose={onClose}
+        onUpdateResponseStatus={updateResponseStatusAction}
+        onUpdateTaskPriority={updateTaskPriorityAction}
+        onUpdateWorkflow={updateWorkflowAction}
+        assignees={message.intent?.assignees ?? null}
+        deadline={message.intent?.deadline ?? null}
+        onUpdateAssignees={updateChatAssigneesAction}
+        onUpdateDeadline={updateChatDeadlineAction}
+        extraContent={
+          message.intent && (
+            <div className="mt-4">
+              <HandoverForm
+                chatMessageId={message.id}
+                taskSummary={message.intent.taskSummary ?? null}
+                assignees={message.intent.assignees ?? null}
+                deadline={message.intent.deadline ?? null}
+                notes={message.intent.notes ?? null}
+              />
+            </div>
+          )
+        }
+      />
+    );
+  }
+
+  return (
+    <LineMessageDetailPane
+      message={message}
+      onClose={onClose}
+      onUpdateResponseStatus={updateLineResponseStatusAction}
+      onUpdateTaskPriority={updateLineTaskPriorityAction}
+      onUpdateAssignees={updateLineAssigneesAction}
+      onUpdateDeadline={updateLineDeadlineAction}
+    />
+  );
+}
+
+export function UnifiedInbox3Pane({
+  messages,
+  selectedMessage,
+  selectedId,
+}: UnifiedInbox3PaneProps) {
+  const selectMessage = useSelectMessage();
+
+  if (messages.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <p className="text-sm text-muted-foreground">該当するメッセージはありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 overflow-hidden">
+      {/* 左ペイン: メッセージ一覧 */}
+      <div
+        className={cn(
+          "flex-shrink-0 overflow-y-auto border-r border-border/60 bg-white",
+          "w-full md:w-[320px]",
+          selectedId && "hidden md:block",
+        )}
+      >
+        {messages.map((msg) => {
+          const isSelected = msg.id === selectedId;
+          return (
+            <button
+              key={`${msg.source}-${msg.id}`}
+              type="button"
+              onClick={() => selectMessage(msg.id)}
+              className={cn(
+                "w-full border-b border-border/40 px-4 py-3 text-left transition-colors hover:bg-accent/50",
+                isSelected && "bg-accent",
+              )}
+            >
+              {msg.source === "gchat" ? <GchatRow msg={msg} /> : <LineRow msg={msg} />}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* 中央+右ペイン: 詳細 */}
+      {selectedMessage ? (
+        <DetailPane message={selectedMessage} onClose={() => selectMessage(null)} />
+      ) : (
+        <div className="hidden flex-1 items-center justify-center md:flex">
+          <div className="text-center">
+            <MessageSquare className="mx-auto h-12 w-12 text-muted-foreground/30" />
+            <p className="mt-2 text-sm text-muted-foreground">メッセージを選択してください</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -374,6 +374,16 @@ export interface LineMessageDetail extends LineMessageSummary {
   rawPayload: Record<string, unknown> | null;
 }
 
+/** 受信箱統合ビュー: Google Chat + LINE の共通型 */
+export type UnifiedMessageSummary =
+  | (ChatMessageSummary & { source: "gchat" })
+  | (LineMessageSummary & { source: "line" });
+
+/** 受信箱統合ビュー: 詳細型 */
+export type UnifiedMessageDetail =
+  | (ChatMessageDetail & { source: "gchat" })
+  | (LineMessageDetail & { source: "line" });
+
 /** GET /api/line-messages/stats のグループ統計 */
 export interface LineGroupStat {
   groupId: string;


### PR DESCRIPTION
## Summary
- 受信箱のデフォルトタブを「すべて」に変更し、Google Chat + LINE メッセージを時系列で統合表示
- `UnifiedInbox3Pane` コンポーネントでソース別の行レンダリング（Chat/LINEバッジ）と詳細ペイン出し分け
- 各ソース halfLimit(15件) で並列取得、`createdAt` 降順マージソート
- ステータス・カテゴリフィルターが統合ビューでも機能
- `/simplify` 3エージェントレビュー済み（ウォーターフォール解消、不要キャスト削除、sort最適化、CategoryBadge統一）

Closes #323

## Test plan
- [x] typecheck 11パッケージ全パス
- [x] lint エラー0件
- [x] テスト全パス（297テスト）
- [ ] 受信箱で「すべて」タブがデフォルト表示されること
- [ ] Google Chat / LINE メッセージが時系列で混在表示されること
- [ ] 各メッセージにソースバッジ（Chat/LINE）が表示されること
- [ ] ステータスフィルター・カテゴリフィルターが統合ビューで機能すること
- [ ] メッセージ選択で正しい詳細ペインが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)