### PR TITLE
feat: ヘッダーにグローバル同期ステータスインジケーター追加

### DIFF
--- a/apps/web/src/components/header.tsx
+++ b/apps/web/src/components/header.tsx
@@ -1,5 +1,6 @@
 import { HelpCircle } from "lucide-react";
 import Link from "next/link";
+import { SyncStatusIndicator } from "@/components/sync-status-indicator";
 import { UserMenu } from "@/components/user-menu";
 import { formatDate } from "@/lib/utils";
 
@@ -19,8 +20,9 @@ export function Header() {
           </a>
         </div>
 
-        {/* 右側: ヘルプ + 日付 + ユーザーメニュー */}
+        {/* 右側: 同期ステータス + ヘルプ + 日付 + ユーザーメニュー */}
         <div className="flex items-center gap-3">
+          <SyncStatusIndicator />
           <Link
             href="/help"
             title="操作マニュアル"

--- a/apps/web/src/components/sync-status-indicator.tsx
+++ b/apps/web/src/components/sync-status-indicator.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import type { SyncStatus } from "@/lib/types";
+
+const POLL_INTERVAL = 60_000;
+
+export function SyncStatusIndicator() {
+  const [status, setStatus] = useState<SyncStatus | null>(null);
+
+  useEffect(() => {
+    const fetchStatus = async () => {
+      if (document.visibilityState !== "visible") return;
+      try {
+        const res = await fetch("/api/chat-messages/sync/status");
+        if (res.ok) {
+          setStatus(await res.json());
+        }
+      } catch {
+        // ネットワークエラーは無視（次回ポーリングで再試行）
+      }
+    };
+
+    fetchStatus();
+    const id = setInterval(fetchStatus, POLL_INTERVAL);
+
+    // タブ復帰時に即座に再取得
+    const onVisible = () => {
+      if (document.visibilityState === "visible") fetchStatus();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+
+    return () => {
+      clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, []);
+
+  if (!status || status.status === "idle") return null;
+
+  const dot = (
+    <span
+      className={`inline-block h-2.5 w-2.5 rounded-full animate-pulse ${
+        status.status === "running" ? "bg-blue-500" : "bg-red-500"
+      }`}
+      title={status.status === "error" ? (status.errorMessage ?? "同期エラー") : "同期中..."}
+    />
+  );
+
+  if (status.status === "error") {
+    return (
+      <Link
+        href="/admin/sync"
+        className="flex items-center"
+        title={status.errorMessage ?? "同期エラー — クリックで詳細"}
+      >
+        {dot}
+      </Link>
+    );
+  }
+
+  return dot;
+}


### PR DESCRIPTION
## Summary
- ヘッダー右側（ヘルプアイコンの左）に同期ステータスドットを常駐配置
- idle: 非表示 / running: 青点滅 / error: 赤点滅+クリックで `/admin/sync` へ遷移
- 60秒ポーリング（バックグラウンドタブではスキップ、タブ復帰時に即時再取得）

## Test plan
- [ ] 正常時（idle）にインジケーターが非表示であること
- [ ] 同期実行中（running）に青い点滅ドットが表示されること
- [ ] エラー時に赤い点滅ドットが表示され、クリックで `/admin/sync` に遷移すること
- [ ] タブをバックグラウンドにした状態でポーリングが停止すること
- [ ] タブ復帰時に即座にステータスが再取得されること

Closes #358

🤖 Generated with [Claude Code](https://claude.com/claude-code)