### PR TITLE
fix: 同期パネルの自動更新を追加

### DIFF
--- a/apps/web/src/app/(protected)/admin/sync/sync-panel.tsx
+++ b/apps/web/src/app/(protected)/admin/sync/sync-panel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertCircle, AlertTriangle, CheckCircle2, Loader2, RefreshCw } from "lucide-react";
-import { useCallback, useState, useTransition } from "react";
+import { useCallback, useEffect, useState, useTransition } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -56,6 +56,19 @@ export function SyncPanel({ initialStatus, initialConfig }: SyncPanelProps) {
       }
     });
   }, []);
+
+  // 60秒ポーリング + タブ復帰時の即時再取得
+  useEffect(() => {
+    const id = window.setInterval(refresh, 60_000);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      window.clearInterval(id);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [refresh]);
 
   const handleSync = useCallback(() => {
     setSyncMessage(null);


### PR DESCRIPTION
## Summary
- 同期管理画面（`/admin/sync`）に60秒ポーリング + タブ復帰時の即時再取得を追加
- ヘッダーの `SyncStatusIndicator` と同じパターン
- 手動リロードなしでステータス・鮮度バッジが自動更新されるようになる

## Test plan
- [x] `pnpm typecheck` — 11/11 PASS
- [x] `pnpm test` — 221/221 PASS
- [ ] デプロイ後、同期パネルを開いたまま待機し、最終同期時刻が自動更新されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)