### PR TITLE
feat: Chat同期の監視・自動復旧・インデックス管理

### DIFF
--- a/apps/api/src/__tests__/chat-sync-routes.test.ts
+++ b/apps/api/src/__tests__/chat-sync-routes.test.ts
@@ -1,13 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // --- モック変数（vi.hoisted で vi.mock と同時にホイスト） ---
-const { mockGetRequestHeaders, mockGet, mockSet, mockAdd, mockRunTransaction } = vi.hoisted(() => ({
-  mockGetRequestHeaders: vi.fn().mockResolvedValue({ Authorization: "Bearer test-token" }),
-  mockGet: vi.fn(),
-  mockSet: vi.fn().mockResolvedValue(undefined),
-  mockAdd: vi.fn().mockResolvedValue({ id: "audit-1" }),
-  mockRunTransaction: vi.fn(),
-}));
+const { mockGetRequestHeaders, mockGet, mockSet, mockAdd, mockRunTransaction, mockConfigGet } =
+  vi.hoisted(() => ({
+    mockGetRequestHeaders: vi.fn().mockResolvedValue({ Authorization: "Bearer test-token" }),
+    mockGet: vi.fn(),
+    mockSet: vi.fn().mockResolvedValue(undefined),
+    mockAdd: vi.fn().mockResolvedValue({ id: "audit-1" }),
+    mockRunTransaction: vi.fn(),
+    mockConfigGet: vi.fn(),
+  }));
 
 vi.mock("google-auth-library", () => ({
   GoogleAuth: class MockGoogleAuth {
@@ -40,6 +42,9 @@ vi.mock("@hr-system/db", () => ({
       where: vi.fn(() => ({
         get: vi.fn().mockResolvedValue({ empty: true, docs: [] }),
       })),
+    },
+    chatSyncConfig: {
+      doc: vi.fn(() => ({ get: mockConfigGet, set: mockSet })),
     },
   },
 }));
@@ -85,6 +90,8 @@ describe("chat-sync routes", () => {
     };
     // syncChatMessages 内の getSyncMetadata() / chatMessages.doc().get() 等のデフォルト
     mockGet.mockResolvedValue({ exists: false });
+    // chatSyncConfig のデフォルト（無効化されていない）
+    mockConfigGet.mockResolvedValue({ exists: false });
     vi.spyOn(globalThis, "fetch").mockResolvedValue(
       new Response(JSON.stringify({ messages: [] }), { status: 200 }),
     );
@@ -207,6 +214,122 @@ describe("chat-sync routes", () => {
       expect(res.status).toBe(500);
       const body = (await res.json()) as { error: string };
       expect(body.error).toContain("同期に失敗しました");
+    });
+  });
+
+  describe("POST /api/chat-messages/sync?source=scheduler（スケジューラー起動）", () => {
+    const schedulerUser = {
+      email: "scheduler@project.iam.gserviceaccount.com",
+      name: "system",
+      sub: "sa-sub",
+      dashboardRole: null as string | null,
+    };
+
+    it("自動同期が無効の場合スキップする", async () => {
+      mockAuthUser = schedulerUser;
+      mockConfigGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ isEnabled: false, intervalMinutes: 30 }),
+      });
+
+      const res = await app.request("/api/chat-messages/sync?source=scheduler", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { message: string };
+      expect(body.message).toBe("自動同期が無効です");
+    });
+
+    it("間隔未到達の場合スキップする", async () => {
+      const { Timestamp } = await import("firebase-admin/firestore");
+      mockAuthUser = schedulerUser;
+      mockConfigGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ isEnabled: true, intervalMinutes: 60 }),
+      });
+      // getSyncMetadata: 直近に成功同期済み（10分前）
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          status: "idle",
+          lastSyncedAt: Timestamp.fromDate(new Date(Date.now() - 10 * 60 * 1000)),
+          updatedAt: Timestamp.fromDate(new Date(Date.now() - 10 * 60 * 1000)),
+        }),
+      });
+
+      const res = await app.request("/api/chat-messages/sync?source=scheduler", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { message: string };
+      expect(body.message).toBe("同期スキップ（間隔未到達）");
+    });
+
+    it("error 状態で30分未経過ならリトライ待機する", async () => {
+      const { Timestamp } = await import("firebase-admin/firestore");
+      mockAuthUser = schedulerUser;
+      mockConfigGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ isEnabled: true, intervalMinutes: 60 }),
+      });
+      // getSyncMetadata: error 状態、10分前に発生
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          status: "error",
+          errorMessage: "Index not found",
+          updatedAt: Timestamp.fromDate(new Date(Date.now() - 10 * 60 * 1000)),
+          lastSyncedAt: Timestamp.fromDate(new Date(Date.now() - 120 * 60 * 1000)),
+        }),
+      });
+
+      const res = await app.request("/api/chat-messages/sync?source=scheduler", {
+        method: "POST",
+      });
+
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { message: string };
+      expect(body.message).toBe("エラー後のリトライ待機中");
+    });
+
+    it("error 状態で30分経過なら interval をスキップして自動リトライする", async () => {
+      const { Timestamp } = await import("firebase-admin/firestore");
+      mockAuthUser = schedulerUser;
+      mockConfigGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({ isEnabled: true, intervalMinutes: 60 }),
+      });
+      // getSyncMetadata: error 状態、40分前に発生（30分超過 → リトライ）
+      // lastSyncedAt は 2時間前（intervalMinutes=60 の間隔内だが、error リトライはスキップすべき）
+      mockGet.mockResolvedValueOnce({
+        exists: true,
+        data: () => ({
+          status: "error",
+          errorMessage: "Index not found",
+          updatedAt: Timestamp.fromDate(new Date(Date.now() - 40 * 60 * 1000)),
+          lastSyncedAt: Timestamp.fromDate(new Date(Date.now() - 50 * 60 * 1000)),
+        }),
+      });
+
+      // acquireSyncLock → 成功
+      mockRunTransaction.mockImplementationOnce(async (fn: (tx: unknown) => Promise<boolean>) => {
+        const tx = {
+          get: vi.fn().mockResolvedValue({ exists: false }),
+          set: vi.fn(),
+        };
+        return fn(tx);
+      });
+
+      const res = await app.request("/api/chat-messages/sync?source=scheduler", {
+        method: "POST",
+      });
+
+      // interval チェックをスキップして同期が実行される
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { message: string };
+      expect(body.message).toBe("同期が完了しました");
     });
   });
 

