### PR TITLE
feat: フィルターUI色統一 — ピルボタンにカテゴリ・優先度・ステータス色を適用

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/page.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/page.tsx
@@ -31,15 +31,27 @@ interface Props {
 
 const PAGE_SIZE = 30;
 
-function FilterPill({ href, label, active }: { href: string; label: string; active: boolean }) {
+function FilterPill({
+  href,
+  label,
+  active,
+  activeClass,
+  inactiveClass,
+}: {
+  href: string;
+  label: string;
+  active: boolean;
+  activeClass?: string;
+  inactiveClass?: string;
+}) {
   return (
     <Link
       href={href}
       className={cn(
         "inline-flex shrink-0 items-center rounded-full px-2.5 py-0.5 text-xs font-medium transition-colors",
         active
-          ? "bg-[var(--gradient-from)] text-white"
-          : "bg-muted text-muted-foreground hover:bg-accent",
+          ? (activeClass ?? "bg-[var(--gradient-from)] text-white")
+          : (inactiveClass ?? "bg-muted text-muted-foreground hover:bg-accent"),
       )}
     >
       {label}
@@ -272,6 +284,8 @@ export default async function ChatMessagesPage({ searchParams }: Props) {
                 href={buildUrl({ category: value, page: "1" })}
                 label={cfg.label}
                 active={params.category === value}
+                activeClass={`${cfg.pill} ring-2`}
+                inactiveClass={`${cfg.pill} opacity-60 hover:opacity-100`}
               />
             ))}
           </FilterRow>

--- a/apps/web/src/app/(protected)/inbox/page.tsx
+++ b/apps/web/src/app/(protected)/inbox/page.tsx
@@ -11,7 +11,7 @@ import {
   getLineMessage,
   getLineMessages,
 } from "@/lib/api";
-import { CATEGORY_OPTIONS } from "@/lib/constants";
+import { CATEGORY_CONFIG, CATEGORY_OPTIONS, RESPONSE_STATUS_DOT_COLORS } from "@/lib/constants";
 import type {
   ChatMessageDetail,
   LineMessageDetail,
@@ -260,6 +260,10 @@ export default async function InboxPage({ searchParams }: Props) {
           {STATUS_TABS.map((tab) => {
             const isActive = tab.value === "all" ? !activeStatus : activeStatus === tab.value;
             const count = getCount(tab.value);
+            const dotColor =
+              tab.value !== "all"
+                ? RESPONSE_STATUS_DOT_COLORS[tab.value as keyof typeof RESPONSE_STATUS_DOT_COLORS]
+                : null;
             return (
               <Link
                 key={tab.value}
@@ -274,6 +278,11 @@ export default async function InboxPage({ searchParams }: Props) {
                     : "bg-white text-slate-600 border border-slate-200 hover:bg-slate-100"
                 }`}
               >
+                {dotColor && (
+                  <span
+                    className={`inline-block h-2 w-2 rounded-full ${isActive ? "bg-white/60" : dotColor}`}
+                  />
+                )}
                 {tab.label}
                 <span
                   className={`rounded-full px-1.5 py-0.5 text-xs tabular-nums ${
@@ -291,6 +300,7 @@ export default async function InboxPage({ searchParams }: Props) {
           <div className="flex flex-wrap gap-1">
             {CATEGORY_OPTIONS.map((opt) => {
               const isActive = opt.value === "all" ? !activeCategory : activeCategory === opt.value;
+              const cfg = opt.value !== "all" ? CATEGORY_CONFIG[opt.value] : null;
               return (
                 <Link
                   key={opt.value}
@@ -301,8 +311,12 @@ export default async function InboxPage({ searchParams }: Props) {
                   })}
                   className={`rounded-full px-2.5 py-1 text-[10px] font-medium transition-colors ${
                     isActive
-                      ? "bg-slate-700 text-white"
-                      : "bg-slate-100 text-slate-600 hover:bg-slate-200"
+                      ? cfg
+                        ? `${cfg.pill} ring-2`
+                        : "bg-slate-700 text-white"
+                      : cfg
+                        ? `${cfg.pill} opacity-60 hover:opacity-100`
+                        : "bg-slate-100 text-slate-600 hover:bg-slate-200"
                   }`}
                 >
                   {opt.label}

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -3,8 +3,14 @@ import type { ChatCategory, ResponseStatus, TaskPriority } from "@hr-system/shar
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
 import { getChatMessages, getLineMessages, getManualTasks } from "@/lib/api";
-import { CATEGORY_OPTIONS } from "@/lib/constants";
-import { FilterSelect } from "./filter-select";
+import {
+  CATEGORY_CONFIG,
+  CATEGORY_OPTIONS,
+  PRIORITY_PILL_COLORS,
+  RESPONSE_STATUS_DOT_COLORS,
+  RESPONSE_STATUS_PILL_COLORS,
+  SOURCE_PILL_COLORS,
+} from "@/lib/constants";
 import { ManualTaskCreateButton } from "./manual-task-form";
 import { TaskBoardContent } from "./task-board-content";
 import type { TaskItem } from "./task-list";
@@ -169,14 +175,6 @@ export default async function TaskBoardPage({ searchParams }: Props) {
   const paged = filtered.slice(offset, offset + PAGE_SIZE);
   const hasMore = offset + PAGE_SIZE < totalCount;
 
-  // FilterSelect（Client Component）に渡すシリアライズ可能なsearchParams
-  const filterParams: Record<string, string> = {};
-  if (params.priority) filterParams.priority = params.priority;
-  if (params.source) filterParams.source = params.source;
-  if (params.status) filterParams.status = params.status;
-  if (params.category) filterParams.category = params.category;
-  if (params.id) filterParams.id = params.id;
-
   function buildUrl(overrides: {
     priority?: string;
     source?: string;
@@ -204,38 +202,137 @@ export default async function TaskBoardPage({ searchParams }: Props) {
   return (
     <div className="-m-6 flex h-[calc(100vh-52px)] flex-col">
       <TaskBoardContent tasks={paged} initialSelectedId={selectedId} pageOffset={offset}>
-        <div className="flex items-center gap-3">
-          <h1 className="text-base font-bold tracking-tight">タスク一覧</h1>
-          <ManualTaskCreateButton />
-          <div className="flex items-center gap-2">
-            <FilterSelect
-              options={PRIORITY_TABS}
-              currentValue={priorityFilter ?? "all"}
-              paramKey="priority"
-              searchParams={filterParams}
-            />
-            <FilterSelect
-              options={SOURCE_TABS}
-              currentValue={sourceFilter}
-              paramKey="source"
-              searchParams={filterParams}
-            />
-            <FilterSelect
-              options={STATUS_TABS}
-              currentValue={statusFilter ?? "all"}
-              paramKey="status"
-              searchParams={filterParams}
-            />
-            <FilterSelect
-              options={CATEGORY_OPTIONS}
-              currentValue={categoryFilter ?? "all"}
-              paramKey="category"
-              searchParams={filterParams}
-            />
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center gap-3">
+            <h1 className="text-base font-bold tracking-tight">タスク一覧</h1>
+            <ManualTaskCreateButton />
+            <span className="ml-auto text-xs tabular-nums text-muted-foreground">
+              {totalCount}件{criticalCount > 0 && ` (極高 ${criticalCount}件)`}
+            </span>
           </div>
-          <span className="ml-auto text-xs tabular-nums text-muted-foreground">
-            {totalCount}件{criticalCount > 0 && ` (極高 ${criticalCount}件)`}
-          </span>
+          <div className="flex flex-wrap items-center gap-1.5">
+            {/* 優先度 */}
+            <span className="mr-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              優先度
+            </span>
+            {PRIORITY_TABS.map((tab) => {
+              const isActive = tab.value === "all" ? !priorityFilter : priorityFilter === tab.value;
+              const colors = tab.value !== "all" ? PRIORITY_PILL_COLORS[tab.value] : null;
+              return (
+                <Link
+                  key={tab.value}
+                  href={buildUrl({
+                    priority: tab.value === "all" ? undefined : tab.value,
+                    page: "1",
+                  })}
+                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                    isActive
+                      ? (colors?.active ?? "bg-slate-800 text-white ring-2 ring-slate-300")
+                      : (colors?.inactive ??
+                        "bg-slate-50 text-slate-500 ring-1 ring-inset ring-slate-200 hover:bg-slate-100")
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+
+            <span className="mx-1.5 h-4 w-px bg-slate-200" />
+
+            {/* ソース */}
+            <span className="mr-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              ソース
+            </span>
+            {SOURCE_TABS.map((tab) => {
+              const isActive = sourceFilter === tab.value;
+              const colors = tab.value !== "all" ? SOURCE_PILL_COLORS[tab.value] : null;
+              return (
+                <Link
+                  key={tab.value}
+                  href={buildUrl({
+                    source: tab.value === "all" ? undefined : tab.value,
+                    page: "1",
+                  })}
+                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                    isActive
+                      ? (colors?.active ?? "bg-slate-800 text-white ring-2 ring-slate-300")
+                      : (colors?.inactive ??
+                        "bg-slate-50 text-slate-500 ring-1 ring-inset ring-slate-200 hover:bg-slate-100")
+                  }`}
+                >
+                  {tab.label}
+                </Link>
+              );
+            })}
+
+            <span className="mx-1.5 h-4 w-px bg-slate-200" />
+
+            {/* ステータス */}
+            <span className="mr-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              状態
+            </span>
+            {STATUS_TABS.map((tab) => {
+              const isActive = tab.value === "all" ? !statusFilter : statusFilter === tab.value;
+              const colors = tab.value !== "all" ? RESPONSE_STATUS_PILL_COLORS[tab.value] : null;
+              const dotColor =
+                tab.value !== "all"
+                  ? RESPONSE_STATUS_DOT_COLORS[tab.value as keyof typeof RESPONSE_STATUS_DOT_COLORS]
+                  : null;
+              return (
+                <Link
+                  key={tab.value}
+                  href={buildUrl({
+                    status: tab.value === "all" ? undefined : tab.value,
+                    page: "1",
+                  })}
+                  className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                    isActive
+                      ? (colors?.active ?? "bg-slate-800 text-white ring-2 ring-slate-300")
+                      : (colors?.inactive ??
+                        "bg-slate-50 text-slate-500 ring-1 ring-inset ring-slate-200 hover:bg-slate-100")
+                  }`}
+                >
+                  {dotColor && (
+                    <span
+                      className={`inline-block h-2 w-2 rounded-full ${isActive ? "bg-white/70" : dotColor}`}
+                    />
+                  )}
+                  {tab.label}
+                </Link>
+              );
+            })}
+
+            <span className="mx-1.5 h-4 w-px bg-slate-200" />
+
+            {/* カテゴリ */}
+            <span className="mr-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              分類
+            </span>
+            {CATEGORY_OPTIONS.map((opt) => {
+              const isActive = opt.value === "all" ? !categoryFilter : categoryFilter === opt.value;
+              const cfg = opt.value !== "all" ? CATEGORY_CONFIG[opt.value] : null;
+              return (
+                <Link
+                  key={opt.value}
+                  href={buildUrl({
+                    category: opt.value === "all" ? undefined : opt.value,
+                    page: "1",
+                  })}
+                  className={`inline-flex items-center rounded-full px-2.5 py-1 text-[11px] font-medium transition-colors ${
+                    isActive
+                      ? cfg
+                        ? `${cfg.pill} ring-2`
+                        : "bg-slate-800 text-white ring-2 ring-slate-300"
+                      : cfg
+                        ? `${cfg.pill} opacity-60 hover:opacity-100`
+                        : "bg-slate-50 text-slate-500 ring-1 ring-inset ring-slate-200 hover:bg-slate-100"
+                  }`}
+                >
+                  {opt.label}
+                </Link>
+              );
+            })}
+          </div>
         </div>
       </TaskBoardContent>
 

--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -84,6 +84,63 @@ export const RESPONSE_STATUS_DOT_COLORS: Record<ResponseStatus, string> = {
   not_required: "bg-gray-400",
 };
 
+/** 優先度ピル色 */
+export const PRIORITY_PILL_COLORS: Record<string, { active: string; inactive: string }> = {
+  critical: {
+    active: "bg-red-600 text-white ring-2 ring-red-300",
+    inactive: "bg-red-50 text-red-700 ring-1 ring-inset ring-red-200 hover:bg-red-100",
+  },
+  high: {
+    active: "bg-orange-500 text-white ring-2 ring-orange-300",
+    inactive: "bg-orange-50 text-orange-700 ring-1 ring-inset ring-orange-200 hover:bg-orange-100",
+  },
+  medium: {
+    active: "bg-blue-600 text-white ring-2 ring-blue-300",
+    inactive: "bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200 hover:bg-blue-100",
+  },
+  low: {
+    active: "bg-slate-500 text-white ring-2 ring-slate-300",
+    inactive: "bg-slate-50 text-slate-600 ring-1 ring-inset ring-slate-200 hover:bg-slate-100",
+  },
+};
+
+/** ソースピル色 */
+export const SOURCE_PILL_COLORS: Record<string, { active: string; inactive: string }> = {
+  gchat: {
+    active: "bg-blue-600 text-white ring-2 ring-blue-300",
+    inactive: "bg-blue-50 text-blue-700 ring-1 ring-inset ring-blue-200 hover:bg-blue-100",
+  },
+  line: {
+    active: "bg-emerald-600 text-white ring-2 ring-emerald-300",
+    inactive:
+      "bg-emerald-50 text-emerald-700 ring-1 ring-inset ring-emerald-200 hover:bg-emerald-100",
+  },
+  manual: {
+    active: "bg-amber-500 text-white ring-2 ring-amber-300",
+    inactive: "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200 hover:bg-amber-100",
+  },
+};
+
+/** 対応状況ピル色（フィルター用） */
+export const RESPONSE_STATUS_PILL_COLORS: Record<string, { active: string; inactive: string }> = {
+  unresponded: {
+    active: "bg-rose-600 text-white ring-2 ring-rose-300",
+    inactive: "bg-rose-50 text-rose-700 ring-1 ring-inset ring-rose-200 hover:bg-rose-100",
+  },
+  in_progress: {
+    active: "bg-amber-500 text-white ring-2 ring-amber-300",
+    inactive: "bg-amber-50 text-amber-700 ring-1 ring-inset ring-amber-200 hover:bg-amber-100",
+  },
+  responded: {
+    active: "bg-green-600 text-white ring-2 ring-green-300",
+    inactive: "bg-green-50 text-green-700 ring-1 ring-inset ring-green-200 hover:bg-green-100",
+  },
+  not_required: {
+    active: "bg-gray-500 text-white ring-2 ring-gray-300",
+    inactive: "bg-gray-50 text-gray-600 ring-1 ring-inset ring-gray-200 hover:bg-gray-100",
+  },
+};
+
 /** カテゴリフィルター選択肢（"すべて" + 10カテゴリ） */
 export const CATEGORY_OPTIONS: { value: ChatCategory | "all"; label: string }[] = [
   { value: "all", label: "すべて" },


### PR DESCRIPTION
## Summary
- タスクボード: `FilterSelect`(select要素) → 色付きピルボタン群に置換（優先度/ソース/ステータス/カテゴリ）
- 受信箱: カテゴリフィルターに `CATEGORY_CONFIG` 色適用 + ステータスタブにドット追加
- chat-messages: `FilterPill` にカテゴリ色の active/inactive 切替を追加

Closes #332

## Test plan
- [x] `pnpm typecheck` PASS
- [x] `pnpm lint` PASS (warnings only)
- [x] `pnpm test` 201テスト全PASS
- [x] `pnpm build` PASS
- [ ] ブラウザ確認: タスクボードのフィルターが色付きピルで表示される
- [ ] ブラウザ確認: 受信箱のカテゴリフィルターがバッジと同色、ステータスにドット付き
- [ ] ブラウザ確認: chat-messagesのカテゴリフィルターがバッジと同色

🤖 Generated with [Claude Code](https://claude.com/claude-code)