### PR TITLE
feat: category → categories 複数カテゴリ対応

### DIFF
--- a/apps/api/src/__tests__/chat-messages-routes.test.ts
+++ b/apps/api/src/__tests__/chat-messages-routes.test.ts
@@ -111,11 +111,11 @@ function makeIntentSnap(
         id: `intent-${id}`,
         data: () => ({
           chatMessageId: id,
-          category: "salary",
+          categories: ["salary"],
           confidenceScore,
           classificationMethod: "ai",
           isManualOverride: false,
-          originalCategory: null,
+          originalCategories: null,
           regexPattern: null,
           responseStatus,
           taskPriority,

--- a/apps/api/src/__tests__/chat-sync.test.ts
+++ b/apps/api/src/__tests__/chat-sync.test.ts
@@ -32,7 +32,7 @@ vi.mock("google-auth-library", () => ({
 // @hr-system/ai モック
 vi.mock("@hr-system/ai", () => ({
   classifyIntent: vi.fn().mockResolvedValue({
-    category: "salary",
+    categories: ["salary"],
     confidence: 0.9,
     classificationMethod: "regex",
     regexPattern: "給与",
@@ -565,7 +565,7 @@ describe("chat-sync service", () => {
       expect(mockBatchSet).toHaveBeenCalledWith(
         { id: "intent-new" },
         expect.objectContaining({
-          category: "salary",
+          categories: ["salary"],
           confidenceScore: 0.9,
           classificationMethod: "regex",
         }),

--- a/apps/api/src/__tests__/intent-stats.test.ts
+++ b/apps/api/src/__tests__/intent-stats.test.ts
@@ -53,11 +53,11 @@ import { app } from "../app.js";
 // Helper to create mock intent docs
 function makeIntentDoc(
   overrides: Partial<{
-    category: string;
+    categories: string[];
     confidenceScore: number;
     classificationMethod: string;
     isManualOverride: boolean;
-    originalCategory: string | null;
+    originalCategories: string[] | null;
     regexPattern: string | null;
     chatMessageId: string;
     createdAt: Timestamp;
@@ -68,11 +68,11 @@ function makeIntentDoc(
     id: overrides.chatMessageId ?? "msg-1",
     data: () => ({
       chatMessageId: "msg-1",
-      category: "salary",
+      categories: ["salary"],
       confidenceScore: 0.85,
       classificationMethod: "ai",
       isManualOverride: false,
-      originalCategory: null,
+      originalCategories: null,
       regexPattern: null,
       createdAt: now,
       ...overrides,
@@ -115,7 +115,7 @@ describe("intent-stats routes", () => {
           makeIntentDoc({
             classificationMethod: "manual",
             isManualOverride: true,
-            originalCategory: "other",
+            originalCategories: ["other"],
             confidenceScore: 0.5,
           }),
         ],
@@ -170,12 +170,20 @@ describe("intent-stats routes", () => {
     it("should return override pairs sorted by count", async () => {
       mockIntentGet.mockResolvedValueOnce({
         docs: [
-          makeIntentDoc({ isManualOverride: true, originalCategory: "other", category: "salary" }),
-          makeIntentDoc({ isManualOverride: true, originalCategory: "other", category: "salary" }),
           makeIntentDoc({
             isManualOverride: true,
-            originalCategory: "hiring",
-            category: "contract",
+            originalCategories: ["other"],
+            categories: ["salary"],
+          }),
+          makeIntentDoc({
+            isManualOverride: true,
+            originalCategories: ["other"],
+            categories: ["salary"],
+          }),
+          makeIntentDoc({
+            isManualOverride: true,
+            originalCategories: ["hiring"],
+            categories: ["contract"],
           }),
         ],
       });
@@ -321,20 +329,20 @@ describe("intent-stats routes", () => {
         docs: [
           makeIntentDoc({
             isManualOverride: true,
-            originalCategory: "other",
-            category: "salary",
+            originalCategories: ["other"],
+            categories: ["salary"],
             chatMessageId: "msg-1",
           }),
           makeIntentDoc({
             isManualOverride: true,
-            originalCategory: "other",
-            category: "salary",
+            originalCategories: ["other"],
+            categories: ["salary"],
             chatMessageId: "msg-2",
           }),
           makeIntentDoc({
             isManualOverride: true,
-            originalCategory: "hiring",
-            category: "contract",
+            originalCategories: ["hiring"],
+            categories: ["contract"],
             chatMessageId: "msg-3",
           }),
         ],

--- a/apps/api/src/routes/chat-messages.ts
+++ b/apps/api/src/routes/chat-messages.ts
@@ -29,7 +29,7 @@ const listQuerySchema = z.object({
 });
 
 const patchIntentSchema = z.object({
-  category: z.enum(CHAT_CATEGORIES),
+  categories: z.array(z.enum(CHAT_CATEGORIES)).min(1),
   comment: z.string().max(500).optional(),
 });
 
@@ -107,7 +107,7 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
     // 1. IntentRecords をネイティブフィルタでクエリ
     let intentQuery = collections.intentRecords as FirebaseFirestore.Query;
     if (category) {
-      intentQuery = intentQuery.where("category", "==", category);
+      intentQuery = intentQuery.where("categories", "array-contains", category);
     }
     if (responseStatus) {
       intentQuery = intentQuery.where("responseStatus", "==", responseStatus);
@@ -231,12 +231,12 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
           intent: intent
             ? {
                 id: intentEntry?.id ?? "",
-                category: intent.category as ChatCategory,
+                categories: intent.categories ?? [],
                 confidenceScore: intent.confidenceScore,
                 classificationMethod: intent.classificationMethod ?? "ai",
                 regexPattern: intent.regexPattern ?? null,
                 isManualOverride: intent.isManualOverride ?? false,
-                originalCategory: intent.originalCategory ?? null,
+                originalCategories: intent.originalCategories ?? null,
                 responseStatus: intent.responseStatus ?? "unresponded",
                 taskPriority: intent.taskPriority ?? null,
                 taskSummary: intent.taskSummary ?? null,
@@ -288,12 +288,12 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
         intent: intent
           ? {
               id: intentEntry?.id ?? "",
-              category: intent.category as ChatCategory,
+              categories: intent.categories ?? [],
               confidenceScore: intent.confidenceScore,
               classificationMethod: intent.classificationMethod ?? "ai",
               regexPattern: intent.regexPattern ?? null,
               isManualOverride: intent.isManualOverride ?? false,
-              originalCategory: intent.originalCategory ?? null,
+              originalCategories: intent.originalCategories ?? null,
               responseStatus: intent.responseStatus ?? "unresponded",
               taskPriority: intent.taskPriority ?? null,
               taskSummary: intent.taskSummary ?? null,
@@ -352,7 +352,7 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
     const intentEntry = intentByMsgId.get(doc.id);
     const intent = intentEntry?.data ?? null;
 
-    if (category && intent?.category !== category) {
+    if (category && !intent?.categories?.includes(category)) {
       return null; // フィルタ外
     }
     if (
@@ -390,12 +390,12 @@ chatMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
       intent: intent
         ? {
             id: intentEntry?.id ?? "",
-            category: intent.category as ChatCategory,
+            categories: intent.categories ?? [],
             confidenceScore: intent.confidenceScore,
             classificationMethod: intent.classificationMethod ?? "ai",
             regexPattern: intent.regexPattern ?? null,
             isManualOverride: intent.isManualOverride ?? false,
-            originalCategory: intent.originalCategory ?? null,
+            originalCategories: intent.originalCategories ?? null,
             responseStatus: intent.responseStatus ?? "unresponded",
             taskPriority: intent.taskPriority ?? null,
             taskSummary: intent.taskSummary ?? null,
@@ -525,13 +525,13 @@ chatMessageRoutes.get("/:id", async (c) => {
     intent: intent
       ? {
           id: intentDoc?.id,
-          category: intent.category,
+          categories: intent.categories ?? [],
           confidenceScore: intent.confidenceScore,
           classificationMethod: intent.classificationMethod ?? "ai",
           regexPattern: intent.regexPattern ?? null,
           reasoning: intent.llmOutput ?? null,
           isManualOverride: intent.isManualOverride ?? false,
-          originalCategory: intent.originalCategory ?? null,
+          originalCategories: intent.originalCategories ?? null,
           overriddenBy: intent.overriddenBy ?? null,
           overriddenAt: toISOOrNull(intent.overriddenAt),
           responseStatus: intent.responseStatus ?? "unresponded",
@@ -557,7 +557,7 @@ chatMessageRoutes.get("/:id", async (c) => {
 // ---------------------------------------------------------------------------
 chatMessageRoutes.patch("/:id/intent", zValidator("json", patchIntentSchema), async (c) => {
   const chatMessageId = c.req.param("id");
-  const { category, comment } = c.req.valid("json");
+  const { categories, comment } = c.req.valid("json");
   const actor = c.get("user");
   const actorRole = c.get("actorRole");
 
@@ -584,12 +584,12 @@ chatMessageRoutes.patch("/:id/intent", zValidator("json", patchIntentSchema), as
       const intentRef = existingDoc.ref;
       const current = existingDoc.data();
       tx.update(intentRef, {
-        category,
+        categories,
         classificationMethod: "manual",
         isManualOverride: true,
-        originalCategory: current.isManualOverride
-          ? current.originalCategory // 2回目以降は最初のオリジナルを保持
-          : current.category,
+        originalCategories: current.isManualOverride
+          ? current.originalCategories // 2回目以降は最初のオリジナルを保持
+          : current.categories,
         overriddenBy: actor.email,
         overriddenAt: FieldValue.serverTimestamp(),
       });
@@ -598,7 +598,7 @@ chatMessageRoutes.patch("/:id/intent", zValidator("json", patchIntentSchema), as
       const intentRef = collections.intentRecords.doc();
       tx.set(intentRef, {
         chatMessageId,
-        category,
+        categories,
         confidenceScore: 1.0,
         extractedParams: null,
         classificationMethod: "manual",
@@ -606,7 +606,7 @@ chatMessageRoutes.patch("/:id/intent", zValidator("json", patchIntentSchema), as
         llmInput: null,
         llmOutput: comment ?? null,
         isManualOverride: true,
-        originalCategory: null,
+        originalCategories: null,
         overriddenBy: actor.email,
         overriddenAt: FieldValue.serverTimestamp() as never,
         responseStatus: "unresponded",
@@ -634,7 +634,7 @@ chatMessageRoutes.patch("/:id/intent", zValidator("json", patchIntentSchema), as
       actorRole: actorRole,
       details: {
         chatMessageId,
-        newCategory: category,
+        newCategories: categories,
         method: "manual",
         comment: comment ?? null,
       },
@@ -647,7 +647,7 @@ chatMessageRoutes.patch("/:id/intent", zValidator("json", patchIntentSchema), as
   clearCache("stats:categories");
   clearCache("inbox-counts:");
 
-  return c.json({ success: true, chatMessageId, category });
+  return c.json({ success: true, chatMessageId, categories });
 });
 
 // ---------------------------------------------------------------------------
@@ -686,7 +686,7 @@ chatMessageRoutes.patch(
         intentDocId = intentRef.id;
         tx.set(intentRef, {
           chatMessageId,
-          category: "other" as ChatCategory,
+          categories: ["other"] as ChatCategory[],
           confidenceScore: 0,
           extractedParams: null,
           classificationMethod: "manual",
@@ -694,7 +694,7 @@ chatMessageRoutes.patch(
           llmInput: null,
           llmOutput: null,
           isManualOverride: false,
-          originalCategory: null,
+          originalCategories: null,
           overriddenBy: null,
           overriddenAt: null,
           responseStatus,
@@ -789,7 +789,7 @@ chatMessageRoutes.patch("/:id/workflow", zValidator("json", patchWorkflowSchema)
       const intentRef = collections.intentRecords.doc();
       tx.set(intentRef, {
         chatMessageId,
-        category: "other" as ChatCategory,
+        categories: ["other"] as ChatCategory[],
         confidenceScore: 0,
         extractedParams: null,
         classificationMethod: "manual",
@@ -797,7 +797,7 @@ chatMessageRoutes.patch("/:id/workflow", zValidator("json", patchWorkflowSchema)
         llmInput: null,
         llmOutput: null,
         isManualOverride: false,
-        originalCategory: null,
+        originalCategories: null,
         overriddenBy: null,
         overriddenAt: null,
         responseStatus: "unresponded",

--- a/apps/api/src/routes/classification-rules.ts
+++ b/apps/api/src/routes/classification-rules.ts
@@ -134,7 +134,7 @@ classificationRulesRoutes.post("/test", zValidator("json", testClassifySchema), 
   const config = await loadClassificationConfig();
   const result = await classifyIntent(message, undefined, config);
   return c.json({
-    category: result.category,
+    category: result.categories[0] ?? "other",
     confidence: result.confidence,
     reasoning: result.reasoning,
     classificationMethod: result.classificationMethod,

--- a/apps/api/src/routes/intent-stats.ts
+++ b/apps/api/src/routes/intent-stats.ts
@@ -148,8 +148,8 @@ intentStatsRoutes.get("/confusion-matrix", zValidator("query", periodQuerySchema
     const matrix: Record<string, Record<string, number>> = {};
     for (const doc of snapshot.docs) {
       const d = doc.data();
-      const original = d.originalCategory ?? "unknown";
-      const corrected = d.category;
+      const original = (d.originalCategories ?? ["unknown"])[0] ?? "unknown";
+      const corrected = (d.categories ?? ["unknown"])[0] ?? "unknown";
       if (!matrix[original]) matrix[original] = {};
       matrix[original][corrected] = (matrix[original][corrected] ?? 0) + 1;
     }
@@ -302,7 +302,7 @@ intentStatsRoutes.get("/override-patterns", async (c) => {
 
     for (const doc of overrideSnap.docs) {
       const d = doc.data();
-      const key = `${d.originalCategory ?? "unknown"}->${d.category}`;
+      const key = `${(d.originalCategories ?? ["unknown"])[0] ?? "unknown"}->${(d.categories ?? ["unknown"])[0] ?? "unknown"}`;
       if (!patternsMap[key]) {
         patternsMap[key] = { count: 0, chatMessageIds: [] };
       }

--- a/apps/api/src/routes/line-messages.ts
+++ b/apps/api/src/routes/line-messages.ts
@@ -33,7 +33,7 @@ function serialize(id: string, msg: Record<string, unknown>) {
     assignees: (msg.assignees as string) ?? null,
     deadline: msg.deadline ? toISO(msg.deadline as FirebaseFirestore.Timestamp) : null,
     responseStatus: (msg.responseStatus as string) ?? "unresponded",
-    category: (msg.category as string) ?? null,
+    categories: (msg.categories as string[]) ?? [],
     workflowSteps: (msg.workflowSteps as Record<string, unknown>) ?? null,
     notes: (msg.notes as string) ?? null,
     createdAt: toISO(msg.createdAt as FirebaseFirestore.Timestamp),
@@ -63,7 +63,7 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
     ]) as FirebaseFirestore.Query;
     if (groupId) tpQuery = tpQuery.where("groupId", "==", groupId);
     if (responseStatus) tpQuery = tpQuery.where("responseStatus", "==", responseStatus);
-    if (category) tpQuery = tpQuery.where("category", "==", category);
+    if (category) tpQuery = tpQuery.where("categories", "array-contains", category);
 
     const tpSnap = await tpQuery.limit(500).get();
     const allDocs = tpSnap.docs.sort((a, b) => {
@@ -89,7 +89,7 @@ lineMessageRoutes.get("/", zValidator("query", listQuerySchema), async (c) => {
     query = query.where("responseStatus", "==", responseStatus);
   }
   if (category) {
-    query = query.where("category", "==", category);
+    query = query.where("categories", "array-contains", category);
   }
 
   const snapshot = await query
@@ -197,7 +197,7 @@ lineMessageRoutes.get("/:id", async (c) => {
     assignees: msg.assignees ?? null,
     deadline: msg.deadline ? toISO(msg.deadline) : null,
     responseStatus: msg.responseStatus ?? "unresponded",
-    category: msg.category ?? null,
+    categories: msg.categories ?? [],
     responseStatusUpdatedBy: msg.responseStatusUpdatedBy ?? null,
     responseStatusUpdatedAt: msg.responseStatusUpdatedAt
       ? toISO(msg.responseStatusUpdatedAt)
@@ -280,7 +280,7 @@ const updateWorkflowSchema = z
     deadline: z.string().datetime({ offset: true }).nullable().optional(),
     notes: z.string().max(2000).nullable().optional(),
     workflowSteps: workflowStepsSchema.optional(),
-    category: z.enum(CHAT_CATEGORIES).nullable().optional(),
+    categories: z.array(z.enum(CHAT_CATEGORIES)).min(1).optional(),
   })
   .refine((data) => Object.keys(data).length > 0, {
     message: "更新するフィールドを1つ以上指定してください",
@@ -315,8 +315,8 @@ lineMessageRoutes.patch("/:id/workflow", zValidator("json", updateWorkflowSchema
     updates.workflowUpdatedBy = actor.email;
     updates.workflowUpdatedAt = FieldValue.serverTimestamp();
   }
-  if (body.category !== undefined) {
-    updates.category = body.category;
+  if (body.categories !== undefined) {
+    updates.categories = body.categories;
   }
 
   if (Object.keys(updates).length > 0) {

--- a/apps/api/src/routes/manual-tasks.ts
+++ b/apps/api/src/routes/manual-tasks.ts
@@ -15,7 +15,7 @@ const createSchema = z.object({
   content: z.string().max(2000).optional().default(""),
   taskPriority: z.enum(TASK_PRIORITIES),
   responseStatus: z.enum(RESPONSE_STATUSES).optional().default("unresponded"),
-  category: z.enum(CHAT_CATEGORIES).nullable().optional().default(null),
+  categories: z.array(z.enum(CHAT_CATEGORIES)).optional().default([]),
   assignees: z.string().max(200).nullable().optional().default(null),
   deadline: z.string().datetime({ offset: true }).nullable().optional().default(null),
 });
@@ -26,7 +26,7 @@ const updateSchema = z
     content: z.string().max(2000),
     taskPriority: z.enum(TASK_PRIORITIES),
     responseStatus: z.enum(RESPONSE_STATUSES),
-    category: z.enum(CHAT_CATEGORIES).nullable(),
+    categories: z.array(z.enum(CHAT_CATEGORIES)),
     assignees: z.string().max(200).nullable(),
     deadline: z.string().datetime({ offset: true }).nullable(),
     notes: z.string().max(2000).nullable(),
@@ -52,7 +52,7 @@ function serialize(id: string, data: ManualTask) {
     content: data.content,
     taskPriority: data.taskPriority,
     responseStatus: data.responseStatus,
-    category: data.category ?? null,
+    categories: data.categories ?? [],
     assignees: data.assignees,
     deadline: toISOOrNull(data.deadline),
     workflowSteps: data.workflowSteps ?? null,
@@ -77,7 +77,7 @@ app.get("/", zValidator("query", listQuerySchema), async (c) => {
   ) as FirebaseFirestore.Query<ManualTask>;
   if (taskPriority) query = query.where("taskPriority", "==", taskPriority);
   if (responseStatus) query = query.where("responseStatus", "==", responseStatus);
-  if (category) query = query.where("category", "==", category);
+  if (category) query = query.where("categories", "array-contains", category);
 
   const [countSnap, docsSnap] = await Promise.all([
     query.count().get(),
@@ -105,7 +105,7 @@ app.post("/", zValidator("json", createSchema), async (c) => {
     content: data.content,
     taskPriority: data.taskPriority,
     responseStatus: data.responseStatus,
-    category: data.category,
+    categories: data.categories,
     assignees: data.assignees,
     deadline: data.deadline ? Timestamp.fromDate(new Date(data.deadline)) : null,
     createdBy: user.email,
@@ -159,7 +159,7 @@ app.patch("/:id", zValidator("json", updateSchema), async (c) => {
   if (body.content !== undefined) updateData.content = body.content;
   if (body.taskPriority !== undefined) updateData.taskPriority = body.taskPriority;
   if (body.responseStatus !== undefined) updateData.responseStatus = body.responseStatus;
-  if (body.category !== undefined) updateData.category = body.category;
+  if (body.categories !== undefined) updateData.categories = body.categories;
   if (body.assignees !== undefined) updateData.assignees = body.assignees;
   if (body.deadline !== undefined)
     updateData.deadline = body.deadline ? Timestamp.fromDate(new Date(body.deadline)) : null;

--- a/apps/api/src/routes/stats.ts
+++ b/apps/api/src/routes/stats.ts
@@ -87,9 +87,11 @@ statsRoutes.get("/categories", async (c) => {
   }
 
   for (const doc of intentSnap.docs) {
-    const cat = doc.data().category;
-    if (cat in counts && counts[cat] !== undefined) {
-      counts[cat]++;
+    const cats = doc.data().categories ?? [];
+    for (const cat of cats) {
+      if (cat in counts && counts[cat] !== undefined) {
+        counts[cat]++;
+      }
     }
   }
 

--- a/apps/api/src/services/chat-sync.ts
+++ b/apps/api/src/services/chat-sync.ts
@@ -41,7 +41,7 @@ async function classifyAndSaveIntent(
   const batch = db.batch();
   batch.set(collections.intentRecords.doc(), {
     chatMessageId: docId,
-    category: result.category,
+    categories: result.categories,
     confidenceScore: result.confidence,
     extractedParams: null,
     classificationMethod: result.classificationMethod,
@@ -49,7 +49,7 @@ async function classifyAndSaveIntent(
     llmInput: result.classificationMethod === "ai" ? content : null,
     llmOutput: result.classificationMethod === "ai" ? result.reasoning : null,
     isManualOverride: false,
-    originalCategory: null,
+    originalCategories: null,
     overriddenBy: null,
     overriddenAt: null,
     responseStatus: "unresponded",

--- a/apps/web/src/__tests__/api-contract.test.ts
+++ b/apps/web/src/__tests__/api-contract.test.ts
@@ -101,12 +101,12 @@ const sampleDraftDetail: DraftDetail = {
 
 const sampleIntentSummary: IntentSummary = {
   id: "intent-001",
-  category: "salary_change",
+  categories: ["salary_change"],
   confidenceScore: 0.95,
   classificationMethod: "ai",
   regexPattern: null,
   isManualOverride: false,
-  originalCategory: null,
+  originalCategories: null,
   responseStatus: "unresponded",
   taskPriority: null,
   taskSummary: null,
@@ -502,7 +502,7 @@ describe("LineMessageSummary 契約", () => {
     assignees: null,
     deadline: null,
     responseStatus: "unresponded",
-    category: null,
+    categories: [],
     workflowSteps: null,
     notes: null,
     createdAt: "2026-03-01T09:00:00.000Z",
@@ -512,10 +512,10 @@ describe("LineMessageSummary 契約", () => {
     expect(hasAllKeys(sampleLineMessage, ["workflowSteps", "notes"])).toBe(true);
   });
 
-  it("category が null 許容で string を受け付けること", () => {
-    expect(sampleLineMessage.category).toBeNull();
-    const withCategory: LineMessageSummary = { ...sampleLineMessage, category: "salary" };
-    expect(withCategory.category).toBe("salary");
+  it("categories が空配列で string[] を受け付けること", () => {
+    expect(sampleLineMessage.categories).toEqual([]);
+    const withCategory: LineMessageSummary = { ...sampleLineMessage, categories: ["salary"] };
+    expect(withCategory.categories).toEqual(["salary"]);
   });
 
   it("workflowSteps が null 許容で WorkflowSteps 型を受け付けること", () => {
@@ -552,7 +552,7 @@ describe("ManualTaskSummary 契約", () => {
     content: "詳細メモ",
     taskPriority: "high",
     responseStatus: "unresponded",
-    category: null,
+    categories: [],
     assignees: null,
     deadline: null,
     workflowSteps: null,

--- a/apps/web/src/__tests__/inbox-3pane.test.tsx
+++ b/apps/web/src/__tests__/inbox-3pane.test.tsx
@@ -14,32 +14,36 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 const mockReplace = vi.fn();
 const mockSearchParams = new URLSearchParams();
 
-vi.mock("@/lib/constants", () => ({
-  CATEGORY_LABELS: {
-    salary: "給与・社保",
-    retirement: "退職・休職",
-    hiring: "入社・採用",
-    contract: "契約変更",
-    transfer: "施設・異動",
-    foreigner: "外国人・ビザ",
-    training: "研修・監査",
-    health_check: "健康診断",
-    attendance: "勤怠・休暇",
-    other: "その他",
-  },
-  RESPONSE_STATUS_LABELS: {
-    unresponded: "未対応",
-    in_progress: "対応中",
-    responded: "対応済",
-    not_required: "対応不要",
-  },
-  RESPONSE_STATUS_DOT_COLORS: {
-    unresponded: "bg-red-500",
-    in_progress: "bg-yellow-500",
-    responded: "bg-green-500",
-    not_required: "bg-gray-400",
-  },
-}));
+vi.mock("@/lib/constants", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/constants")>();
+  return {
+    ...actual,
+    CATEGORY_LABELS: {
+      salary: "給与・社保",
+      retirement: "退職・休職",
+      hiring: "入社・採用",
+      contract: "契約変更",
+      transfer: "施設・異動",
+      foreigner: "外国人・ビザ",
+      training: "研修・監査",
+      health_check: "健康診断",
+      attendance: "勤怠・休暇",
+      other: "その他",
+    },
+    RESPONSE_STATUS_LABELS: {
+      unresponded: "未対応",
+      in_progress: "対応中",
+      responded: "対応済",
+      not_required: "対応不要",
+    },
+    RESPONSE_STATUS_DOT_COLORS: {
+      unresponded: "bg-red-500",
+      in_progress: "bg-yellow-500",
+      responded: "bg-green-500",
+      not_required: "bg-gray-400",
+    },
+  };
+});
 
 vi.mock("@/lib/utils", () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(" "),
@@ -124,6 +128,7 @@ vi.mock("../app/(protected)/inbox/actions", () => ({
   updateTaskPriorityAction: vi.fn(),
   updateWorkflowAction: vi.fn(),
   updateChatAssigneesAction: vi.fn(),
+  updateChatCategoriesAction: vi.fn(),
   updateChatDeadlineAction: vi.fn(),
 }));
 
@@ -175,12 +180,12 @@ function makeSummary(overrides: Partial<ChatMessageSummary> = {}): ChatMessageSu
     createdAt: "2026-03-01T09:00:00Z",
     intent: {
       id: "intent-1",
-      category: "salary",
+      categories: ["salary"],
       confidenceScore: 0.95,
       classificationMethod: "ai",
       regexPattern: null,
       isManualOverride: false,
-      originalCategory: null,
+      originalCategories: null,
       responseStatus: "unresponded",
       taskPriority: null,
       taskSummary: null,
@@ -202,12 +207,12 @@ function makeDetail(overrides: Partial<ChatMessageDetail> = {}): ChatMessageDeta
     rawPayload: null,
     intent: {
       id: "intent-1",
-      category: "salary",
+      categories: ["salary"],
       confidenceScore: 0.95,
       classificationMethod: "ai",
       regexPattern: null,
       isManualOverride: false,
-      originalCategory: null,
+      originalCategories: null,
       responseStatus: "unresponded",
       taskPriority: null,
       taskSummary: null,

--- a/apps/web/src/__tests__/task-board-interaction.test.tsx
+++ b/apps/web/src/__tests__/task-board-interaction.test.tsx
@@ -105,7 +105,7 @@ function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
     assignees: null,
     deadline: null,
     groupName: null,
-    category: null,
+    categories: [],
     workflowSteps: null,
     notes: null,
     createdAt: "2026-03-01T09:00:00Z",

--- a/apps/web/src/__tests__/task-board.test.tsx
+++ b/apps/web/src/__tests__/task-board.test.tsx
@@ -110,7 +110,7 @@ function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
     assignees: null,
     deadline: null,
     groupName: null,
-    category: null,
+    categories: [],
     workflowSteps: null,
     notes: null,
     createdAt: "2026-03-01T09:00:00Z",
@@ -296,7 +296,7 @@ describe("TaskList", () => {
   it("カテゴリがある場合にバッジが表示される", () => {
     const html = renderToHtml(
       React.createElement(TaskList, {
-        tasks: [makeTask({ category: "salary" })],
+        tasks: [makeTask({ categories: ["salary"] })],
         selectedId: null,
         onSelect: mockOnSelect,
       }),
@@ -307,7 +307,7 @@ describe("TaskList", () => {
   it("カテゴリが null の場合はダッシュが表示される", () => {
     const html = renderToHtml(
       React.createElement(TaskList, {
-        tasks: [makeTask({ category: null })],
+        tasks: [makeTask({ categories: [] })],
         selectedId: null,
         onSelect: mockOnSelect,
       }),
@@ -348,7 +348,7 @@ describe("TaskList", () => {
         tasks: [
           makeTask({
             source: "gchat",
-            category: "salary",
+            categories: ["salary"],
             workflowSteps: {
               salaryListReflection: "completed",
               noticeExecution: "undetermined",
@@ -376,7 +376,7 @@ describe("TaskList", () => {
         tasks: [
           makeTask({
             source: "line",
-            category: "attendance",
+            categories: ["attendance"],
             workflowSteps: {
               salaryListReflection: "completed",
               smartHRReflection: "undetermined",
@@ -400,7 +400,7 @@ describe("TaskList", () => {
         tasks: [
           makeTask({
             source: "manual",
-            category: null,
+            categories: [],
             workflowSteps: {
               salaryListReflection: "undetermined",
               smartHRReflection: "undetermined",

--- a/apps/web/src/app/(protected)/chat-messages/[id]/ai-panel.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/ai-panel.tsx
@@ -43,7 +43,7 @@ interface AiPanelProps {
 export function AiPanel({ intent }: AiPanelProps) {
   const conf = getConfidenceLabel(intent.confidenceScore);
   // biome-ignore lint/style/noNonNullAssertion: オブジェクトの固定キーアクセス
-  const actions = CATEGORY_ACTIONS[intent.category] ?? CATEGORY_ACTIONS.other!;
+  const actions = CATEGORY_ACTIONS[intent.categories[0] ?? "other"] ?? CATEGORY_ACTIONS.other!;
 
   return (
     <div className="space-y-4">

--- a/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/page.tsx
@@ -42,7 +42,7 @@ export default async function ChatMessageDetailPage({ params }: Props) {
 
   // 同カテゴリの類似メッセージ取得
   const similarMessages = intent
-    ? await getChatMessages({ category: intent.category, limit: 6 }).then((res) =>
+    ? await getChatMessages({ category: intent.categories[0], limit: 6 }).then((res) =>
         res.data.filter((m) => m.id !== id).slice(0, 5),
       )
     : [];
@@ -139,21 +139,25 @@ export default async function ChatMessageDetailPage({ params }: Props) {
             {intent ? (
               <>
                 <div className="flex items-center gap-2">
-                  <span
-                    className={`rounded-full px-3 py-1 text-sm font-medium ${getCategoryPill(
-                      intent.category,
-                    )}`}
-                  >
-                    {getCategoryLabel(intent.category)}
-                  </span>
+                  {intent.categories.map((cat) => (
+                    <span
+                      key={cat}
+                      className={`rounded-full px-3 py-1 text-sm font-medium ${getCategoryPill(cat)}`}
+                    >
+                      {getCategoryLabel(cat)}
+                    </span>
+                  ))}
                   {intent.isManualOverride && (
                     <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800">
                       手動修正済
                     </span>
                   )}
                 </div>
-                {intent.isManualOverride && intent.originalCategory && (
-                  <Row label="元のカテゴリ" value={getCategoryLabel(intent.originalCategory)} />
+                {intent.isManualOverride && intent.originalCategories && (
+                  <Row
+                    label="元のカテゴリ"
+                    value={intent.originalCategories.map(getCategoryLabel).join(", ")}
+                  />
                 )}
                 {intent.overriddenBy && <Row label="修正者" value={intent.overriddenBy} />}
                 {intent.overriddenAt && (
@@ -183,7 +187,10 @@ export default async function ChatMessageDetailPage({ params }: Props) {
             <CardTitle className="text-lg">手動再分類</CardTitle>
           </CardHeader>
           <CardContent>
-            <ReclassifyForm chatMessageId={id} currentCategory={intent?.category ?? "other"} />
+            <ReclassifyForm
+              chatMessageId={id}
+              currentCategories={intent?.categories ?? ["other"]}
+            />
           </CardContent>
         </Card>
 
@@ -227,7 +234,7 @@ export default async function ChatMessageDetailPage({ params }: Props) {
             <CardTitle className="text-lg">
               同カテゴリの最近のメッセージ
               <span className="ml-2 text-sm font-normal text-muted-foreground">
-                {getCategoryLabel(intent.category)}
+                {intent.categories.map(getCategoryLabel).join(", ")}
               </span>
             </CardTitle>
           </CardHeader>

--- a/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/line-message-card.tsx
@@ -109,7 +109,7 @@ export function LineMessageCard({ msg }: { msg: LineMessageSummary }) {
               <span className="inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium bg-[#06C755]/10 text-[#06C755] ring-1 ring-inset ring-[#06C755]/20">
                 LINE
               </span>
-              <CategoryBadge category={msg.category} />
+              <CategoryBadge categories={msg.categories} />
               {msg.groupName && (
                 <span className="text-xs text-muted-foreground">{msg.groupName}</span>
               )}

--- a/apps/web/src/app/(protected)/chat-messages/message-card.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/message-card.tsx
@@ -72,8 +72,8 @@ function ConfidenceMeter({ score }: { score: number }) {
 
 export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
   const router = useRouter();
-  const catCfg = msg.intent
-    ? (CATEGORY_CONFIG[msg.intent.category] ?? CATEGORY_CONFIG.other)
+  const catCfg = msg.intent?.categories?.[0]
+    ? (CATEGORY_CONFIG[msg.intent.categories[0]] ?? CATEGORY_CONFIG.other)
     : null;
   const accent = catCfg?.accent ?? "border-l-slate-200";
   const senderDisplay = msg.senderName || "不明";
@@ -161,7 +161,7 @@ export function MessageCard({ msg }: { msg: ChatMessageSummary }) {
 
             {/* Metadata */}
             <div className="flex flex-wrap items-center gap-2">
-              <CategoryBadge category={msg.intent?.category} />
+              <CategoryBadge categories={msg.intent?.categories} />
               {methCfg && (
                 <span
                   className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${methCfg.cls}`}

--- a/apps/web/src/app/(protected)/inbox/actions.ts
+++ b/apps/web/src/app/(protected)/inbox/actions.ts
@@ -4,6 +4,7 @@ import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { revalidatePath } from "next/cache";
 import { requireAccess } from "@/lib/access-control";
 import {
+  reclassifyIntent,
   updateLineResponseStatus,
   updateLineTaskPriority,
   updateLineWorkflow,
@@ -88,6 +89,21 @@ export async function updateLineAssigneesAction(messageId: string, assignees: st
 export async function updateLineDeadlineAction(messageId: string, deadline: string | null) {
   await requireAccess();
   await updateLineWorkflow(messageId, { deadline });
+  revalidatePath("/inbox");
+  revalidatePath("/task-board");
+}
+
+export async function updateChatCategoriesAction(chatMessageId: string, categories: string[]) {
+  await requireAccess();
+  await reclassifyIntent(chatMessageId, { categories });
+  revalidatePath("/inbox");
+  revalidatePath("/chat-messages");
+  revalidatePath("/task-board");
+}
+
+export async function updateLineCategoriesAction(messageId: string, categories: string[]) {
+  await requireAccess();
+  await updateLineWorkflow(messageId, { categories });
   revalidatePath("/inbox");
   revalidatePath("/task-board");
 }

--- a/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
@@ -9,6 +9,7 @@ import type { ChatMessageDetail, ChatMessageSummary } from "@/lib/types";
 import { cn, formatDateTimeJST } from "@/lib/utils";
 import {
   updateChatAssigneesAction,
+  updateChatCategoriesAction,
   updateChatDeadlineAction,
   updateResponseStatusAction,
   updateTaskPriorityAction,
@@ -47,7 +48,7 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
         {messages.map((msg) => {
           const intent = msg.intent;
           const responseStatus = (intent?.responseStatus ?? "unresponded") as ResponseStatus;
-          const category = intent?.category ?? "other";
+          const categories = intent?.categories ?? ["other"];
           const isSelected = msg.id === selectedId;
 
           return (
@@ -82,9 +83,14 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
               <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{msg.content}</p>
 
               <div className="mt-1.5 flex items-center gap-1.5">
-                <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
-                  {CATEGORY_LABELS[category] ?? category}
-                </span>
+                {categories.map((cat) => (
+                  <span
+                    key={cat}
+                    className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground"
+                  >
+                    {CATEGORY_LABELS[cat] ?? cat}
+                  </span>
+                ))}
                 {intent?.confidenceScore != null && (
                   <span className="text-xs tabular-nums text-muted-foreground">
                     {(intent.confidenceScore * 100).toFixed(0)}%
@@ -112,6 +118,7 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
           deadline={selectedMessage.intent?.deadline ?? null}
           onUpdateAssignees={updateChatAssigneesAction}
           onUpdateDeadline={updateChatDeadlineAction}
+          onUpdateCategories={updateChatCategoriesAction}
           extraContent={
             selectedMessage.intent && (
               <div className="mt-4">

--- a/apps/web/src/app/(protected)/inbox/inbox-list.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-list.tsx
@@ -55,7 +55,7 @@ function InboxCard({
 }) {
   const intent = message.intent;
   const responseStatus = (intent?.responseStatus ?? "unresponded") as ResponseStatus;
-  const category = intent?.category ?? "other";
+  const categories = intent?.categories ?? ["other"];
   const [currentStatus, setCurrentStatus] = useState<ResponseStatus>(responseStatus);
   const [statusSaving, setStatusSaving] = useState(false);
 
@@ -98,9 +98,11 @@ function InboxCard({
           {/* Top: sender + category + status */}
           <div className="flex items-center gap-2 text-xs">
             <span className="font-medium text-foreground">{message.senderName}</span>
-            <span className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground">
-              {CATEGORY_LABELS[category] ?? category}
-            </span>
+            {categories.map((cat) => (
+              <span key={cat} className="rounded bg-muted px-1.5 py-0.5 text-muted-foreground">
+                {CATEGORY_LABELS[cat] ?? cat}
+              </span>
+            ))}
             <span
               className={cn(
                 "rounded-full px-2 py-0.5 text-xs font-medium",

--- a/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
@@ -9,6 +9,7 @@ import type { LineMessageDetail, LineMessageSummary } from "@/lib/types";
 import { cn, formatDateTimeJST } from "@/lib/utils";
 import {
   updateLineAssigneesAction,
+  updateLineCategoriesAction,
   updateLineDeadlineAction,
   updateLineResponseStatusAction,
   updateLineTaskPriorityAction,
@@ -87,7 +88,7 @@ export function LineInbox3Pane({ messages, selectedMessage, selectedId }: LineIn
                 <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-xs text-emerald-700">
                   LINE
                 </span>
-                <CategoryBadge category={msg.category} />
+                <CategoryBadge categories={msg.categories} />
                 {msg.lineMessageType !== "text" && (
                   <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
                     {msg.lineMessageType}
@@ -109,6 +110,7 @@ export function LineInbox3Pane({ messages, selectedMessage, selectedId }: LineIn
           onUpdateTaskPriority={updateLineTaskPriorityAction}
           onUpdateAssignees={updateLineAssigneesAction}
           onUpdateDeadline={updateLineDeadlineAction}
+          onUpdateCategories={updateLineCategoriesAction}
         />
       ) : (
         <div className="hidden flex-1 items-center justify-center md:flex">

--- a/apps/web/src/app/(protected)/inbox/unified-inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/unified-inbox-3pane.tsx
@@ -11,8 +11,10 @@ import type { UnifiedMessageDetail, UnifiedMessageSummary } from "@/lib/types";
 import { cn, formatDateTimeJST } from "@/lib/utils";
 import {
   updateChatAssigneesAction,
+  updateChatCategoriesAction,
   updateChatDeadlineAction,
   updateLineAssigneesAction,
+  updateLineCategoriesAction,
   updateLineDeadlineAction,
   updateLineResponseStatusAction,
   updateLineTaskPriorityAction,
@@ -32,7 +34,7 @@ interface UnifiedInbox3PaneProps {
 function GchatRow({ msg }: { msg: UnifiedMessageSummary & { source: "gchat" } }) {
   const intent = msg.intent;
   const responseStatus = (intent?.responseStatus ?? "unresponded") as ResponseStatus;
-  const category = intent?.category ?? "other";
+  const categories = intent?.categories ?? ["other"];
 
   return (
     <>
@@ -54,7 +56,7 @@ function GchatRow({ msg }: { msg: UnifiedMessageSummary & { source: "gchat" } })
       <p className="mt-1 line-clamp-2 text-xs text-muted-foreground">{msg.content}</p>
       <div className="mt-1.5 flex items-center gap-1.5">
         <span className="rounded bg-blue-50 px-1.5 py-0.5 text-xs text-blue-700">Chat</span>
-        <CategoryBadge category={category} />
+        <CategoryBadge categories={categories} />
         {intent?.confidenceScore != null && (
           <span className="text-xs tabular-nums text-muted-foreground">
             {(intent.confidenceScore * 100).toFixed(0)}%
@@ -99,7 +101,7 @@ function LineRow({ msg }: { msg: UnifiedMessageSummary & { source: "line" } }) {
       </p>
       <div className="mt-1.5 flex items-center gap-1.5">
         <span className="rounded bg-emerald-50 px-1.5 py-0.5 text-xs text-emerald-700">LINE</span>
-        <CategoryBadge category={msg.category} />
+        <CategoryBadge categories={msg.categories} />
         {msg.lineMessageType !== "text" && (
           <span className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
             {msg.lineMessageType}
@@ -124,6 +126,7 @@ function DetailPane({ message, onClose }: { message: UnifiedMessageDetail; onClo
         deadline={message.intent?.deadline ?? null}
         onUpdateAssignees={updateChatAssigneesAction}
         onUpdateDeadline={updateChatDeadlineAction}
+        onUpdateCategories={updateChatCategoriesAction}
         extraContent={
           message.intent && (
             <div className="mt-4">
@@ -149,6 +152,7 @@ function DetailPane({ message, onClose }: { message: UnifiedMessageDetail; onClo
       onUpdateTaskPriority={updateLineTaskPriorityAction}
       onUpdateAssignees={updateLineAssigneesAction}
       onUpdateDeadline={updateLineDeadlineAction}
+      onUpdateCategories={updateLineCategoriesAction}
     />
   );
 }

--- a/apps/web/src/app/(protected)/task-board/actions.ts
+++ b/apps/web/src/app/(protected)/task-board/actions.ts
@@ -87,7 +87,7 @@ export async function createManualTaskAction(body: {
   content?: string;
   taskPriority: TaskPriority;
   responseStatus?: ResponseStatus;
-  category?: string | null;
+  categories?: string[];
   assignees?: string | null;
   deadline?: string | null;
 }): Promise<ManualTaskSummary> {
@@ -154,7 +154,7 @@ export async function updateLineDeadlineFromTaskBoard(messageId: string, deadlin
 
 export async function updateLineWorkflowFromTaskBoard(
   messageId: string,
-  body: { workflowSteps?: WorkflowSteps; notes?: string | null; category?: string | null },
+  body: { workflowSteps?: WorkflowSteps; notes?: string | null; categories?: string[] },
 ) {
   await requireAccess();
   await updateLineWorkflow(messageId, body);

--- a/apps/web/src/app/(protected)/task-board/manual-task-form.tsx
+++ b/apps/web/src/app/(protected)/task-board/manual-task-form.tsx
@@ -112,7 +112,7 @@ export function ManualTaskCreateButton() {
         title,
         content: (formData.get("content") as string) || "",
         taskPriority: priority,
-        category,
+        categories: category ? [category] : [],
         assignees: assigneeValue.trim() || null,
         deadline: deadline ? `${format(deadline, "yyyy-MM-dd")}T00:00:00+09:00` : null,
       });

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -91,7 +91,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         assignees: msg.intent?.assignees ?? null,
         deadline: msg.intent?.deadline ?? null,
         groupName: null,
-        category: msg.intent?.category ?? null,
+        categories: msg.intent?.categories ?? [],
         workflowSteps: msg.intent?.workflowSteps ?? null,
         notes: msg.intent?.notes ?? null,
         createdAt: msg.createdAt,
@@ -113,7 +113,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         assignees: msg.assignees ?? null,
         deadline: msg.deadline ?? null,
         groupName: msg.groupName,
-        category: msg.category ?? null,
+        categories: msg.categories ?? [],
         workflowSteps: msg.workflowSteps ?? null,
         notes: msg.notes ?? null,
         createdAt: msg.createdAt,
@@ -134,7 +134,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
         assignees: task.assignees,
         deadline: task.deadline,
         groupName: null,
-        category: task.category ?? null,
+        categories: task.categories ?? [],
         workflowSteps: task.workflowSteps ?? null,
         notes: task.notes ?? null,
         createdAt: task.createdAt,
@@ -151,7 +151,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
     filtered = filtered.filter((t) => t.responseStatus === statusFilter);
   }
   if (categoryFilter) {
-    filtered = filtered.filter((t) => t.category === categoryFilter);
+    filtered = filtered.filter((t) => t.categories.includes(categoryFilter));
   }
 
   // 優先度順 → 日時降順でソート

--- a/apps/web/src/app/(protected)/task-board/task-board-content.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-board-content.tsx
@@ -223,6 +223,12 @@ export function TaskBoardContent({ tasks, initialSelectedId, pageOffset = 0, chi
                 onUpdateTaskPriority={updateLineTaskPriorityFromTaskBoard}
                 onUpdateAssignees={handleLineAssignees}
                 onUpdateDeadline={handleLineDeadline}
+                onUpdateCategories={async (id, cats) => {
+                  const { updateLineCategoriesAction } = await import(
+                    "@/app/(protected)/inbox/actions"
+                  );
+                  await updateLineCategoriesAction(id, cats);
+                }}
               />
             ) : isManualTask && selectedTask ? (
               <ManualTaskDetailPane task={selectedTask} onClose={handleClose} />

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -40,7 +40,7 @@ export interface TaskItem {
   assignees: string | null;
   deadline: string | null;
   groupName: string | null;
-  category: string | null;
+  categories: string[];
   workflowSteps: WorkflowSteps | null;
   notes: string | null;
   createdAt: string;
@@ -210,7 +210,7 @@ function TaskRow({
   };
 
   // 給与カテゴリのみステップ列を表示
-  const showSteps = isSalaryCategory(task.category);
+  const showSteps = task.categories.some(isSalaryCategory);
 
   // ステップ全完了 かつ 対応済でない場合にサジェスト表示
   const allStepsResolved =
@@ -340,9 +340,16 @@ function TaskRow({
 
       {/* カテゴリ */}
       <td className="px-2 py-2.5 text-center">
-        {task.category ? (
-          <span className="inline-block rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-700">
-            {CATEGORY_LABELS[task.category] ?? task.category}
+        {task.categories.length > 0 ? (
+          <span className="inline-flex flex-wrap gap-0.5">
+            {task.categories.map((cat) => (
+              <span
+                key={cat}
+                className="inline-block rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-700"
+              >
+                {CATEGORY_LABELS[cat] ?? cat}
+              </span>
+            ))}
           </span>
         ) : (
           <span className="text-muted-foreground/40">—</span>

--- a/apps/web/src/components/categories-field.tsx
+++ b/apps/web/src/components/categories-field.tsx
@@ -1,0 +1,117 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { CategoryBadge } from "@/components/category-badge";
+import { CATEGORY_CONFIG } from "@/lib/constants";
+
+interface CategoriesFieldProps {
+  categories: string[];
+  onSave: (categories: string[]) => Promise<void>;
+}
+
+const ALL_CATEGORIES = Object.entries(CATEGORY_CONFIG).map(([value, cfg]) => ({
+  value,
+  label: cfg.label,
+  pill: cfg.pill,
+}));
+
+export function CategoriesField({ categories, onSave }: CategoriesFieldProps) {
+  const [editing, setEditing] = useState(false);
+  const [selected, setSelected] = useState<string[]>(categories);
+  const [isPending, startTransition] = useTransition();
+
+  function toggleCategory(value: string) {
+    setSelected((prev) =>
+      prev.includes(value) ? prev.filter((c) => c !== value) : [...prev, value],
+    );
+  }
+
+  function handleCancel() {
+    setSelected(categories);
+    setEditing(false);
+  }
+
+  function handleSave() {
+    if (selected.length === 0) return;
+    startTransition(async () => {
+      await onSave(selected);
+      setEditing(false);
+    });
+  }
+
+  if (!editing) {
+    return (
+      <div className="flex items-center gap-2">
+        <CategoryBadge categories={categories} />
+        <button
+          type="button"
+          onClick={() => {
+            setSelected(categories);
+            setEditing(true);
+          }}
+          className="text-muted-foreground hover:text-foreground"
+          title="カテゴリを編集"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="14"
+            height="14"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            aria-hidden="true"
+          >
+            <path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z" />
+            <path d="m15 5 4 4" />
+          </svg>
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex flex-wrap gap-1.5">
+        {ALL_CATEGORIES.map((opt) => (
+          <button
+            key={opt.value}
+            type="button"
+            onClick={() => toggleCategory(opt.value)}
+            disabled={isPending}
+            className={`rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors ${
+              selected.includes(opt.value)
+                ? "bg-primary text-primary-foreground"
+                : "bg-muted text-muted-foreground hover:bg-accent"
+            }`}
+          >
+            {opt.label}
+          </button>
+        ))}
+      </div>
+      {selected.length === 0 && (
+        <p className="text-xs text-destructive">最低1つのカテゴリを選択してください</p>
+      )}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          disabled={isPending || selected.length === 0}
+          className="rounded-md bg-primary px-3 py-1 text-xs font-medium text-primary-foreground hover:bg-primary/90 disabled:opacity-50"
+        >
+          {isPending ? "保存中..." : "保存"}
+        </button>
+        <button
+          type="button"
+          onClick={handleCancel}
+          disabled={isPending}
+          className="rounded-md bg-muted px-3 py-1 text-xs font-medium text-muted-foreground hover:bg-accent"
+        >
+          キャンセル
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/category-badge.tsx
+++ b/apps/web/src/components/category-badge.tsx
@@ -1,21 +1,37 @@
 import { CATEGORY_CONFIG } from "@/lib/constants";
 
 interface CategoryBadgeProps {
-  category: string | null | undefined;
+  /** 単一カテゴリ（後方互換） */
+  category?: string | null | undefined;
+  /** 複数カテゴリ */
+  categories?: string[];
 }
 
-export function CategoryBadge({ category }: CategoryBadgeProps) {
-  const cfg = category ? (CATEGORY_CONFIG[category] ?? CATEGORY_CONFIG.other) : null;
-
-  if (!cfg) {
-    return <span className="text-xs text-muted-foreground">未分類</span>;
-  }
-
+function SingleBadge({ category }: { category: string }) {
+  // biome-ignore lint/style/noNonNullAssertion: CATEGORY_CONFIG.other is always defined
+  const cfg = (CATEGORY_CONFIG[category] ?? CATEGORY_CONFIG.other)!;
   return (
     <span
       className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${cfg.pill}`}
     >
       {cfg.label}
+    </span>
+  );
+}
+
+export function CategoryBadge({ category, categories }: CategoryBadgeProps) {
+  // categories 優先
+  const cats = categories ?? (category ? [category] : []);
+
+  if (cats.length === 0) {
+    return <span className="text-xs text-muted-foreground">未分類</span>;
+  }
+
+  return (
+    <span className="inline-flex flex-wrap gap-1">
+      {cats.map((c) => (
+        <SingleBadge key={c} category={c} />
+      ))}
     </span>
   );
 }

--- a/apps/web/src/components/line-message-detail-pane.tsx
+++ b/apps/web/src/components/line-message-detail-pane.tsx
@@ -2,7 +2,7 @@
 
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { X } from "lucide-react";
-import { CategoryBadge } from "@/components/category-badge";
+import { CategoriesField } from "@/components/categories-field";
 import { AssigneesField, DeadlineField } from "@/components/inline-edit-field";
 import { ResponseStatusButtons } from "@/components/response-status-buttons";
 import { TaskPrioritySelector } from "@/components/task-priority-selector";
@@ -16,6 +16,7 @@ interface LineMessageDetailPaneProps {
   onUpdateTaskPriority: (id: string, priority: TaskPriority | null) => Promise<void>;
   onUpdateAssignees: (id: string, assignees: string | null) => Promise<void>;
   onUpdateDeadline: (id: string, deadline: string | null) => Promise<void>;
+  onUpdateCategories: (id: string, categories: string[]) => Promise<void>;
 }
 
 export function LineMessageDetailPane({
@@ -25,6 +26,7 @@ export function LineMessageDetailPane({
   onUpdateTaskPriority,
   onUpdateAssignees,
   onUpdateDeadline,
+  onUpdateCategories,
 }: LineMessageDetailPaneProps) {
   const responseStatus = message.responseStatus;
 
@@ -45,7 +47,10 @@ export function LineMessageDetailPane({
             {message.groupName && (
               <span className="text-xs text-muted-foreground">@ {message.groupName}</span>
             )}
-            <CategoryBadge category={message.category} />
+            <CategoriesField
+              categories={message.categories}
+              onSave={(cats) => onUpdateCategories(message.id, cats)}
+            />
             <span className="text-xs text-muted-foreground">
               {formatDateTimeJST(message.createdAt)}
             </span>

--- a/apps/web/src/components/message-detail-pane.tsx
+++ b/apps/web/src/components/message-detail-pane.tsx
@@ -3,6 +3,7 @@
 import type { ResponseStatus, TaskPriority } from "@hr-system/shared";
 import { X } from "lucide-react";
 import type { ReactNode } from "react";
+import { CategoriesField } from "@/components/categories-field";
 import { AttachmentList } from "@/components/chat/attachment-list";
 import { AssigneesField, DeadlineField } from "@/components/inline-edit-field";
 import { ResponseStatusButtons } from "@/components/response-status-buttons";
@@ -33,6 +34,8 @@ export interface ChatMessageDetailPaneProps {
   onUpdateAssignees?: (id: string, assignees: string | null) => Promise<void>;
   /** Save deadline callback */
   onUpdateDeadline?: (id: string, deadline: string | null) => Promise<void>;
+  /** Save categories callback */
+  onUpdateCategories?: (id: string, categories: string[]) => Promise<void>;
 }
 
 export function ChatMessageDetailPane({
@@ -46,6 +49,7 @@ export function ChatMessageDetailPane({
   deadline,
   onUpdateAssignees,
   onUpdateDeadline,
+  onUpdateCategories,
 }: ChatMessageDetailPaneProps) {
   const intent = message.intent as IntentDetail | null;
   const responseStatus = (intent?.responseStatus ?? "unresponded") as ResponseStatus;
@@ -97,6 +101,17 @@ export function ChatMessageDetailPane({
             {message.attachments.length > 0 && (
               <div className="mt-3">
                 <AttachmentList attachments={message.attachments} />
+              </div>
+            )}
+
+            {/* カテゴリ */}
+            {intent && onUpdateCategories && (
+              <div className="mt-4">
+                <p className="mb-2 text-xs font-semibold text-muted-foreground">カテゴリ</p>
+                <CategoriesField
+                  categories={intent.categories}
+                  onSave={(cats) => onUpdateCategories(message.id, cats)}
+                />
               </div>
             )}
 

--- a/apps/web/src/components/reclassify-form.tsx
+++ b/apps/web/src/components/reclassify-form.tsx
@@ -19,20 +19,31 @@ const CATEGORY_OPTIONS = [
 
 export function ReclassifyForm({
   chatMessageId,
-  currentCategory,
+  currentCategories,
 }: {
   chatMessageId: string;
-  currentCategory: string;
+  currentCategories: string[];
 }) {
   const router = useRouter();
-  const [category, setCategory] = useState(currentCategory);
+  const [selected, setSelected] = useState<string[]>(currentCategories);
   const [comment, setComment] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
 
+  function toggleCategory(value: string) {
+    setSelected((prev) =>
+      prev.includes(value) ? prev.filter((c) => c !== value) : [...prev, value],
+    );
+  }
+
+  const hasChanged =
+    selected.length !== currentCategories.length ||
+    selected.some((c) => !currentCategories.includes(c));
+
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
+    if (selected.length === 0) return;
     setLoading(true);
     setError(null);
     setSuccess(false);
@@ -40,7 +51,7 @@ export function ReclassifyForm({
       const res = await fetch(`/api/chat-messages/${chatMessageId}/intent`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ category, comment: comment || undefined }),
+        body: JSON.stringify({ categories: selected, comment: comment || undefined }),
       });
       if (!res.ok) {
         const body = await res.json();
@@ -63,9 +74,9 @@ export function ReclassifyForm({
           <button
             key={opt.value}
             type="button"
-            onClick={() => setCategory(opt.value)}
+            onClick={() => toggleCategory(opt.value)}
             className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              category === opt.value
+              selected.includes(opt.value)
                 ? "bg-primary text-primary-foreground"
                 : "bg-muted text-muted-foreground hover:bg-accent"
             }`}
@@ -74,6 +85,10 @@ export function ReclassifyForm({
           </button>
         ))}
       </div>
+
+      {selected.length === 0 && (
+        <p className="text-xs text-destructive">最低1つのカテゴリを選択してください</p>
+      )}
 
       <textarea
         value={comment}
@@ -85,7 +100,7 @@ export function ReclassifyForm({
       />
 
       <div className="flex items-center gap-3">
-        <Button type="submit" size="sm" disabled={loading || category === currentCategory}>
+        <Button type="submit" size="sm" disabled={loading || !hasChanged || selected.length === 0}>
           {loading ? "保存中..." : "再分類を保存"}
         </Button>
         {success && <span className="text-sm text-green-600">保存しました</span>}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -139,8 +139,8 @@ export function getChatMessage(id: string) {
   return request<ChatMessageDetail>(`/api/chat-messages/${id}`);
 }
 
-export function reclassifyIntent(id: string, body: { category: string; comment?: string }) {
-  return request<{ success: boolean; chatMessageId: string; category: string }>(
+export function reclassifyIntent(id: string, body: { categories: string[]; comment?: string }) {
+  return request<{ success: boolean; chatMessageId: string; categories: string[] }>(
     `/api/chat-messages/${id}/intent`,
     { method: "PATCH", body: JSON.stringify(body) },
   );
@@ -446,7 +446,7 @@ export function updateLineWorkflow(
     deadline?: string | null;
     notes?: string | null;
     workflowSteps?: WorkflowSteps;
-    category?: string | null;
+    categories?: string[];
   },
 ) {
   return request<{ success: boolean }>(`/api/line-messages/${encodeURIComponent(id)}/workflow`, {
@@ -490,7 +490,7 @@ export function createManualTask(body: {
   content?: string;
   taskPriority: TaskPriority;
   responseStatus?: ResponseStatus;
-  category?: string | null;
+  categories?: string[];
   assignees?: string | null;
   deadline?: string | null;
 }) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -191,12 +191,12 @@ export interface AdminUser {
 /** Intent 分類結果（一覧・詳細共通） */
 export interface IntentSummary {
   id: string;
-  category: string;
+  categories: string[];
   confidenceScore: number;
   classificationMethod: "ai" | "regex" | "manual";
   regexPattern: string | null;
   isManualOverride: boolean;
-  originalCategory: string | null;
+  originalCategories: string[] | null;
   responseStatus: "unresponded" | "in_progress" | "responded" | "not_required";
   taskPriority: TaskPriority | null;
   taskSummary: string | null;
@@ -360,7 +360,7 @@ export interface LineMessageSummary {
   assignees: string | null;
   deadline: string | null;
   responseStatus: ResponseStatus;
-  category: string | null;
+  categories: string[];
   workflowSteps: WorkflowSteps | null;
   notes: string | null;
   createdAt: string;
@@ -398,7 +398,7 @@ export interface ManualTaskSummary {
   content: string;
   taskPriority: TaskPriority;
   responseStatus: ResponseStatus;
-  category: string | null;
+  categories: string[];
   assignees: string | null;
   deadline: string | null;
   workflowSteps: WorkflowSteps | null;

--- a/apps/worker/src/__tests__/line-webhook.test.ts
+++ b/apps/worker/src/__tests__/line-webhook.test.ts
@@ -25,7 +25,7 @@ vi.mock("@hr-system/db", () => ({
 
 vi.mock("@hr-system/ai", () => ({
   classifyIntent: vi.fn().mockResolvedValue({
-    category: "attendance",
+    categories: ["attendance"],
     confidence: 0.92,
     reasoning: "勤務表に関する相談",
     classificationMethod: "regex",
@@ -179,7 +179,7 @@ describe("LINE Webhook", () => {
       undefined,
       expect.any(Object),
     );
-    expect(mockUpdate).toHaveBeenCalledWith({ category: "attendance" });
+    expect(mockUpdate).toHaveBeenCalledWith({ categories: ["attendance"] });
   });
 
   it("カテゴリ分類が失敗してもメッセージ保存は成功する", async () => {

--- a/apps/worker/src/__tests__/process-message.integration.test.ts
+++ b/apps/worker/src/__tests__/process-message.integration.test.ts
@@ -100,7 +100,7 @@ describe("processMessage Firestore 操作 — Emulator 統合テスト", () => {
       const intentRef = db.collection("intent_records").doc();
       await intentRef.set({
         chatMessageId: chatRef.id,
-        category: "salary",
+        categories: ["salary"],
         confidenceScore: 0.95,
         extractedParams: null,
         classificationMethod: "ai",
@@ -108,7 +108,7 @@ describe("processMessage Firestore 操作 — Emulator 統合テスト", () => {
         llmInput: "テスト",
         llmOutput: "給与変更の指示",
         isManualOverride: false,
-        originalCategory: null,
+        originalCategories: null,
         overriddenBy: null,
         overriddenAt: null,
         responseStatus: "unresponded",
@@ -128,7 +128,7 @@ describe("processMessage Firestore 操作 — Emulator 統合テスト", () => {
       expect(doc.exists).toBe(true);
       const data = doc.data()!;
       expect(data.chatMessageId).toBe(chatRef.id);
-      expect(data.category).toBe("salary");
+      expect(data.categories).toEqual(["salary"]);
       expect(data.confidenceScore).toBe(0.95);
       expect(data.classificationMethod).toBe("ai");
       expect(data.responseStatus).toBe("unresponded");
@@ -139,7 +139,7 @@ describe("processMessage Firestore 操作 — Emulator 統合テスト", () => {
 
       await db.collection("intent_records").add({
         chatMessageId,
-        category: "other",
+        categories: ["other"],
         confidenceScore: 0.8,
         createdAt: FieldValue.serverTimestamp(),
       });
@@ -151,7 +151,7 @@ describe("processMessage Firestore 操作 — Emulator 統合テスト", () => {
         .get();
 
       expect(snap.empty).toBe(false);
-      expect(snap.docs[0]!.data().category).toBe("other");
+      expect(snap.docs[0]!.data().categories).toEqual(["other"]);
     });
   });
 
@@ -278,7 +278,7 @@ describe("processMessage Firestore 操作 — Emulator 統合テスト", () => {
       // 親の IntentRecord
       await db.collection("intent_records").add({
         chatMessageId: parentChatId,
-        category: "salary",
+        categories: ["salary"],
         confidenceScore: 0.95,
         createdAt: FieldValue.serverTimestamp(),
       });
@@ -291,7 +291,7 @@ describe("processMessage Firestore 操作 — Emulator 統合テスト", () => {
 
       expect(snap.empty).toBe(false);
       const data = snap.docs[0]!.data();
-      expect(data.category).toBe("salary");
+      expect(data.categories).toEqual(["salary"]);
       expect(data.confidenceScore).toBe(0.95);
     });
   });
@@ -327,7 +327,7 @@ describe("processMessage Firestore 操作 — Emulator 統合テスト", () => {
       const intentRef = db.collection("intent_records").doc();
       await intentRef.set({
         chatMessageId: chatRef.id,
-        category: "salary",
+        categories: ["salary"],
         confidenceScore: 0.95,
         classificationMethod: "ai",
         responseStatus: "unresponded",

--- a/apps/worker/src/__tests__/process-message.test.ts
+++ b/apps/worker/src/__tests__/process-message.test.ts
@@ -150,7 +150,7 @@ describe("processMessage", () => {
     mockGetClassificationConfig.mockResolvedValue({});
     // デフォルト: 非給与カテゴリ
     mockClassifyIntent.mockResolvedValue({
-      category: "other",
+      categories: ["other"],
       confidence: 0.9,
       reasoning: "その他の指示",
       classificationMethod: "ai",
@@ -197,7 +197,7 @@ describe("processMessage", () => {
 
     it("給与カテゴリ: handleSalary を呼ぶ", async () => {
       mockClassifyIntent.mockResolvedValue({
-        category: "salary",
+        categories: ["salary"],
         confidence: 0.95,
         reasoning: "給与変更指示",
         classificationMethod: "ai",
@@ -211,7 +211,7 @@ describe("processMessage", () => {
       expect(mockHandleSalary).toHaveBeenCalledWith(
         mockChatMessageRef.id,
         expect.objectContaining({ text: "山田さんの給与を2ピッチ上げてください" }),
-        expect.objectContaining({ category: "salary" }),
+        expect.objectContaining({ categories: ["salary"] }),
       );
     });
 
@@ -285,7 +285,7 @@ describe("processMessage", () => {
         makeQuerySnapshot([
           makeDocSnapshot("intent-parent-001", {
             chatMessageId: PARENT_DOC_ID,
-            category: "salary",
+            categories: ["salary"],
             confidenceScore: 0.95,
           }),
         ]),
@@ -356,7 +356,7 @@ describe("processMessage", () => {
         makeQuerySnapshot([
           makeDocSnapshot("intent-parent-many", {
             chatMessageId: PARENT_DOC_ID,
-            category: "salary",
+            categories: ["salary"],
             confidenceScore: 0.9,
           }),
         ]),

--- a/apps/worker/src/__tests__/salary-handler.test.ts
+++ b/apps/worker/src/__tests__/salary-handler.test.ts
@@ -100,7 +100,7 @@ function makeIntentResult(
   overrides: Partial<IntentClassificationResult> = {},
 ): IntentClassificationResult {
   return {
-    category: "salary",
+    categories: ["salary"],
     confidence: 0.95,
     reasoning: "給与変更指示",
     classificationMethod: "ai",

--- a/apps/worker/src/pipeline/process-line-message.ts
+++ b/apps/worker/src/pipeline/process-line-message.ts
@@ -109,6 +109,7 @@ export async function processLineEvent(event: LineWebhookEvent): Promise<void> {
     contentUrl,
     lineMessageType: message.type,
     rawPayload: event as unknown as Record<string, unknown>,
+    categories: [],
     taskPriority: null,
     assignees: null,
     deadline: null,
@@ -125,9 +126,9 @@ export async function processLineEvent(event: LineWebhookEvent): Promise<void> {
     try {
       const config = await getClassificationConfig();
       const result = await classifyIntent(textContent, undefined, config);
-      await docRef.update({ category: result.category });
+      await docRef.update({ categories: result.categories });
       console.log(
-        `[LineWorker] Classified: ${lineMessageId} → ${result.category} (${result.classificationMethod}, confidence: ${result.confidence})`,
+        `[LineWorker] Classified: ${lineMessageId} → ${result.categories.join(",")} (${result.classificationMethod}, confidence: ${result.confidence})`,
       );
     } catch (e) {
       console.warn(`[LineWorker] Category classification failed (non-blocking): ${String(e)}`);

--- a/apps/worker/src/pipeline/process-message.ts
+++ b/apps/worker/src/pipeline/process-message.ts
@@ -99,7 +99,7 @@ export async function processMessage(event: ChatEvent): Promise<void> {
   try {
     await intentRef.set({
       chatMessageId: chatMessageRef.id,
-      category: intentResult.category,
+      categories: intentResult.categories,
       confidenceScore: intentResult.confidence,
       extractedParams: null,
       classificationMethod: intentResult.classificationMethod,
@@ -107,7 +107,7 @@ export async function processMessage(event: ChatEvent): Promise<void> {
       llmInput: intentResult.classificationMethod === "ai" ? enrichedEvent.text : null,
       llmOutput: intentResult.classificationMethod === "ai" ? intentResult.reasoning : null,
       isManualOverride: false,
-      originalCategory: null,
+      originalCategories: null,
       overriddenBy: null,
       overriddenAt: null,
       responseStatus: "unresponded",
@@ -131,12 +131,12 @@ export async function processMessage(event: ChatEvent): Promise<void> {
   await writeAuditLog("intent_classified", "intent_record", intentRef.id);
 
   // 7. カテゴリ別ハンドラへルーティング
-  if (intentResult.category === "salary") {
+  if (intentResult.categories.includes("salary")) {
     await handleSalary(chatMessageRef.id, enrichedEvent, intentResult);
   } else {
     // Phase 1: 給与以外はログのみ記録
     console.info(
-      `[Worker] Non-salary category: ${intentResult.category}, message: ${chatMessageRef.id}`,
+      `[Worker] Non-salary categories: ${intentResult.categories.join(",")}, message: ${chatMessageRef.id}`,
     );
   }
 
@@ -188,7 +188,7 @@ async function getThreadContext(
   const replyCount = Math.max(0, totalInThread - 1);
 
   return {
-    parentCategory: parentIntent?.category ?? "other",
+    parentCategory: parentIntent?.categories?.[0] ?? "other",
     parentConfidence: parentIntent?.confidenceScore ?? 0,
     parentSnippet: parentData.content.slice(0, 100),
     replyCount,

--- a/apps/worker/src/scripts/backfill-line-category.ts
+++ b/apps/worker/src/scripts/backfill-line-category.ts
@@ -32,7 +32,12 @@ async function main() {
   const snapshot = await collections.lineMessages.get();
   const targets = snapshot.docs.filter((doc) => {
     const d = doc.data();
-    return !d.category && d.lineMessageType === "text" && d.content && d.content.length > 0;
+    return (
+      (!d.categories || d.categories.length === 0) &&
+      d.lineMessageType === "text" &&
+      d.content &&
+      d.content.length > 0
+    );
   });
 
   console.log(`[Backfill] Found ${targets.length} / ${snapshot.size} messages to classify`);
@@ -55,10 +60,10 @@ async function main() {
     const d = doc.data();
     try {
       const result = await classifyIntent(d.content, undefined, config);
-      await doc.ref.update({ category: result.category });
+      await doc.ref.update({ categories: result.categories });
       classified++;
       console.log(
-        `  [${classified + failed}/${targets.length}] ${doc.id} → ${result.category} (${result.classificationMethod}, ${result.confidence.toFixed(2)})`,
+        `  [${classified + failed}/${targets.length}] ${doc.id} → ${result.categories.join(",")} (${result.classificationMethod}, ${result.confidence.toFixed(2)})`,
       );
     } catch (e) {
       failed++;

--- a/apps/worker/src/scripts/migrate-category-to-categories.ts
+++ b/apps/worker/src/scripts/migrate-category-to-categories.ts
@@ -1,0 +1,221 @@
+/**
+ * category → categories マイグレーションスクリプト
+ *
+ * 既存ドキュメントの `category: string` を `categories: string[]` に変換し、
+ * 旧 `category` フィールドを削除する。
+ *
+ * 対象コレクション:
+ *   - intent_records: category → categories, originalCategory → originalCategories
+ *   - line_messages: category → categories
+ *   - manual_tasks: category → categories
+ *
+ * 実行:
+ *   pnpm --filter @hr-system/worker tsx src/scripts/migrate-category-to-categories.ts
+ *
+ * --dry-run フラグで更新せずに対象件数のみ確認可能:
+ *   pnpm --filter @hr-system/worker tsx src/scripts/migrate-category-to-categories.ts --dry-run
+ */
+import "@hr-system/db/client"; // Firebase 初期化
+import { collections } from "@hr-system/db";
+import { FieldValue } from "firebase-admin/firestore";
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const BATCH_SIZE = 500;
+
+interface MigrationResult {
+  collection: string;
+  total: number;
+  migrated: number;
+  skipped: number;
+  failed: number;
+}
+
+async function migrateIntentRecords(): Promise<MigrationResult> {
+  const name = "intent_records";
+  console.log(`\n[Migrate] Processing ${name}...`);
+
+  const snapshot = await collections.intentRecords.get();
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  const docs = snapshot.docs;
+  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
+    const batch = docs.slice(i, i + BATCH_SIZE);
+    const writeBatch = collections.intentRecords.firestore.batch();
+    let batchCount = 0;
+
+    for (const doc of batch) {
+      const data = doc.data() as unknown as Record<string, unknown>;
+
+      // 既に移行済み（categories フィールドが存在）
+      if (Array.isArray(data.categories)) {
+        skipped++;
+        continue;
+      }
+
+      const category = data.category as string | null | undefined;
+      const categories = category ? [category] : [];
+
+      const originalCategory = data.originalCategory as string | null | undefined;
+      const originalCategories = originalCategory ? [originalCategory] : null;
+
+      if (!DRY_RUN) {
+        writeBatch.update(doc.ref, {
+          categories,
+          originalCategories,
+          category: FieldValue.delete(),
+          originalCategory: FieldValue.delete(),
+        });
+        batchCount++;
+      }
+      migrated++;
+    }
+
+    if (!DRY_RUN && batchCount > 0) {
+      try {
+        await writeBatch.commit();
+      } catch (e) {
+        failed += batchCount;
+        migrated -= batchCount;
+        console.error(`  Batch commit failed: ${String(e)}`);
+      }
+    }
+  }
+
+  console.log(
+    `  [${name}] total=${snapshot.size}, migrated=${migrated}, skipped=${skipped}, failed=${failed}`,
+  );
+  return { collection: name, total: snapshot.size, migrated, skipped, failed };
+}
+
+async function migrateLineMessages(): Promise<MigrationResult> {
+  const name = "line_messages";
+  console.log(`\n[Migrate] Processing ${name}...`);
+
+  const snapshot = await collections.lineMessages.get();
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  const docs = snapshot.docs;
+  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
+    const batch = docs.slice(i, i + BATCH_SIZE);
+    const writeBatch = collections.lineMessages.firestore.batch();
+    let batchCount = 0;
+
+    for (const doc of batch) {
+      const data = doc.data() as unknown as Record<string, unknown>;
+
+      if (Array.isArray(data.categories)) {
+        skipped++;
+        continue;
+      }
+
+      const category = data.category as string | null | undefined;
+      const categories = category ? [category] : [];
+
+      if (!DRY_RUN) {
+        writeBatch.update(doc.ref, {
+          categories,
+          category: FieldValue.delete(),
+        });
+        batchCount++;
+      }
+      migrated++;
+    }
+
+    if (!DRY_RUN && batchCount > 0) {
+      try {
+        await writeBatch.commit();
+      } catch (e) {
+        failed += batchCount;
+        migrated -= batchCount;
+        console.error(`  Batch commit failed: ${String(e)}`);
+      }
+    }
+  }
+
+  console.log(
+    `  [${name}] total=${snapshot.size}, migrated=${migrated}, skipped=${skipped}, failed=${failed}`,
+  );
+  return { collection: name, total: snapshot.size, migrated, skipped, failed };
+}
+
+async function migrateManualTasks(): Promise<MigrationResult> {
+  const name = "manual_tasks";
+  console.log(`\n[Migrate] Processing ${name}...`);
+
+  const snapshot = await collections.manualTasks.get();
+  let migrated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  const docs = snapshot.docs;
+  for (let i = 0; i < docs.length; i += BATCH_SIZE) {
+    const batch = docs.slice(i, i + BATCH_SIZE);
+    const writeBatch = collections.manualTasks.firestore.batch();
+    let batchCount = 0;
+
+    for (const doc of batch) {
+      const data = doc.data() as unknown as Record<string, unknown>;
+
+      if (Array.isArray(data.categories)) {
+        skipped++;
+        continue;
+      }
+
+      const category = data.category as string | null | undefined;
+      const categories = category ? [category] : [];
+
+      if (!DRY_RUN) {
+        writeBatch.update(doc.ref, {
+          categories,
+          category: FieldValue.delete(),
+        });
+        batchCount++;
+      }
+      migrated++;
+    }
+
+    if (!DRY_RUN && batchCount > 0) {
+      try {
+        await writeBatch.commit();
+      } catch (e) {
+        failed += batchCount;
+        migrated -= batchCount;
+        console.error(`  Batch commit failed: ${String(e)}`);
+      }
+    }
+  }
+
+  console.log(
+    `  [${name}] total=${snapshot.size}, migrated=${migrated}, skipped=${skipped}, failed=${failed}`,
+  );
+  return { collection: name, total: snapshot.size, migrated, skipped, failed };
+}
+
+async function main() {
+  console.log(`[Migrate] category → categories migration${DRY_RUN ? " (DRY RUN)" : ""}`);
+
+  const results = await Promise.all([
+    migrateIntentRecords(),
+    migrateLineMessages(),
+    migrateManualTasks(),
+  ]);
+
+  console.log("\n[Migrate] Summary:");
+  for (const r of results) {
+    console.log(
+      `  ${r.collection}: ${r.migrated} migrated, ${r.skipped} skipped, ${r.failed} failed (total: ${r.total})`,
+    );
+  }
+
+  const totalFailed = results.reduce((sum, r) => sum + r.failed, 0);
+  process.exit(totalFailed > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error("[Migrate] Fatal error:", e);
+  process.exit(1);
+});

--- a/packages/ai/src/__tests__/intent-classifier.test.ts
+++ b/packages/ai/src/__tests__/intent-classifier.test.ts
@@ -46,7 +46,7 @@ describe("classifyIntent", () => {
 
     const result = await classifyIntent("田中さんの給与を30万に変更してください");
 
-    expect(result.category).toBe("salary");
+    expect(result.categories[0]).toBe("salary");
     expect(result.confidence).toBeGreaterThan(0.8);
     expect(result.reasoning).toBeTruthy();
   });
@@ -62,7 +62,7 @@ describe("classifyIntent", () => {
 
     const result = await classifyIntent("山田さんが退職します");
 
-    expect(result.category).toBe("retirement");
+    expect(result.categories[0]).toBe("retirement");
   });
 
   it("健康診断メッセージをhealth_checkに分類する", async () => {
@@ -76,7 +76,7 @@ describe("classifyIntent", () => {
 
     const result = await classifyIntent("健康診断の予約をお願いします");
 
-    expect(result.category).toBe("health_check");
+    expect(result.categories[0]).toBe("health_check");
   });
 
   it("confidenceが0-1の範囲であること", async () => {
@@ -142,7 +142,7 @@ describe("classifyIntent — ThreadContext", () => {
   it("親confidence >= 0.90 の場合、返信は同カテゴリを継承する（AI 呼び出しなし）", async () => {
     const result = await classifyIntent("承知しました", salaryContext);
 
-    expect(result.category).toBe("salary");
+    expect(result.categories[0]).toBe("salary");
     expect(result.confidence).toBeCloseTo(0.95 * 0.9, 5);
     expect(result.classificationMethod).toBe("regex");
     expect(result.regexPattern).toBe("thread_context_inheritance");
@@ -168,7 +168,7 @@ describe("classifyIntent — ThreadContext", () => {
 
     const result = await classifyIntent("田中さんの件はどうなりましたか", lowConfidenceContext);
 
-    expect(result.category).toBe("salary");
+    expect(result.categories[0]).toBe("salary");
     expect(result.classificationMethod).toBe("ai");
     expect(mockGenerateContent).toHaveBeenCalledOnce();
   });
@@ -185,7 +185,7 @@ describe("classifyIntent — ThreadContext", () => {
     // context 引数なし（後方互換）— regex にマッチしない曖昧なメッセージ
     const result = await classifyIntent("例の件について確認したいのですが");
 
-    expect(result.category).toBe("other");
+    expect(result.categories[0]).toBe("other");
     expect(result.classificationMethod).toBe("ai");
     expect(mockGenerateContent).toHaveBeenCalledOnce();
   });
@@ -200,7 +200,7 @@ describe("classifyIntent — ThreadContext", () => {
 
     const result = await classifyIntent("了解です", boundaryContext);
 
-    expect(result.category).toBe("contract");
+    expect(result.categories[0]).toBe("contract");
     expect(result.classificationMethod).toBe("regex");
     expect(mockGenerateContent).not.toHaveBeenCalled();
   });
@@ -225,7 +225,7 @@ describe("classifyIntent — ClassificationConfig", () => {
 
     const result = await classifyIntent("カスタム研修の実施について", undefined, config);
 
-    expect(result.category).toBe("training");
+    expect(result.categories[0]).toBe("training");
     expect(result.classificationMethod).toBe("regex");
     expect(result.regexPattern).toBe("custom_training");
     expect(mockGenerateContent).not.toHaveBeenCalled();
@@ -246,7 +246,7 @@ describe("classifyIntent — ClassificationConfig", () => {
 
     const result = await classifyIntent("テストメッセージ", undefined, config);
 
-    expect(result.category).toBe("salary");
+    expect(result.categories[0]).toBe("salary");
     expect(result.classificationMethod).toBe("ai");
     // プロンプトにカスタム内容が含まれていることを確認
     // biome-ignore lint/style/noNonNullAssertion: test assertion
@@ -276,7 +276,7 @@ describe("classifyIntent — ClassificationConfig", () => {
 
     const result = await classifyIntent("新入社員の対応", undefined, config);
 
-    expect(result.category).toBe("hiring");
+    expect(result.categories[0]).toBe("hiring");
     // Few-shot のターン対が含まれていることを確認
     // biome-ignore lint/style/noNonNullAssertion: test assertion
     const callArgs = mockGenerateContent.mock.calls[0]![0];
@@ -291,7 +291,7 @@ describe("classifyIntent — ClassificationConfig", () => {
     // "昇給" はデフォルト REGEX_RULES にマッチする
     const result = await classifyIntent("昇給の相談です");
 
-    expect(result.category).toBe("salary");
+    expect(result.categories[0]).toBe("salary");
     expect(result.classificationMethod).toBe("regex");
     expect(mockGenerateContent).not.toHaveBeenCalled();
   });

--- a/packages/ai/src/intent-classifier.ts
+++ b/packages/ai/src/intent-classifier.ts
@@ -3,7 +3,7 @@ import { getGenerativeModel } from "./gemini-client.js";
 import { INTENT_CLASSIFICATION_PROMPT } from "./prompts.js";
 
 export interface IntentClassificationResult {
-  category: ChatCategory;
+  categories: ChatCategory[];
   confidence: number;
   reasoning: string;
   /** 分類方法: "regex"=正規表現による高確信分類, "ai"=LLMによる分類 */
@@ -191,7 +191,7 @@ function tryRegexClassify(
   if (!best || best.confidence < 0.85) return null;
 
   return {
-    category: best.rule.category,
+    categories: [best.rule.category],
     confidence: best.confidence,
     reasoning: `正規表現パターン "${best.rule.name}" にマッチ`,
     classificationMethod: "regex",
@@ -240,7 +240,7 @@ export async function classifyIntent(
   // スレッドコンテキスト継承: 親の確信度が高い場合は返信も同カテゴリとみなす
   if (context && context.parentConfidence >= 0.9) {
     return {
-      category: context.parentCategory,
+      categories: [context.parentCategory],
       confidence: context.parentConfidence * 0.9,
       reasoning: `親スレッドのカテゴリ "${context.parentCategory}" を継承（親confidence: ${context.parentConfidence.toFixed(2)}）`,
       classificationMethod: "regex",
@@ -312,7 +312,7 @@ export async function classifyIntent(
   const confidence = Math.max(0, Math.min(1, Number(result.confidence) || 0));
 
   return {
-    category: result.category as ChatCategory,
+    categories: [result.category as ChatCategory],
     confidence,
     reasoning: String(result.reasoning ?? ""),
     classificationMethod: "ai",

--- a/packages/db/src/seed/backfill-chat.ts
+++ b/packages/db/src/seed/backfill-chat.ts
@@ -490,7 +490,7 @@ async function writeMessages(messages: ChatApiMessage[]): Promise<void> {
       const intentRef = collections.intentRecords.doc(intentDocId);
       intentBatch.set(intentRef, {
         chatMessageId: docId,
-        category,
+        categories: [category],
         confidenceScore: matchedKeyword ? 0.9 : 0.5,
         extractedParams: null,
         classificationMethod: "regex" as const,
@@ -498,7 +498,7 @@ async function writeMessages(messages: ChatApiMessage[]): Promise<void> {
         llmInput: null,
         llmOutput: null,
         isManualOverride: false,
-        originalCategory: null,
+        originalCategories: null,
         overriddenBy: null,
         overriddenAt: null,
         responseStatus: "unresponded" as const,

--- a/packages/db/src/types.ts
+++ b/packages/db/src/types.ts
@@ -142,7 +142,7 @@ export interface ChatMessage {
 /** AI Intent 分類結果 */
 export interface IntentRecord {
   chatMessageId: string;
-  category: ChatCategory;
+  categories: ChatCategory[];
   confidenceScore: number;
   extractedParams: Record<string, unknown> | null;
   /** 分類方法: "regex"=正規表現, "ai"=LLM, "manual"=人手修正 */
@@ -154,7 +154,7 @@ export interface IntentRecord {
   /** 手動修正フラグ */
   isManualOverride: boolean;
   /** 修正前のカテゴリ（手動修正時のみ） */
-  originalCategory: ChatCategory | null;
+  originalCategories: ChatCategory[] | null;
   /** 修正者 email */
   overriddenBy: string | null;
   overriddenAt: Timestamp | null;
@@ -303,8 +303,8 @@ export interface LineMessage {
   assignees: string | null;
   /** 期限（ISO 8601 datetime） */
   deadline: Timestamp | null;
-  /** カテゴリ（手動選択） */
-  category?: ChatCategory | null;
+  /** カテゴリ（複数選択） */
+  categories: ChatCategory[];
   /** 対応状況（受信箱管理用） */
   responseStatus: "unresponded" | "in_progress" | "responded" | "not_required";
   /** 対応状況の最終更新者 */
@@ -366,8 +366,8 @@ export interface ManualTask {
   taskPriority: TaskPriority;
   /** 対応状況 */
   responseStatus: ResponseStatus;
-  /** カテゴリ（手動選択） */
-  category?: ChatCategory | null;
+  /** カテゴリ（複数選択） */
+  categories: ChatCategory[];
   /** 担当者（自由入力） */
   assignees: string | null;
   /** 期限（任意） */


### PR DESCRIPTION
## Summary

- データモデルを `category: string` → `categories: string[]` に完全移行
- 1メッセージに複数カテゴリを設定可能にする（例: 異動+給与変更）
- CategoriesField（インライン編集UI）を新規追加、全詳細ビューに配置
- マイグレーションスクリプト追加（既存データの変換用）

## Changes (47 files)

### Phase 1: 型定義
- `packages/db/src/types.ts`: IntentRecord, LineMessage, ManualTask の `category` → `categories`
- `packages/ai/src/intent-classifier.ts`: IntentClassificationResult を配列化
- `apps/web/src/lib/types.ts`: Web型を更新

### Phase 2: バックエンドAPI
- chat-messages, line-messages, manual-tasks の全ルートを `array-contains` クエリに変更
- PATCH ハンドラを `categories` 対応に
- intent-stats, stats ルートの集計ロジックを更新

### Phase 3: Worker
- process-message, process-line-message を `categories` 対応に

### Phase 4: マイグレーション
- `migrate-category-to-categories.ts` 新規（`--dry-run` 対応、500件バッチ）

### Phase 5: フロントエンド
- `CategoriesField` 新規コンポーネント（トグルUI、楽観的更新）
- `CategoryBadge` 複数バッジ表示対応
- `ReclassifyForm` 複数選択対応
- 全Inboxペイン、詳細ビュー、task-board を更新
- Server Actions にカテゴリ更新アクション追加

## Test plan

- [x] typecheck: 11/11 パッケージ PASS
- [x] lint: 0 errors
- [x] test: 450/450 テスト PASS (worker: 80, api: 169, web: 201)
- [x] build: 全パッケージ成功
- [ ] ブラウザ確認: 受信箱でカテゴリ編集 → 保存 → 一覧更新
- [ ] マイグレーション実行: `--dry-run` → 本実行

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)