### PR TITLE
fix: タスク解除後にダイアログを自動で閉じる

### DIFF
--- a/apps/web/src/components/line-message-detail-pane.tsx
+++ b/apps/web/src/components/line-message-detail-pane.tsx
@@ -43,6 +43,7 @@ export function LineMessageDetailPane({
     setShowRemoveDialog(false);
     onUpdateTaskPriority(message.id, null);
     toast.success("タスクを解除しました");
+    onClose();
   };
 
   return (

--- a/apps/web/src/components/message-detail-pane.tsx
+++ b/apps/web/src/components/message-detail-pane.tsx
@@ -64,6 +64,7 @@ export function ChatMessageDetailPane({
     setShowRemoveDialog(false);
     onUpdateTaskPriority(message.id, null);
     toast.success("タスクを解除しました");
+    onClose();
   };
 
   return (


### PR DESCRIPTION
## Summary
- タスク解除確認後に `onClose()` を呼び出し、詳細ダイアログ/ペインを自動的に閉じるように変更
- 対象: `LineMessageDetailPane` と `ChatMessageDetailPane` の `handleConfirmRemove`

Closes #369

## Test plan
- [x] `pnpm typecheck` 全PASS
- [x] `pnpm test` 全207テスト PASS
- [x] `pnpm lint` エラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)