--- a/apps/api/src/routes/chat-sync.ts
+++ b/apps/api/src/routes/chat-sync.ts
@@ -44,7 +44,16 @@ chatSyncRoutes.post("/", async (c) => {
     }
     if (config && config.intervalMinutes > 0) {
       const meta = await getSyncMetadata();
-      if (meta?.lastSyncedAt) {
+
+      // error 状態なら30分後に自動リトライ（interval チェックをスキップ）
+      if (meta?.status === "error" && meta?.updatedAt) {
+        const errorAge = Date.now() - meta.updatedAt.toDate().getTime();
+        if (errorAge < 30 * 60 * 1000) {
+          return c.json({ message: "エラー後のリトライ待機中" }, 200);
+        }
+        console.warn("Auto-retrying after error:", meta.errorMessage?.slice(0, 100));
+        // error リトライ時は interval チェックをスキップして同期実行へ進む
+      } else if (meta?.lastSyncedAt) {
         const elapsedMs = Date.now() - meta.lastSyncedAt.toDate().getTime();
         const intervalMs = config.intervalMinutes * 60 * 1000;
         if (elapsedMs < intervalMs) {

--- a/apps/web/src/app/(protected)/admin/admin-tabs.tsx
+++ b/apps/web/src/app/(protected)/admin/admin-tabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { MessageSquareMore, Settings2, Users } from "lucide-react";
+import { MessageSquareMore, RefreshCw, Settings2, Users } from "lucide-react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { cn } from "@/lib/utils";
@@ -8,6 +8,7 @@ import { cn } from "@/lib/utils";
 const tabs = [
   { href: "/admin/users", label: "ユーザー", icon: Users },
   { href: "/admin/spaces", label: "スペース", icon: MessageSquareMore },
+  { href: "/admin/sync", label: "同期", icon: RefreshCw },
   { href: "/admin/ai-settings", label: "AI設定", icon: Settings2 },
 ] as const;
 

--- a/apps/web/src/app/(protected)/admin/sync/actions.ts
+++ b/apps/web/src/app/(protected)/admin/sync/actions.ts
@@ -1,0 +1,37 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { requireAdmin } from "@/lib/access-control";
+import {
+  getChatSyncConfig,
+  getChatSyncStatus,
+  triggerChatSync,
+  updateChatSyncConfig,
+} from "@/lib/api";
+import type { SyncConfig, SyncStatus } from "@/lib/types";
+
+export async function getSyncStatusAction(): Promise<{
+  status: SyncStatus;
+  config: SyncConfig;
+}> {
+  await requireAdmin();
+  const [status, config] = await Promise.all([getChatSyncStatus(), getChatSyncConfig()]);
+  return { status, config };
+}
+
+export async function triggerSyncAction(): Promise<{ message: string }> {
+  await requireAdmin();
+  const result = await triggerChatSync();
+  revalidatePath("/admin/sync");
+  return result;
+}
+
+export async function updateSyncConfigAction(updates: {
+  intervalMinutes?: number;
+  isEnabled?: boolean;
+}): Promise<SyncConfig> {
+  await requireAdmin();
+  const result = await updateChatSyncConfig(updates);
+  revalidatePath("/admin/sync");
+  return result;
+}

--- a/apps/web/src/app/(protected)/admin/sync/page.tsx
+++ b/apps/web/src/app/(protected)/admin/sync/page.tsx
@@ -1,0 +1,20 @@
+import { requireAdmin } from "@/lib/access-control";
+import { getChatSyncConfig, getChatSyncStatus } from "@/lib/api";
+import { SyncPanel } from "./sync-panel";
+
+export default async function AdminSyncPage() {
+  await requireAdmin();
+  const [status, config] = await Promise.all([getChatSyncStatus(), getChatSyncConfig()]);
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-sm font-semibold">Chat同期</h2>
+        <p className="text-xs text-muted-foreground">
+          Google Chatメッセージの同期状態を監視し、手動同期を実行できます
+        </p>
+      </div>
+      <SyncPanel initialStatus={status} initialConfig={config} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(protected)/admin/sync/sync-panel.tsx
+++ b/apps/web/src/app/(protected)/admin/sync/sync-panel.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { AlertCircle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
+import { useCallback, useState, useTransition } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import type { SyncConfig, SyncStatus } from "@/lib/types";
+import { getSyncStatusAction, triggerSyncAction, updateSyncConfigAction } from "./actions";
+
+interface SyncPanelProps {
+  initialStatus: SyncStatus;
+  initialConfig: SyncConfig;
+}
+
+function formatDate(iso: string | null): string {
+  if (!iso) return "未同期";
+  return new Date(iso).toLocaleString("ja-JP", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
+const statusBadge = {
+  idle: { label: "正常", variant: "default" as const, className: "bg-green-600" },
+  running: { label: "同期中", variant: "default" as const, className: "bg-blue-600" },
+  error: { label: "エラー", variant: "destructive" as const, className: "" },
+} as const;
+
+export function SyncPanel({ initialStatus, initialConfig }: SyncPanelProps) {
+  const [status, setStatus] = useState<SyncStatus>(initialStatus);
+  const [config, setConfig] = useState<SyncConfig>(initialConfig);
+  const [interval, setInterval] = useState(String(initialConfig.intervalMinutes));
+  const [isPending, startTransition] = useTransition();
+  const [syncMessage, setSyncMessage] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+
+  const refresh = useCallback(() => {
+    setActionError(null);
+    startTransition(async () => {
+      try {
+        const result = await getSyncStatusAction();
+        setStatus(result.status);
+        setConfig(result.config);
+        setInterval(String(result.config.intervalMinutes));
+      } catch {
+        setActionError("ステータスの取得に失敗しました");
+      }
+    });
+  }, []);
+
+  const handleSync = useCallback(() => {
+    setSyncMessage(null);
+    setActionError(null);
+    startTransition(async () => {
+      try {
+        const result = await triggerSyncAction();
+        setSyncMessage(result.message);
+        const updated = await getSyncStatusAction();
+        setStatus(updated.status);
+      } catch {
+        setActionError("同期の実行に失敗しました。しばらく待ってから再試行してください。");
+      }
+    });
+  }, []);
+
+  const handleToggleEnabled = useCallback((checked: boolean) => {
+    setActionError(null);
+    startTransition(async () => {
+      try {
+        const updated = await updateSyncConfigAction({ isEnabled: checked });
+        setConfig(updated);
+      } catch {
+        setActionError("設定の更新に失敗しました");
+      }
+    });
+  }, []);
+
+  const handleIntervalSave = useCallback(() => {
+    const val = Number.parseInt(interval, 10);
+    if (Number.isNaN(val) || val < 1) return;
+    setActionError(null);
+    startTransition(async () => {
+      try {
+        const updated = await updateSyncConfigAction({ intervalMinutes: val });
+        setConfig(updated);
+        setInterval(String(updated.intervalMinutes));
+      } catch {
+        setActionError("設定の更新に失敗しました");
+      }
+    });
+  }, [interval]);
+
+  const badge = statusBadge[status.status];
+
+  return (
+    <div className="space-y-6">
+      {/* Action error banner */}
+      {actionError && (
+        <div className="flex items-start gap-3 rounded-xl border border-amber-200/60 bg-amber-50 p-4">
+          <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+          <p className="text-sm text-amber-800">{actionError}</p>
+        </div>
+      )}
+
+      {/* Sync error banner */}
+      {status.status === "error" && status.errorMessage && (
+        <div className="flex items-start gap-3 rounded-xl border border-red-200/60 bg-red-50 p-4">
+          <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-red-600" />
+          <div>
+            <p className="text-sm font-semibold text-red-800">同期エラーが発生しています</p>
+            <p className="mt-1 text-sm text-red-700">{status.errorMessage}</p>
+            <p className="mt-2 text-xs text-red-600">
+              30分後に自動リトライされます。すぐに再試行するには「今すぐ同期」ボタンを押してください。
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Success message */}
+      {syncMessage && status.status !== "error" && (
+        <div className="flex items-center gap-3 rounded-xl border border-green-200/60 bg-green-50 p-4">
+          <CheckCircle2 className="h-5 w-5 shrink-0 text-green-600" />
+          <p className="text-sm text-green-800">{syncMessage}</p>
+        </div>
+      )}
+
+      {/* Status card */}
+      <div className="rounded-xl border border-border/60 bg-card p-6">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-semibold">同期ステータス</h2>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={refresh}
+              disabled={isPending}
+              className="h-8 w-8 p-0"
+            >
+              <RefreshCw className={`h-4 w-4 ${isPending ? "animate-spin" : ""}`} />
+            </Button>
+            <Badge variant={badge.variant} className={badge.className}>
+              {badge.label}
+            </Badge>
+          </div>
+        </div>
+
+        <dl className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-3">
+          <div>
+            <dt className="text-xs text-muted-foreground">最終同期</dt>
+            <dd className="mt-1 text-sm font-medium">{formatDate(status.lastSyncedAt)}</dd>
+          </div>
+          {status.lastResult && (
+            <>
+              <div>
+                <dt className="text-xs text-muted-foreground">取得件数</dt>
+                <dd className="mt-1 text-sm font-medium">
+                  {status.lastResult.newMessages} 件
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    (重複スキップ: {status.lastResult.duplicateSkipped})
+                  </span>
+                </dd>
+              </div>
+              <div>
+                <dt className="text-xs text-muted-foreground">処理時間</dt>
+                <dd className="mt-1 text-sm font-medium">
+                  {(status.lastResult.durationMs / 1000).toFixed(1)} 秒
+                </dd>
+              </div>
+            </>
+          )}
+        </dl>
+
+        <div className="mt-6">
+          <Button
+            onClick={handleSync}
+            disabled={isPending || status.status === "running"}
+            size="sm"
+          >
+            {isPending ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="mr-2 h-4 w-4" />
+            )}
+            今すぐ同期
+          </Button>
+        </div>
+      </div>
+
+      {/* Config card */}
+      <div className="rounded-xl border border-border/60 bg-card p-6">
+        <h2 className="text-sm font-semibold">同期設定</h2>
+
+        <div className="mt-4 space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <Label htmlFor="sync-enabled" className="text-sm">
+                自動同期
+              </Label>
+              <p className="text-xs text-muted-foreground">
+                Cloud Scheduler による定期同期を有効にします
+              </p>
+            </div>
+            <Switch
+              id="sync-enabled"
+              checked={config.isEnabled}
+              onCheckedChange={handleToggleEnabled}
+              disabled={isPending}
+            />
+          </div>
+
+          <div className="flex items-end gap-2">
+            <div className="flex-1">
+              <Label htmlFor="sync-interval" className="text-sm">
+                同期間隔（分）
+              </Label>
+              <Input
+                id="sync-interval"
+                type="number"
+                min={1}
+                value={interval}
+                onChange={(e) => setInterval(e.target.value)}
+                className="mt-1"
+                disabled={isPending}
+              />
+            </div>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleIntervalSave}
+              disabled={isPending || Number(interval) === config.intervalMinutes}
+            >
+              保存
+            </Button>
+          </div>
+
+          {config.updatedAt && (
+            <p className="text-xs text-muted-foreground">
+              最終更新: {formatDate(config.updatedAt)}
+              {config.updatedBy && ` (${config.updatedBy})`}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/switch.tsx
+++ b/apps/web/src/components/ui/switch.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Switch as SwitchPrimitive } from "radix-ui";
+import type * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+function Switch({
+  className,
+  size = "default",
+  ...props
+}: React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  size?: "sm" | "default";
+}) {
+  return (
+    <SwitchPrimitive.Root
+      data-slot="switch"
+      data-size={size}
+      className={cn(
+        "peer group/switch inline-flex shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 data-[size=default]:h-[1.15rem] data-[size=default]:w-8 data-[size=sm]:h-3.5 data-[size=sm]:w-6 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input dark:data-[state=unchecked]:bg-input/80",
+        className,
+      )}
+      {...props}
+    >
+      <SwitchPrimitive.Thumb
+        data-slot="switch-thumb"
+        className={cn(
+          "pointer-events-none block rounded-full bg-background ring-0 transition-transform group-data-[size=default]/switch:size-4 group-data-[size=sm]/switch:size-3 data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0 dark:data-[state=checked]:bg-primary-foreground dark:data-[state=unchecked]:bg-foreground",
+        )}
+      />
+    </SwitchPrimitive.Root>
+  );
+}
+
+export { Switch };

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -183,6 +183,22 @@
         { "fieldPath": "category", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]
+    },
+    {
+      "collectionGroup": "classification_rules",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isActive", "order": "ASCENDING" },
+        { "fieldPath": "priority", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "llm_classification_rules",
+      "queryScope": "COLLECTION",
+      "fields": [
+        { "fieldPath": "isActive", "order": "ASCENDING" },
+        { "fieldPath": "priority", "order": "ASCENDING" }
+      ]
     }
   ],
   "fieldOverrides": []


### PR DESCRIPTION
## Summary

Closes #358

12日間 Chat 同期がエラーで停止していた事故を受け、3つの構造的欠陥を修正:

- **管理画面に「同期」タブ追加**: ステータス可視化（最終同期・取得件数・処理時間・statusバッジ）、エラー時の赤アラートバナー、「今すぐ同期」ボタン、自動同期トグル・間隔設定
- **error 状態の自動リトライ**: スケジューラーが error を検出→30分後に interval チェックをスキップして自動再試行（Codexレビューで interval との干渉バグを検出・修正済み）
- **Firestore インデックスのコード管理**: classification_rules / llm_classification_rules の複合インデックスを firestore.indexes.json に追加

## Changes

| ファイル | 変更 |
|---------|------|
| `admin-tabs.tsx` | 同期タブ追加 |
| `sync/page.tsx` | Server Component（requireAdmin + データ取得） |
| `sync/actions.ts` | Server Actions 3つ（status/trigger/config） |
| `sync/sync-panel.tsx` | Client Component（ステータス + 手動同期 + 設定） |
| `chat-sync.ts` | error 自動リトライ（interval スキップ付き） |
| `firestore.indexes.json` | 複合インデックス2件追加 |
| `switch.tsx` | shadcn Switch UIコンポーネント |

## Test plan

- [x] `pnpm test` 全370件PASS（API 169 + Web 201）
- [x] `pnpm lint` 変更ファイル全エラーなし
- [x] `/admin/sync` ページでステータス表示・手動同期ボタン・設定変更動作確認
- [x] Codex レビュー High 2件修正済み（interval干渉 + UIエラーハンドリング）
- [ ] `firebase deploy --only firestore:indexes` で本番インデックスデプロイ（マージ後手動）

🤖 Generated with [Claude Code](https://claude.com/claude-code)