### PR TITLE
fix: Cloud Scheduler SA認証のaudience不一致を修正

### DIFF
--- a/apps/api/src/__tests__/auth.test.ts
+++ b/apps/api/src/__tests__/auth.test.ts
@@ -207,6 +207,36 @@ describe("authMiddleware", () => {
     expect(res.status).toBe(403);
   });
 
+  it("SA トークンの audience 不一致 → audience なしフォールバックで認証成功", async () => {
+    vi.stubEnv("GOOGLE_CLIENT_ID", "web-client-id.apps.googleusercontent.com");
+    vi.stubEnv("ALLOWED_SERVICE_ACCOUNTS", "hr-api@hr-system-487809.iam.gserviceaccount.com");
+
+    const saPayload = {
+      email: "hr-api@hr-system-487809.iam.gserviceaccount.com",
+      sub: "sa-sub",
+    };
+
+    // 1回目: audience 付き → reject（Cloud Scheduler の audience は Cloud Run URL）
+    // 2回目: audience なし → resolve
+    mockVerifyIdToken
+      .mockRejectedValueOnce(new Error("Token used too late / wrong audience"))
+      .mockResolvedValueOnce({ getPayload: () => saPayload });
+
+    const app = createTestApp();
+    const res = await app.request("/test", {
+      headers: { Authorization: "Bearer scheduler-oidc-token" },
+    });
+
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { user: { email: string; dashboardRole: null } };
+    expect(body.user.email).toBe("hr-api@hr-system-487809.iam.gserviceaccount.com");
+    expect(body.user.dashboardRole).toBeNull();
+    // verifyIdToken が2回呼ばれた（フォールバック）
+    expect(mockVerifyIdToken).toHaveBeenCalledTimes(2);
+
+    vi.unstubAllEnvs();
+  });
+
   it("複数SAホワイトリスト → 2番目のSAも許可される", async () => {
     vi.stubEnv(
       "ALLOWED_SERVICE_ACCOUNTS",

--- a/apps/api/src/middleware/auth.ts
+++ b/apps/api/src/middleware/auth.ts
@@ -65,10 +65,19 @@ export const authMiddleware = createMiddleware(async (c, next) => {
       logger.error("GOOGLE_CLIENT_ID is not configured in production");
       throw new HTTPException(500, { message: "Server misconfiguration" });
     }
-    const ticket = await client.verifyIdToken({
-      idToken: token,
-      ...(audience ? { audience } : {}),
-    });
+    // トークン検証: audience 付き → 失敗時 audience なしで再試行（SA 用フォールバック）
+    // Cloud Scheduler の OIDC トークンは Cloud Run URL を audience に持つため、
+    // GOOGLE_CLIENT_ID（Web OAuth用）では検証に失敗する。SA は ALLOWED_SERVICE_ACCOUNTS で担保。
+    let ticket: import("google-auth-library").LoginTicket;
+    try {
+      ticket = await client.verifyIdToken({
+        idToken: token,
+        ...(audience ? { audience } : {}),
+      });
+    } catch {
+      // audience 不一致の可能性 → audience なしで再検証
+      ticket = await client.verifyIdToken({ idToken: token });
+    }
     const payload = ticket.getPayload();
     if (!payload?.email) throw new Error("No email in token");
 


### PR DESCRIPTION
## Summary
- Cloud SchedulerのOIDCトークンaudience（Cloud Run URL）とverifyIdTokenのaudience（GOOGLE_CLIENT_ID）が不一致で全リクエストが401になっていた問題を修正
- verifyIdTokenをaudience付き→audienceなしの2段階フォールバック方式に変更
- SAの安全性は既存のALLOWED_SERVICE_ACCOUNTSホワイトリストで担保

## デプロイ後の追加作業
```bash
gcloud run services update hr-api \
  --region=asia-northeast1 \
  --update-env-vars="ALLOWED_SERVICE_ACCOUNTS=hr-api@hr-system-487809.iam.gserviceaccount.com"
```

## Test plan
- [x] SA audience不一致→フォールバック認証成功のテスト追加
- [x] 既存テスト全174件 PASS
- [x] 型チェック PASS
- [ ] マージ後、Cloud Run環境変数 `ALLOWED_SERVICE_ACCOUNTS` を設定
- [ ] Cloud Schedulerログで認証成功を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)