### PR TITLE
fix: IntentRecord重複時の更新漏れを修正

### DIFF
--- a/apps/api/src/routes/chat-messages.ts
+++ b/apps/api/src/routes/chat-messages.ts
@@ -765,7 +765,6 @@ chatMessageRoutes.patch("/:id/workflow", zValidator("json", patchWorkflowSchema)
 
   const intentSnap = await collections.intentRecords
     .where("chatMessageId", "==", chatMessageId)
-    .limit(1)
     .get();
 
   const updates: Record<string, unknown> = {
@@ -782,8 +781,13 @@ chatMessageRoutes.patch("/:id/workflow", zValidator("json", patchWorkflowSchema)
 
   await db.runTransaction(async (tx) => {
     if (!intentSnap.empty) {
+      // 最初の1件を更新、重複があれば余分なレコードを削除
       // biome-ignore lint/style/noNonNullAssertion: intentSnap.empty checked above
       tx.update(intentSnap.docs[0]!.ref, updates);
+      for (let i = 1; i < intentSnap.docs.length; i++) {
+        // biome-ignore lint/style/noNonNullAssertion: bounds checked in loop
+        tx.delete(intentSnap.docs[i]!.ref);
+      }
     } else {
       // IntentRecord がなければ新規作成
       const intentRef = collections.intentRecords.doc();


### PR DESCRIPTION
## Summary
- `PATCH /api/chat-messages/:id/workflow` で `.limit(1)` を除去し全件取得
- 重複 IntentRecord がある場合、最初の1件を更新し2件目以降をトランザクション内で削除
- 既存の重複データ7件（+ 今里安江の1件）は手動でクリーンアップ済み

## 根本原因
同一 chatMessageId に対して IntentRecord が2件存在するケースがあった。
`PATCH /workflow` は `.limit(1)` で最初の1件のみ更新していたため、
2件目の `taskPriority: "medium"` が残り続け、タスク一覧から除外されなかった。

Closes #371

## Test plan
- [x] `pnpm typecheck` 全PASS
- [x] API テスト 173件 全PASS
- [x] Web テスト 207件 全PASS
- [x] Firestore の重複データ8件をクリーンアップ済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)