### PR TITLE
feat: ワークフローステップのラベル・並び順変更

### DIFF
--- a/apps/web/src/__tests__/ai-panel.test.ts
+++ b/apps/web/src/__tests__/ai-panel.test.ts
@@ -73,7 +73,7 @@ describe("CATEGORY_ACTIONS", () => {
   it("salary カテゴリは給与関連のアクションを含む", () => {
     const actions = CATEGORY_ACTIONS.salary;
     expect(actions).toContain("給与変更ドラフトの確認・作成");
-    expect(actions).toContain("SmartHRへの反映");
+    expect(actions).toContain("SmartHR更新");
   });
 
   it("未定義カテゴリの場合は undefined を返す（呼び出し側で other にフォールバック）", () => {

--- a/apps/web/src/app/(protected)/chat-messages/[id]/ai-panel.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/[id]/ai-panel.tsx
@@ -3,12 +3,7 @@ import type { IntentDetail } from "@/lib/types";
 import { cn } from "@/lib/utils";
 
 export const CATEGORY_ACTIONS: Record<string, string[]> = {
-  salary: [
-    "給与変更ドラフトの確認・作成",
-    "職員給与一覧SSへの反映",
-    "SmartHRへの反映",
-    "社労士への共有",
-  ],
+  salary: ["給与変更ドラフトの確認・作成", "SmartHR更新", "本人通知", "社労士共有", "給与DB反映"],
   retirement: [
     "退職届の確認",
     "最終給与計算",

--- a/apps/web/src/app/(protected)/chat-messages/table-view.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/table-view.tsx
@@ -212,25 +212,25 @@ export function TableView({
             </th>
             <th
               className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
-              title="❶SS反映"
+              title="❶SmartHR更新"
             >
               ❶
             </th>
             <th
               className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
-              title="❷SmartHR反映"
+              title="❷本人通知"
             >
               ❷
             </th>
             <th
               className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
-              title="❸通知・締結"
+              title="❸社労士共有"
             >
               ❸
             </th>
             <th
               className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
-              title="❹社労士共有"
+              title="❹給与DB反映"
             >
               ❹
             </th>

--- a/apps/web/src/lib/workflow-steps.ts
+++ b/apps/web/src/lib/workflow-steps.ts
@@ -8,10 +8,10 @@ export const STEP_CYCLE: WorkflowStepStatus[] = [
 ];
 
 export const DEFAULT_STEPS: WorkflowSteps = {
-  salaryListReflection: "undetermined",
   smartHRReflection: "undetermined",
   noticeExecution: "undetermined",
   laborLawyerShare: "undetermined",
+  salaryListReflection: "undetermined",
 };
 
 /** テーブルセル用の共通スタイル（列に依存しないアイコン・色） */
@@ -31,51 +31,51 @@ export const STEP_CONFIG: Record<WorkflowStepStatus, { label: string; cls: strin
   },
 };
 
-/** 表示順序（スプレッドシート準拠）: ❶SS反映 → ❷SmartHR → ❸通知・締結 → ❹社労士共有 */
+/** 表示順序: ❶SmartHR更新 → ❷本人通知 → ❸社労士共有 → ❹給与DB反映 */
 export const STEP_KEYS = [
-  "salaryListReflection",
   "smartHRReflection",
   "noticeExecution",
   "laborLawyerShare",
+  "salaryListReflection",
 ] as const;
 
 /** STEP_KEYS と同期した番号アイコン */
 export const STEP_NUMBERS = ["❶", "❷", "❸", "❹"] as const;
 
-/** 列ごとのステータスラベル（スプレッドシート準拠） */
+/** 列ごとのステータスラベル */
 export const STEP_STATUS_LABELS: Record<keyof WorkflowSteps, Record<WorkflowStepStatus, string>> = {
-  salaryListReflection: {
-    undetermined: "未判定",
-    not_required: "対応不要と判定",
-    completed: "要対応で反映済み",
-    pending: "要対応で未対応",
-  },
   smartHRReflection: {
     undetermined: "未判定",
-    not_required: "反映不要と判定",
-    completed: "要反映で反映済み",
-    pending: "要対応で未反映",
+    not_required: "更新不要と判定",
+    completed: "更新済み",
+    pending: "要更新で未対応",
   },
   noticeExecution: {
     undetermined: "未判定",
-    not_required: "対応不要と判定",
-    completed: "要対応で反映済み",
-    pending: "要対応で未反映",
+    not_required: "通知不要と判定",
+    completed: "通知済み",
+    pending: "要通知で未対応",
   },
   laborLawyerShare: {
     undetermined: "未判定",
-    not_required: "対応不要と判定",
-    completed: "要対応で反映済み",
-    pending: "要対応で未反映",
+    not_required: "共有不要と判定",
+    completed: "共有済み",
+    pending: "要共有で未対応",
+  },
+  salaryListReflection: {
+    undetermined: "未判定",
+    not_required: "反映不要と判定",
+    completed: "反映済み",
+    pending: "要反映で未対応",
   },
 };
 
 /** 列の表示名 */
 export const STEP_LABELS: Record<keyof WorkflowSteps, { label: string; shortLabel: string }> = {
-  salaryListReflection: { label: "職員給与一覧SSへの反映", shortLabel: "SS反映" },
-  smartHRReflection: { label: "SmartHRへの反映", shortLabel: "SmartHR" },
-  noticeExecution: { label: "通知・締結", shortLabel: "通知" },
-  laborLawyerShare: { label: "社労士共有", shortLabel: "社労士" },
+  smartHRReflection: { label: "SmartHR更新", shortLabel: "SmartHR更新" },
+  noticeExecution: { label: "本人通知", shortLabel: "本人通知" },
+  laborLawyerShare: { label: "社労士共有", shortLabel: "社労士共有" },
+  salaryListReflection: { label: "給与DB反映", shortLabel: "給与DB反映" },
 };
 
 /** 給与関連カテゴリかどうか（ワークフローステップ表示判定用） */


### PR DESCRIPTION
## Summary
- ワークフローステップの並び順とラベルを変更
- ❶SmartHR更新 → ❷本人通知 → ❸社労士共有 → ❹給与DB反映
- キー名はDB互換性維持のため変更なし

## Test plan
- [x] typecheck PASS
- [x] test 201件 PASS
- [x] build PASS
- [ ] 受信箱・タスクボード・メッセージ一覧でカラム順序・ラベルが正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)