### PR TITLE
fix: ワークフローステップのselect編集不可を修正

### DIFF
--- a/apps/web/src/__tests__/task-board.test.tsx
+++ b/apps/web/src/__tests__/task-board.test.tsx
@@ -390,8 +390,8 @@ describe("TaskList", () => {
         onOpenDialog: mockOnOpenDialog,
       }),
     );
-    // Select ドロップダウンが表示される（role="combobox"）
-    expect(html).toContain('role="combobox"');
+    // select ドロップダウンが表示される
+    expect(html).toContain("<select");
     // completed ステップに緑の色分けが適用される
     expect(html).toContain("bg-green-50");
     // not_required ステップに青の色分けが適用される

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -17,13 +17,6 @@ import {
 import { useEffect, useState, useTransition } from "react";
 import { TaskPriorityDot } from "@/components/task-priority-selector";
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
   CATEGORY_LABELS,
   RESPONSE_STATUS_BADGE_COLORS,
   RESPONSE_STATUS_LABELS,
@@ -413,43 +406,28 @@ function TaskRow({
         const colors = STEP_STATUS_COLORS[status];
         const labels = STEP_STATUS_LABELS[key];
         return (
-          <td
-            key={key}
-            className="px-1 py-2.5 text-center"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
-          >
+          <td key={key} className="px-1 py-2.5 text-center">
             {showSteps ? (
-              <Select
+              <select
                 value={status}
-                onValueChange={(v) => handleStepChange(key, v as WorkflowStepStatus)}
+                onChange={(e) => {
+                  e.stopPropagation();
+                  handleStepChange(key, e.target.value as WorkflowStepStatus);
+                }}
+                onClick={(e) => e.stopPropagation()}
                 disabled={isPending}
+                className={cn(
+                  "w-full cursor-pointer rounded border px-1 py-1 text-[10px] font-medium outline-none transition-colors",
+                  colors.triggerBg,
+                  colors.text,
+                )}
               >
-                <SelectTrigger
-                  size="sm"
-                  className={cn(
-                    "h-7 w-full min-w-0 gap-0.5 rounded border px-1.5 text-[10px] font-medium shadow-none",
-                    colors.triggerBg,
-                    colors.text,
-                  )}
-                >
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent position="popper" className="min-w-[160px]">
-                  {STEP_CYCLE.map((s) => (
-                    <SelectItem key={s} value={s}>
-                      <span
-                        className={cn(
-                          "inline-block rounded-full px-2 py-0.5 text-[11px] font-medium",
-                          STEP_STATUS_COLORS[s].badge,
-                        )}
-                      >
-                        {labels[s]}
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+                {STEP_CYCLE.map((s) => (
+                  <option key={s} value={s}>
+                    {labels[s]}
+                  </option>
+                ))}
+              </select>
             ) : (
               <span className="text-muted-foreground/30">—</span>
             )}


### PR DESCRIPTION
## Summary
- Radix Selectがテーブルセル内で正しくレンダリングされない問題を修正
- ネイティブHTML `<select>` 要素に置き換え、確実に動作するように変更
- 色分け・ラベルはそのまま維持

## Test plan
- [x] typecheck全PASS
- [x] test全PASS（201テスト）
- [x] build全PASS
- [ ] 給与カテゴリタスクでドロップダウンが表示・選択可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)