### PR TITLE
feat: 明示的なタスク解除ボタン追加 + 優先度トグル解除の廃止

### DIFF
--- a/apps/web/src/components/line-message-detail-pane.tsx
+++ b/apps/web/src/components/line-message-detail-pane.tsx
@@ -35,20 +35,12 @@ export function LineMessageDetailPane({
   onUpdateNotes,
 }: LineMessageDetailPaneProps) {
   const responseStatus = message.responseStatus;
-  const [showClearDialog, setShowClearDialog] = useState(false);
+  const [showRemoveDialog, setShowRemoveDialog] = useState(false);
 
-  const handlePriorityChange = (p: TaskPriority | null) => {
-    if (p === null) {
-      setShowClearDialog(true);
-      return;
-    }
-    onUpdateTaskPriority(message.id, p);
-  };
-
-  const handleConfirmClear = () => {
-    setShowClearDialog(false);
+  const handleConfirmRemove = () => {
+    setShowRemoveDialog(false);
     onUpdateTaskPriority(message.id, null);
-    toast.success("優先度を解除しました");
+    toast.success("タスクを解除しました");
   };
 
   return (
@@ -104,11 +96,25 @@ export function LineMessageDetailPane({
         {/* タスク優先度 */}
         <div className="mt-4">
           <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
-          <TaskPrioritySelector value={message.taskPriority} onChange={handlePriorityChange} />
+          <div className="flex items-center gap-2">
+            <TaskPrioritySelector
+              value={message.taskPriority}
+              onChange={(p) => p && onUpdateTaskPriority(message.id, p)}
+            />
+            {message.taskPriority && (
+              <button
+                type="button"
+                onClick={() => setShowRemoveDialog(true)}
+                className="rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-600 hover:bg-red-100 transition-colors"
+              >
+                タスク解除
+              </button>
+            )}
+          </div>
           <PriorityClearDialog
-            open={showClearDialog}
-            onConfirm={handleConfirmClear}
-            onCancel={() => setShowClearDialog(false)}
+            open={showRemoveDialog}
+            onConfirm={handleConfirmRemove}
+            onCancel={() => setShowRemoveDialog(false)}
           />
         </div>
 

--- a/apps/web/src/components/message-detail-pane.tsx
+++ b/apps/web/src/components/message-detail-pane.tsx
@@ -55,20 +55,12 @@ export function ChatMessageDetailPane({
 }: ChatMessageDetailPaneProps) {
   const intent = message.intent as IntentDetail | null;
   const responseStatus = (intent?.responseStatus ?? "unresponded") as ResponseStatus;
-  const [showClearDialog, setShowClearDialog] = useState(false);
+  const [showRemoveDialog, setShowRemoveDialog] = useState(false);
 
-  const handlePriorityChange = (p: TaskPriority | null) => {
-    if (p === null) {
-      setShowClearDialog(true);
-      return;
-    }
-    onUpdateTaskPriority(message.id, p);
-  };
-
-  const handleConfirmClear = () => {
-    setShowClearDialog(false);
+  const handleConfirmRemove = () => {
+    setShowRemoveDialog(false);
     onUpdateTaskPriority(message.id, null);
-    toast.success("優先度を解除しました");
+    toast.success("タスクを解除しました");
   };
 
   return (
@@ -144,14 +136,25 @@ export function ChatMessageDetailPane({
             {/* タスク優先度 */}
             <div className="mt-4">
               <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
-              <TaskPrioritySelector
-                value={intent?.taskPriority ?? null}
-                onChange={handlePriorityChange}
-              />
+              <div className="flex items-center gap-2">
+                <TaskPrioritySelector
+                  value={intent?.taskPriority ?? null}
+                  onChange={(p) => p && onUpdateTaskPriority(message.id, p)}
+                />
+                {intent?.taskPriority && (
+                  <button
+                    type="button"
+                    onClick={() => setShowRemoveDialog(true)}
+                    className="rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-600 hover:bg-red-100 transition-colors"
+                  >
+                    タスク解除
+                  </button>
+                )}
+              </div>
               <PriorityClearDialog
-                open={showClearDialog}
-                onConfirm={handleConfirmClear}
-                onCancel={() => setShowClearDialog(false)}
+                open={showRemoveDialog}
+                onConfirm={handleConfirmRemove}
+                onCancel={() => setShowRemoveDialog(false)}
               />
             </div>
 

--- a/apps/web/src/components/priority-clear-dialog.tsx
+++ b/apps/web/src/components/priority-clear-dialog.tsx
@@ -24,10 +24,10 @@ export function PriorityClearDialog({ open, onConfirm, onCancel }: PriorityClear
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             <AlertTriangle size={18} className="text-amber-500" />
-            優先度の解除
+            タスク解除の確認
           </DialogTitle>
           <DialogDescription>
-            優先度を解除すると、このメッセージはタスク一覧から除外されます。解除しますか？
+            タスクを解除すると、タスク一覧から除外されます。解除しますか？
           </DialogDescription>
         </DialogHeader>
         <DialogFooter>

--- a/apps/web/src/components/task-priority-selector.tsx
+++ b/apps/web/src/components/task-priority-selector.tsx
@@ -49,7 +49,7 @@ export function TaskPrioritySelector({ value, onChange }: TaskPrioritySelectorPr
           <button
             key={opt.value}
             type="button"
-            onClick={() => onChange(isActive ? null : opt.value)}
+            onClick={() => !isActive && onChange(opt.value)}
             className={cn(
               "inline-flex items-center gap-1 rounded-md border px-2 py-1 text-xs transition-colors",
               isActive


### PR DESCRIPTION
## Summary

- 優先度ボタンの再押下によるトグル解除を廃止（対応状況ボタンと同じ「選択のみ」に統一）
- Chat/LINE 詳細ペインに明示的な「タスク解除」ボタンを追加
- 優先度が設定されている場合のみ表示
- 確認ダイアログ + トースト通知で丁寧なフィードバック

## 変更内容

| ファイル | 変更 |
|---------|------|
| `task-priority-selector.tsx` | `isActive ? null : opt.value` → `!isActive && onChange(opt.value)` |
| `message-detail-pane.tsx` | タスク解除ボタン追加、handlePriorityChange 簡素化 |
| `line-message-detail-pane.tsx` | 同上 |
| `priority-clear-dialog.tsx` | 文言を「タスク解除の確認」に統一 |

## Test plan

- [x] `pnpm typecheck` PASS
- [x] `pnpm lint` PASS
- [x] `pnpm test` 201件全PASS
- [x] 選択済み優先度を再押下 → 何も起きない（トグル解除廃止）
- [x] 「タスク解除」ボタンクリック → 確認ダイアログ表示
- [x] キャンセル → 優先度保持、暗転なし
- [x] 優先度未設定のメッセージ → 「タスク解除」ボタン非表示

Closes #355

🤖 Generated with [Claude Code](https://claude.com/claude-code)