### PR TITLE
fix: タスク詳細ダイアログのスクロール・解除ボタン・メモ表示を修正

### DIFF
--- a/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/inbox-3pane.tsx
@@ -109,26 +109,28 @@ export function Inbox3Pane({ messages, selectedMessage, selectedId }: Inbox3Pane
 
       {/* 中央+右ペイン: 詳細 */}
       {selectedMessage ? (
-        <ChatMessageDetailPane
-          message={selectedMessage}
-          onClose={() => selectMessage(null)}
-          onUpdateResponseStatus={updateResponseStatusAction}
-          onUpdateTaskPriority={updateTaskPriorityAction}
-          onUpdateWorkflow={updateWorkflowAction}
-          assignees={selectedMessage.intent?.assignees ?? null}
-          deadline={selectedMessage.intent?.deadline ?? null}
-          onUpdateAssignees={updateChatAssigneesAction}
-          onUpdateDeadline={updateChatDeadlineAction}
-          onUpdateCategories={updateChatCategoriesAction}
-          extraContent={
-            <div className="mt-4">
-              <NotesField
-                value={selectedMessage.intent?.notes ?? null}
-                onSave={(notes) => updateChatNotesAction(selectedMessage.id, notes)}
-              />
-            </div>
-          }
-        />
+        <div className="flex-1 overflow-y-auto">
+          <ChatMessageDetailPane
+            message={selectedMessage}
+            onClose={() => selectMessage(null)}
+            onUpdateResponseStatus={updateResponseStatusAction}
+            onUpdateTaskPriority={updateTaskPriorityAction}
+            onUpdateWorkflow={updateWorkflowAction}
+            assignees={selectedMessage.intent?.assignees ?? null}
+            deadline={selectedMessage.intent?.deadline ?? null}
+            onUpdateAssignees={updateChatAssigneesAction}
+            onUpdateDeadline={updateChatDeadlineAction}
+            onUpdateCategories={updateChatCategoriesAction}
+            extraContent={
+              <div className="mt-4">
+                <NotesField
+                  value={selectedMessage.intent?.notes ?? null}
+                  onSave={(notes) => updateChatNotesAction(selectedMessage.id, notes)}
+                />
+              </div>
+            }
+          />
+        </div>
       ) : (
         <div className="hidden flex-1 items-center justify-center md:flex">
           <div className="text-center">

--- a/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/line-inbox-3pane.tsx
@@ -104,16 +104,18 @@ export function LineInbox3Pane({ messages, selectedMessage, selectedId }: LineIn
 
       {/* 中央ペイン: 詳細 */}
       {selectedMessage ? (
-        <LineMessageDetailPane
-          message={selectedMessage}
-          onClose={() => selectMessage(null)}
-          onUpdateResponseStatus={updateLineResponseStatusAction}
-          onUpdateTaskPriority={updateLineTaskPriorityAction}
-          onUpdateAssignees={updateLineAssigneesAction}
-          onUpdateDeadline={updateLineDeadlineAction}
-          onUpdateCategories={updateLineCategoriesAction}
-          onUpdateNotes={updateLineNotesAction}
-        />
+        <div className="flex-1 overflow-y-auto">
+          <LineMessageDetailPane
+            message={selectedMessage}
+            onClose={() => selectMessage(null)}
+            onUpdateResponseStatus={updateLineResponseStatusAction}
+            onUpdateTaskPriority={updateLineTaskPriorityAction}
+            onUpdateAssignees={updateLineAssigneesAction}
+            onUpdateDeadline={updateLineDeadlineAction}
+            onUpdateCategories={updateLineCategoriesAction}
+            onUpdateNotes={updateLineNotesAction}
+          />
+        </div>
       ) : (
         <div className="hidden flex-1 items-center justify-center md:flex">
           <div className="text-center">

--- a/apps/web/src/app/(protected)/inbox/unified-inbox-3pane.tsx
+++ b/apps/web/src/app/(protected)/inbox/unified-inbox-3pane.tsx
@@ -200,7 +200,9 @@ export function UnifiedInbox3Pane({
 
       {/* 中央+右ペイン: 詳細 */}
       {selectedMessage ? (
-        <DetailPane message={selectedMessage} onClose={() => selectMessage(null)} />
+        <div className="flex-1 overflow-y-auto">
+          <DetailPane message={selectedMessage} onClose={() => selectMessage(null)} />
+        </div>
       ) : (
         <div className="hidden flex-1 items-center justify-center md:flex">
           <div className="text-center">

--- a/apps/web/src/app/(protected)/task-board/task-board-content.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-board-content.tsx
@@ -216,6 +216,7 @@ export function TaskBoardContent({ tasks, initialSelectedId, pageOffset = 0, chi
                 onUpdateResponseStatus={updateResponseStatusFromTaskBoard}
                 onUpdateTaskPriority={updateTaskPriorityFromTaskBoard}
                 onUpdateWorkflow={updateWorkflowFromTaskBoard}
+                showTaskRemove
                 assignees={chatDetail.intent?.assignees ?? null}
                 deadline={chatDetail.intent?.deadline ?? null}
                 onUpdateAssignees={handleChatAssignees}
@@ -240,6 +241,7 @@ export function TaskBoardContent({ tasks, initialSelectedId, pageOffset = 0, chi
                 onClose={handleDialogClose}
                 onUpdateResponseStatus={updateLineResponseStatusFromTaskBoard}
                 onUpdateTaskPriority={updateLineTaskPriorityFromTaskBoard}
+                showTaskRemove
                 onUpdateAssignees={handleLineAssignees}
                 onUpdateDeadline={handleLineDeadline}
                 onUpdateCategories={async (id, cats) => {

--- a/apps/web/src/components/line-message-detail-pane.tsx
+++ b/apps/web/src/components/line-message-detail-pane.tsx
@@ -22,6 +22,7 @@ interface LineMessageDetailPaneProps {
   onUpdateDeadline: (id: string, deadline: string | null) => Promise<void>;
   onUpdateCategories: (id: string, categories: string[]) => Promise<void>;
   onUpdateNotes?: (id: string, notes: string | null) => Promise<void>;
+  showTaskRemove?: boolean;
 }
 
 export function LineMessageDetailPane({
@@ -33,6 +34,7 @@ export function LineMessageDetailPane({
   onUpdateDeadline,
   onUpdateCategories,
   onUpdateNotes,
+  showTaskRemove,
 }: LineMessageDetailPaneProps) {
   const responseStatus = message.responseStatus;
   const [showRemoveDialog, setShowRemoveDialog] = useState(false);
@@ -44,112 +46,110 @@ export function LineMessageDetailPane({
   };
 
   return (
-    <div className="flex flex-1 overflow-hidden">
-      <div className="flex-1 overflow-y-auto p-5">
-        {/* ヘッダー */}
-        <div className="mb-4 flex items-center justify-between">
-          <div className="flex items-center gap-2">
+    <div className="p-5">
+      {/* ヘッダー */}
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-muted-foreground hover:bg-accent md:hidden"
+          >
+            <X className="h-4 w-4" />
+          </button>
+          <h2 className="text-base font-bold">{message.senderName}</h2>
+          {message.groupName && (
+            <span className="text-xs text-muted-foreground">@ {message.groupName}</span>
+          )}
+          <CategoriesField
+            categories={message.categories}
+            onSave={(cats) => onUpdateCategories(message.id, cats)}
+          />
+          <span className="text-xs text-muted-foreground">
+            {formatDateTimeJST(message.createdAt)}
+          </span>
+        </div>
+      </div>
+
+      {/* メッセージ本文 */}
+      <div className="rounded-lg bg-muted/50 p-4 text-sm leading-relaxed">
+        {message.lineMessageType === "image" && message.contentUrl ? (
+          // biome-ignore lint/performance/noImgElement: 外部GCS signed URLのため next/image は不適
+          <img
+            src={message.contentUrl}
+            alt="LINE画像メッセージ"
+            className="max-w-full rounded-lg"
+          />
+        ) : (
+          message.content
+        )}
+      </div>
+
+      {/* 対応ステータス変更 */}
+      <div className="mt-4">
+        <p className="mb-2 text-xs font-semibold text-muted-foreground">対応状況</p>
+        <ResponseStatusButtons
+          currentStatus={responseStatus}
+          onChangeStatus={(s) => onUpdateResponseStatus(message.id, s)}
+        />
+      </div>
+
+      {/* タスク優先度 */}
+      <div className="mt-4">
+        <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
+        <div className="flex items-center gap-2">
+          <TaskPrioritySelector
+            value={message.taskPriority}
+            onChange={(p) => p && onUpdateTaskPriority(message.id, p)}
+          />
+          {(message.taskPriority || showTaskRemove) && (
             <button
               type="button"
-              onClick={onClose}
-              className="rounded p-1 text-muted-foreground hover:bg-accent md:hidden"
+              onClick={() => setShowRemoveDialog(true)}
+              className="rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-600 hover:bg-red-100 transition-colors"
             >
-              <X className="h-4 w-4" />
+              タスク解除
             </button>
-            <h2 className="text-base font-bold">{message.senderName}</h2>
-            {message.groupName && (
-              <span className="text-xs text-muted-foreground">@ {message.groupName}</span>
-            )}
-            <CategoriesField
-              categories={message.categories}
-              onSave={(cats) => onUpdateCategories(message.id, cats)}
-            />
-            <span className="text-xs text-muted-foreground">
-              {formatDateTimeJST(message.createdAt)}
-            </span>
-          </div>
-        </div>
-
-        {/* メッセージ本文 */}
-        <div className="rounded-lg bg-muted/50 p-4 text-sm leading-relaxed">
-          {message.lineMessageType === "image" && message.contentUrl ? (
-            // biome-ignore lint/performance/noImgElement: 外部GCS signed URLのため next/image は不適
-            <img
-              src={message.contentUrl}
-              alt="LINE画像メッセージ"
-              className="max-w-full rounded-lg"
-            />
-          ) : (
-            message.content
           )}
         </div>
+        <PriorityClearDialog
+          open={showRemoveDialog}
+          onConfirm={handleConfirmRemove}
+          onCancel={() => setShowRemoveDialog(false)}
+        />
+      </div>
 
-        {/* 対応ステータス変更 */}
+      {/* 担当者・期限 */}
+      <div className="mt-4 space-y-2 rounded-lg border border-border/60 bg-muted/20 p-3">
+        <AssigneesField
+          value={message.assignees}
+          onSave={(v) => onUpdateAssignees(message.id, v)}
+        />
+        <DeadlineField value={message.deadline} onSave={(v) => onUpdateDeadline(message.id, v)} />
+      </div>
+
+      {/* メモ */}
+      {onUpdateNotes && (
         <div className="mt-4">
-          <p className="mb-2 text-xs font-semibold text-muted-foreground">対応状況</p>
-          <ResponseStatusButtons
-            currentStatus={responseStatus}
-            onChangeStatus={(s) => onUpdateResponseStatus(message.id, s)}
+          <NotesField
+            value={message.notes ?? null}
+            onSave={(notes) => onUpdateNotes(message.id, notes)}
           />
         </div>
+      )}
 
-        {/* タスク優先度 */}
-        <div className="mt-4">
-          <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
-          <div className="flex items-center gap-2">
-            <TaskPrioritySelector
-              value={message.taskPriority}
-              onChange={(p) => p && onUpdateTaskPriority(message.id, p)}
-            />
-            {message.taskPriority && (
-              <button
-                type="button"
-                onClick={() => setShowRemoveDialog(true)}
-                className="rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-600 hover:bg-red-100 transition-colors"
-              >
-                タスク解除
-              </button>
-            )}
-          </div>
-          <PriorityClearDialog
-            open={showRemoveDialog}
-            onConfirm={handleConfirmRemove}
-            onCancel={() => setShowRemoveDialog(false)}
+      {/* メタ情報 */}
+      <div className="mt-6 space-y-2 rounded-lg border border-border/60 bg-muted/20 p-3">
+        <h3 className="text-xs font-bold text-muted-foreground">メッセージ情報</h3>
+        <InfoRow label="グループ" value={message.groupName ?? "不明"} />
+        <InfoRow label="送信者" value={message.senderName} />
+        <InfoRow label="タイプ" value={message.lineMessageType} />
+        {message.responseStatusUpdatedBy && (
+          <InfoRow
+            label="最終更新"
+            value={`${message.responseStatusUpdatedBy} (${message.responseStatusUpdatedAt ? formatDateTimeJST(message.responseStatusUpdatedAt) : ""})`}
           />
-        </div>
-
-        {/* 担当者・期限 */}
-        <div className="mt-4 space-y-2 rounded-lg border border-border/60 bg-muted/20 p-3">
-          <AssigneesField
-            value={message.assignees}
-            onSave={(v) => onUpdateAssignees(message.id, v)}
-          />
-          <DeadlineField value={message.deadline} onSave={(v) => onUpdateDeadline(message.id, v)} />
-        </div>
-
-        {/* メモ */}
-        {onUpdateNotes && (
-          <div className="mt-4">
-            <NotesField
-              value={message.notes ?? null}
-              onSave={(notes) => onUpdateNotes(message.id, notes)}
-            />
-          </div>
         )}
-
-        {/* メタ情報 */}
-        <div className="mt-6 space-y-2 rounded-lg border border-border/60 bg-muted/20 p-3">
-          <h3 className="text-xs font-bold text-muted-foreground">メッセージ情報</h3>
-          <InfoRow label="グループ" value={message.groupName ?? "不明"} />
-          <InfoRow label="送信者" value={message.senderName} />
-          <InfoRow label="タイプ" value={message.lineMessageType} />
-          {message.responseStatusUpdatedBy && (
-            <InfoRow
-              label="最終更新"
-              value={`${message.responseStatusUpdatedBy} (${message.responseStatusUpdatedAt ? formatDateTimeJST(message.responseStatusUpdatedAt) : ""})`}
-            />
-          )}
-        </div>
       </div>
     </div>
   );

--- a/apps/web/src/components/message-detail-pane.tsx
+++ b/apps/web/src/components/message-detail-pane.tsx
@@ -38,6 +38,8 @@ export interface ChatMessageDetailPaneProps {
   onUpdateDeadline?: (id: string, deadline: string | null) => Promise<void>;
   /** Save categories callback */
   onUpdateCategories?: (id: string, categories: string[]) => Promise<void>;
+  /** Always show task remove button (e.g. when opened from task board) */
+  showTaskRemove?: boolean;
 }
 
 export function ChatMessageDetailPane({
@@ -52,6 +54,7 @@ export function ChatMessageDetailPane({
   onUpdateAssignees,
   onUpdateDeadline,
   onUpdateCategories,
+  showTaskRemove,
 }: ChatMessageDetailPaneProps) {
   const intent = message.intent as IntentDetail | null;
   const responseStatus = (intent?.responseStatus ?? "unresponded") as ResponseStatus;
@@ -64,138 +67,135 @@ export function ChatMessageDetailPane({
   };
 
   return (
-    <div className="flex flex-1 overflow-hidden">
-      {/* 中央ペイン: メッセージ詳細 */}
-      <div className="flex-1 overflow-y-auto p-5">
-        {/* ヘッダー */}
-        <div className="mb-4 flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <button
-              type="button"
-              onClick={onClose}
-              className="rounded p-1 text-muted-foreground hover:bg-accent md:hidden"
-            >
-              <X className="h-4 w-4" />
-            </button>
-            <h2 className="text-base font-bold">{message.senderName}</h2>
-            {message.spaceDisplayName && (
-              <span className="text-xs text-muted-foreground">@ {message.spaceDisplayName}</span>
-            )}
-            <span className="text-xs text-muted-foreground">
-              {formatDateTimeJST(message.createdAt)}
-            </span>
-          </div>
+    <div className="p-5">
+      {/* ヘッダー */}
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-muted-foreground hover:bg-accent md:hidden"
+          >
+            <X className="h-4 w-4" />
+          </button>
+          <h2 className="text-base font-bold">{message.senderName}</h2>
+          {message.spaceDisplayName && (
+            <span className="text-xs text-muted-foreground">@ {message.spaceDisplayName}</span>
+          )}
+          <span className="text-xs text-muted-foreground">
+            {formatDateTimeJST(message.createdAt)}
+          </span>
         </div>
+      </div>
 
-        {/* メッセージ / スレッド タブ */}
-        <Tabs defaultValue="message">
-          {message.threadMessages.length > 0 && (
-            <TabsList variant="line" className="mb-4 w-full">
-              <TabsTrigger value="message" className="flex-1">
-                メッセージ
-              </TabsTrigger>
-              <TabsTrigger value="thread" className="flex-1">
-                スレッド ({message.threadMessages.length})
-              </TabsTrigger>
-            </TabsList>
+      {/* メッセージ / スレッド タブ */}
+      <Tabs defaultValue="message">
+        {message.threadMessages.length > 0 && (
+          <TabsList variant="line" className="mb-4 w-full">
+            <TabsTrigger value="message" className="flex-1">
+              メッセージ
+            </TabsTrigger>
+            <TabsTrigger value="thread" className="flex-1">
+              スレッド ({message.threadMessages.length})
+            </TabsTrigger>
+          </TabsList>
+        )}
+
+        <TabsContent value="message">
+          {/* メッセージ本文 */}
+          <div className="rounded-lg bg-muted/50 p-4 text-sm leading-relaxed">
+            {message.content}
+          </div>
+
+          {/* 添付ファイル */}
+          {message.attachments.length > 0 && (
+            <div className="mt-3">
+              <AttachmentList attachments={message.attachments} />
+            </div>
           )}
 
-          <TabsContent value="message">
-            {/* メッセージ本文 */}
-            <div className="rounded-lg bg-muted/50 p-4 text-sm leading-relaxed">
-              {message.content}
-            </div>
-
-            {/* 添付ファイル */}
-            {message.attachments.length > 0 && (
-              <div className="mt-3">
-                <AttachmentList attachments={message.attachments} />
-              </div>
-            )}
-
-            {/* カテゴリ */}
-            {intent && onUpdateCategories && (
-              <div className="mt-4">
-                <p className="mb-2 text-xs font-semibold text-muted-foreground">カテゴリ</p>
-                <CategoriesField
-                  categories={intent.categories}
-                  onSave={(cats) => onUpdateCategories(message.id, cats)}
-                />
-              </div>
-            )}
-
-            {/* 対応ステータス変更 */}
+          {/* カテゴリ */}
+          {intent && onUpdateCategories && (
             <div className="mt-4">
-              <p className="mb-2 text-xs font-semibold text-muted-foreground">対応状況</p>
-              <ResponseStatusButtons
-                currentStatus={responseStatus}
-                onChangeStatus={(s) => onUpdateResponseStatus(message.id, s)}
+              <p className="mb-2 text-xs font-semibold text-muted-foreground">カテゴリ</p>
+              <CategoriesField
+                categories={intent.categories}
+                onSave={(cats) => onUpdateCategories(message.id, cats)}
               />
             </div>
+          )}
 
-            {/* タスク優先度 */}
-            <div className="mt-4">
-              <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
-              <div className="flex items-center gap-2">
-                <TaskPrioritySelector
-                  value={intent?.taskPriority ?? null}
-                  onChange={(p) => p && onUpdateTaskPriority(message.id, p)}
-                />
-                {intent?.taskPriority && (
-                  <button
-                    type="button"
-                    onClick={() => setShowRemoveDialog(true)}
-                    className="rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-600 hover:bg-red-100 transition-colors"
-                  >
-                    タスク解除
-                  </button>
-                )}
-              </div>
-              <PriorityClearDialog
-                open={showRemoveDialog}
-                onConfirm={handleConfirmRemove}
-                onCancel={() => setShowRemoveDialog(false)}
-              />
-            </div>
-
-            {/* 担当者・期限 */}
-            {onUpdateAssignees && onUpdateDeadline && (
-              <div className="mt-4 space-y-2 rounded-lg border border-border/60 bg-muted/20 p-3">
-                <AssigneesField
-                  value={assignees ?? null}
-                  onSave={(v) => onUpdateAssignees(message.id, v)}
-                />
-                <DeadlineField
-                  value={deadline ?? null}
-                  onSave={(v) => onUpdateDeadline(message.id, v)}
-                />
-              </div>
-            )}
-
-            {/* ワークフロー */}
-            {intent && (
-              <div className="mt-4">
-                <p className="mb-2 text-xs font-semibold text-muted-foreground">ワークフロー</p>
-                <WorkflowPanelWrapper
-                  chatMessageId={message.id}
-                  steps={intent.workflowSteps ?? null}
-                  onUpdateWorkflow={onUpdateWorkflow}
-                />
-              </div>
-            )}
-
-            {/* Extra content slot (e.g. NotesField) */}
-            {extraContent}
-          </TabsContent>
-
-          <TabsContent value="thread">
-            <ThreadView
-              threadMessages={message.threadMessages}
-              originalSenderName={message.senderName}
+          {/* 対応ステータス変更 */}
+          <div className="mt-4">
+            <p className="mb-2 text-xs font-semibold text-muted-foreground">対応状況</p>
+            <ResponseStatusButtons
+              currentStatus={responseStatus}
+              onChangeStatus={(s) => onUpdateResponseStatus(message.id, s)}
             />
-          </TabsContent>
-        </Tabs>
-      </div>
+          </div>
+
+          {/* タスク優先度 */}
+          <div className="mt-4">
+            <p className="mb-2 text-xs font-semibold text-muted-foreground">タスク優先度</p>
+            <div className="flex items-center gap-2">
+              <TaskPrioritySelector
+                value={intent?.taskPriority ?? null}
+                onChange={(p) => p && onUpdateTaskPriority(message.id, p)}
+              />
+              {(intent?.taskPriority || showTaskRemove) && (
+                <button
+                  type="button"
+                  onClick={() => setShowRemoveDialog(true)}
+                  className="rounded-md border border-red-200 bg-red-50 px-2 py-1 text-xs text-red-600 hover:bg-red-100 transition-colors"
+                >
+                  タスク解除
+                </button>
+              )}
+            </div>
+            <PriorityClearDialog
+              open={showRemoveDialog}
+              onConfirm={handleConfirmRemove}
+              onCancel={() => setShowRemoveDialog(false)}
+            />
+          </div>
+
+          {/* 担当者・期限 */}
+          {onUpdateAssignees && onUpdateDeadline && (
+            <div className="mt-4 space-y-2 rounded-lg border border-border/60 bg-muted/20 p-3">
+              <AssigneesField
+                value={assignees ?? null}
+                onSave={(v) => onUpdateAssignees(message.id, v)}
+              />
+              <DeadlineField
+                value={deadline ?? null}
+                onSave={(v) => onUpdateDeadline(message.id, v)}
+              />
+            </div>
+          )}
+
+          {/* ワークフロー */}
+          {intent && (
+            <div className="mt-4">
+              <p className="mb-2 text-xs font-semibold text-muted-foreground">ワークフロー</p>
+              <WorkflowPanelWrapper
+                chatMessageId={message.id}
+                steps={intent.workflowSteps ?? null}
+                onUpdateWorkflow={onUpdateWorkflow}
+              />
+            </div>
+          )}
+
+          {/* Extra content slot (e.g. NotesField) */}
+          {extraContent}
+        </TabsContent>
+
+        <TabsContent value="thread">
+          <ThreadView
+            threadMessages={message.threadMessages}
+            originalSenderName={message.senderName}
+          />
+        </TabsContent>
+      </Tabs>
     </div>
   );
 }

--- a/apps/web/src/components/notes-field.tsx
+++ b/apps/web/src/components/notes-field.tsx
@@ -37,7 +37,7 @@ export function NotesField({ value, onSave }: NotesFieldProps) {
 
   return (
     <div className="space-y-1">
-      <p className="text-xs font-semibold text-muted-foreground">
+      <p className="text-sm font-semibold text-muted-foreground">
         メモ
         {saving && <span className="ml-1 text-muted-foreground/60">保存中...</span>}
       </p>
@@ -45,9 +45,9 @@ export function NotesField({ value, onSave }: NotesFieldProps) {
         value={localNotes}
         onChange={(e) => setLocalNotes(e.target.value)}
         onBlur={handleBlur}
-        placeholder="メモ"
-        rows={2}
-        className="w-full resize-none rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-foreground/80 placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
+        placeholder="メモを入力..."
+        rows={3}
+        className="w-full resize-y rounded border border-transparent bg-transparent px-2 py-1 text-sm leading-relaxed text-foreground/80 placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- ダイアログ内の縦スクロールが効かない問題を修正（`overflow-hidden` の構造を解消）
- タスクボードのダイアログで「タスク解除」ボタンが常に表示されるよう修正（`showTaskRemove` prop追加）
- メモ欄のフォントサイズ拡大（12px→14px）、行数増加（2→3行）、縦リサイズ可能に変更

## Test plan
- [x] ダイアログ内で縦スクロールが正常に動作すること
- [x] タスク優先度の横に「タスク解除」ボタンが表示されること
- [x] メモ欄が読みやすいサイズで表示され、リサイズ可能なこと
- [x] Inbox 3ペインレイアウトでのスクロールが壊れていないこと
- [x] typecheck / lint 全PASS

Closes #363, Closes #364, Closes #365

🤖 Generated with [Claude Code](https://claude.com/claude-code)