### PR TITLE
feat: ワークフローステップ番号アイコン廃止・ラベル表示に統一

### DIFF
--- a/apps/web/src/__tests__/task-board.test.tsx
+++ b/apps/web/src/__tests__/task-board.test.tsx
@@ -317,7 +317,7 @@ describe("TaskList", () => {
     expect(html).not.toContain("給与・社保");
   });
 
-  it("テーブルヘッダーにワークフローステップ列（❶❷❸❹）が存在する", () => {
+  it("テーブルヘッダーにワークフローステップ列が存在する", () => {
     const html = renderToHtml(
       React.createElement(TaskList, {
         tasks: [makeTask()],
@@ -325,10 +325,10 @@ describe("TaskList", () => {
         onSelect: mockOnSelect,
       }),
     );
-    expect(html).toContain("❶");
-    expect(html).toContain("❷");
-    expect(html).toContain("❸");
-    expect(html).toContain("❹");
+    expect(html).toContain("SmartHR更新");
+    expect(html).toContain("本人通知");
+    expect(html).toContain("社労士共有");
+    expect(html).toContain("給与DB反映");
   });
 
   it("テーブルヘッダーにメモ列が存在する", () => {

--- a/apps/web/src/app/(protected)/chat-messages/table-view.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/table-view.tsx
@@ -5,7 +5,13 @@ import Link from "next/link";
 import { useState, useTransition } from "react";
 import type { ChatMessageSummary, WorkflowSteps } from "@/lib/types";
 import { buildMessageSearchUrl, formatDateJST } from "@/lib/utils";
-import { DEFAULT_STEPS, nextStepStatus, STEP_CONFIG, STEP_KEYS } from "@/lib/workflow-steps";
+import {
+  DEFAULT_STEPS,
+  nextStepStatus,
+  STEP_CONFIG,
+  STEP_KEYS,
+  STEP_LABELS,
+} from "@/lib/workflow-steps";
 import { updateResponseStatusAction, updateWorkflowAction } from "./[id]/actions";
 
 type ResponseStatus = NonNullable<ChatMessageSummary["intent"]>["responseStatus"];
@@ -151,7 +157,7 @@ function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
         </button>
       </td>
 
-      {/* ❶〜❹ */}
+      {/* ワークフローステップ */}
       {STEP_KEYS.map((key) => (
         <td key={key} className="w-10 px-1 py-2 text-center">
           <button
@@ -210,30 +216,15 @@ export function TableView({
             <th className="whitespace-nowrap px-2 py-2 text-center text-xs font-semibold text-muted-foreground">
               対応状況
             </th>
-            <th
-              className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
-              title="❶SmartHR更新"
-            >
-              ❶
-            </th>
-            <th
-              className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
-              title="❷本人通知"
-            >
-              ❷
-            </th>
-            <th
-              className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
-              title="❸社労士共有"
-            >
-              ❸
-            </th>
-            <th
-              className="w-10 px-1 py-2 text-center text-xs font-semibold text-muted-foreground"
-              title="❹給与DB反映"
-            >
-              ❹
-            </th>
+            {STEP_KEYS.map((key) => (
+              <th
+                key={key}
+                className="px-1 py-2 text-center text-[10px] font-semibold text-muted-foreground"
+                title={STEP_LABELS[key].label}
+              >
+                {STEP_LABELS[key].shortLabel}
+              </th>
+            ))}
             <th className="px-2 py-2 text-left text-xs font-semibold text-muted-foreground">
               メモ
             </th>

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -17,7 +17,6 @@ import {
   STEP_CONFIG,
   STEP_KEYS,
   STEP_LABELS,
-  STEP_NUMBERS,
 } from "@/lib/workflow-steps";
 import {
   updateLineResponseStatusFromTaskBoard,
@@ -111,14 +110,13 @@ export function TaskList({
               ステータス
             </th>
             <th className="w-20 px-2 py-2.5 text-left font-semibold text-muted-foreground">期限</th>
-            {STEP_KEYS.map((key, i) => (
+            {STEP_KEYS.map((key) => (
               <th
                 key={key}
                 className="w-14 px-1 py-2.5 text-center font-semibold text-muted-foreground"
                 title={STEP_LABELS[key].label}
               >
                 <span className="block text-[10px] leading-tight">
-                  {STEP_NUMBERS[i]}
                   {STEP_LABELS[key].shortLabel}
                 </span>
               </th>
@@ -382,7 +380,7 @@ function TaskRow({
         )}
       </td>
 
-      {/* ❶〜❹ ワークフローステップ（給与カテゴリのみ操作可能） */}
+      {/* ワークフローステップ（給与カテゴリのみ操作可能） */}
       {STEP_KEYS.map((key) => {
         return (
           <td key={key} className="px-1 py-2.5 text-center">

--- a/apps/web/src/lib/workflow-steps.ts
+++ b/apps/web/src/lib/workflow-steps.ts
@@ -39,9 +39,6 @@ export const STEP_KEYS = [
   "salaryListReflection",
 ] as const;
 
-/** STEP_KEYS と同期した番号アイコン */
-export const STEP_NUMBERS = ["❶", "❷", "❸", "❹"] as const;
-
 /** 列ごとのステータスラベル */
 export const STEP_STATUS_LABELS: Record<keyof WorkflowSteps, Record<WorkflowStepStatus, string>> = {
   smartHRReflection: {


### PR DESCRIPTION
## Summary
- ❶❷❸❹の番号アイコンを廃止し、ラベル名（SmartHR更新/本人通知/社労士共有/給与DB反映）を直接表示
- table-view.tsx のハードコードヘッダーを STEP_KEYS.map に統一
- STEP_NUMBERS 定数を削除

## Test plan
- [x] typecheck / test / build 全PASS
- [ ] タスクボード・メッセージ一覧でラベル表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)