### PR TITLE
feat: 記事のコピー列を折り返し全表示 (#340)

### DIFF
--- a/apps/web/src/app/(protected)/chat-messages/table-view.tsx
+++ b/apps/web/src/app/(protected)/chat-messages/table-view.tsx
@@ -100,11 +100,11 @@ function TableRow({ msg, rowNo }: { msg: ChatMessageSummary; rowNo: number }) {
       </td>
 
       {/* 記事のコピー */}
-      <td className="max-w-[240px] px-2 py-2">
+      <td className="px-2 py-2">
         <div className="flex items-start gap-1">
           <Link
             href={`/chat-messages/${msg.id}`}
-            className="line-clamp-2 text-xs text-foreground/80 hover:text-foreground hover:underline"
+            className="whitespace-pre-wrap text-xs text-foreground/80 hover:text-foreground hover:underline"
           >
             {msg.content}
           </Link>

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -281,7 +281,7 @@ function TaskRow({
         </div>
         <p
           className={cn(
-            "mt-0.5 line-clamp-2 leading-relaxed",
+            "mt-0.5 whitespace-pre-wrap leading-relaxed",
             isCritical ? "text-red-700" : "text-muted-foreground",
           )}
         >


### PR DESCRIPTION
## Summary
- 記事のコピー列の `line-clamp-2` を `whitespace-pre-wrap` に変更し全文表示
- タスクボード・メッセージ一覧の両方で対応

## Test plan
- [x] typecheck / test 全PASS
- [ ] タスクボード・メッセージ一覧で長文が折り返し表示されることを確認

Closes #340

🤖 Generated with [Claude Code](https://claude.com/claude-code)