### PR TITLE
fix: メモ欄を入力内容に応じて自動拡張

### DIFF
--- a/apps/web/src/components/notes-field.tsx
+++ b/apps/web/src/components/notes-field.tsx
@@ -7,16 +7,24 @@ interface NotesFieldProps {
   onSave: (notes: string | null) => Promise<void>;
 }
 
+function resizeTextarea(el: HTMLTextAreaElement | null) {
+  if (!el) return;
+  el.style.height = "auto";
+  el.style.height = `${el.scrollHeight}px`;
+}
+
 export function NotesField({ value, onSave }: NotesFieldProps) {
   const [localNotes, setLocalNotes] = useState(value ?? "");
   const [saving, setSaving] = useState(false);
   const savedValue = useRef(value ?? "");
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   // sync when prop changes externally
   useEffect(() => {
     const v = value ?? "";
     setLocalNotes(v);
     savedValue.current = v;
+    requestAnimationFrame(() => resizeTextarea(textareaRef.current));
   }, [value]);
 
   async function handleBlur() {
@@ -42,12 +50,16 @@ export function NotesField({ value, onSave }: NotesFieldProps) {
         {saving && <span className="ml-1 text-muted-foreground/60">保存中...</span>}
       </p>
       <textarea
+        ref={textareaRef}
         value={localNotes}
-        onChange={(e) => setLocalNotes(e.target.value)}
+        onChange={(e) => {
+          setLocalNotes(e.target.value);
+          resizeTextarea(e.target);
+        }}
         onBlur={handleBlur}
         placeholder="メモを入力..."
-        rows={3}
-        className="w-full resize-y rounded border border-transparent bg-transparent px-2 py-1 text-sm leading-relaxed text-foreground/80 placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
+        rows={2}
+        className="w-full resize-none overflow-hidden rounded border border-transparent bg-transparent px-2 py-1 text-sm leading-relaxed text-foreground/80 placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
       />
     </div>
   );


### PR DESCRIPTION
## Summary
- メモ textarea を固定行数 + 手動リサイズから、入力内容に応じた自動拡張に変更
- `resize-none overflow-hidden` + `resizeTextarea()` で改行に追従して高さが伸びる
- メモ内のスクロールが不要になり、親ダイアログのスクロールのみで完結

## Test plan
- [ ] メモに改行を入力すると textarea の高さが自動的に拡張されること
- [ ] 既存メモがある場合、ダイアログ表示時に高さが自動調整されること
- [ ] typecheck / lint PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)