### PR TITLE
fix: Chat連携アカウントの redirect_uri 修正・確認ダイアログ追加・UX改善

### DIFF
--- a/apps/web/src/app/(protected)/admin/spaces/page.tsx
+++ b/apps/web/src/app/(protected)/admin/spaces/page.tsx
@@ -8,7 +8,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { requireAdmin } from "@/lib/access-control";
-import { getChatSpaces, getLineGroups } from "@/lib/api";
+import { getChatCredentials, getChatSpaces, getLineGroups } from "@/lib/api";
 import { AddSpaceForm } from "./add-space-form";
 import { LineGroupActions } from "./line-group-actions";
 import { SpaceActions } from "./space-actions";
@@ -26,22 +26,42 @@ export default async function AdminSpacesPage({ searchParams }: Props) {
     <div className="space-y-6">
       <SpacesTabNav activeTab={tab} />
 
-      {tab === "chat" && <ChatSpacesTab />}
+      {tab === "chat" && <ChatSpacesContent />}
       {tab === "line" && <LineGroupsTab />}
     </div>
   );
 }
 
-async function ChatSpacesTab() {
-  const { data: spaces } = await getChatSpaces(true);
-  const syncAccountEmail = process.env.CHAT_SYNC_ACCOUNT_EMAIL ?? "yasushi.honda@aozora-cg.com";
+async function ChatSpacesContent() {
+  const [{ data: spaces }, credentials] = await Promise.all([
+    getChatSpaces(true),
+    getChatCredentials()
+      .then((r) => r.data)
+      .catch((err) => {
+        console.error("[admin/spaces] getChatCredentials failed:", err);
+        return null;
+      }),
+  ]);
 
   return (
     <div className="space-y-4">
       <div className="rounded-xl border border-amber-200/60 bg-amber-50 p-4">
         <p className="text-sm text-amber-800">
-          ⚠ 追加するスペースには <span className="font-mono font-medium">{syncAccountEmail}</span>{" "}
-          が参加している必要があります。
+          {credentials?.email ? (
+            <>
+              ⚠ 追加するスペースには{" "}
+              <span className="font-mono font-medium">{credentials.email}</span>{" "}
+              が参加している必要があります。
+            </>
+          ) : (
+            <>
+              ⚠ 同期アカウントが未連携です。
+              <a href="/admin/sync" className="underline font-medium hover:text-amber-900">
+                同期ページ
+              </a>
+              でアカウントを連携してください。
+            </>
+          )}
         </p>
         <details className="mt-2">
           <summary className="cursor-pointer text-xs text-amber-700 hover:text-amber-900 select-none">

--- a/apps/web/src/app/(protected)/admin/sync/sync-panel.tsx
+++ b/apps/web/src/app/(protected)/admin/sync/sync-panel.tsx
@@ -158,6 +158,16 @@ export function SyncPanel({ initialStatus, initialConfig, initialCredentials }: 
     });
   }, [interval]);
 
+  const handleChatConnect = useCallback(() => {
+    if (
+      window.confirm(
+        "このアカウントで Google Chat の認証を行います。\n連携するアカウントは、対象の Chat スペースに参加しているメンバーである必要があります。\n\n続行しますか？",
+      )
+    ) {
+      window.location.href = "/api/auth/chat-connect";
+    }
+  }, []);
+
   const handleDisconnect = useCallback(() => {
     setActionError(null);
     startTransition(async () => {
@@ -227,7 +237,8 @@ export function SyncPanel({ initialStatus, initialConfig, initialCredentials }: 
       <div className="rounded-xl border border-border/60 bg-card p-6">
         <h2 className="text-sm font-semibold">連携アカウント</h2>
         <p className="mt-1 text-xs text-muted-foreground">
-          Chat API の認証に使用する Google アカウント
+          Chat API の認証に使用する Google アカウント。
+          連携するアカウントは対象スペースのメンバーである必要があります。
         </p>
 
         <div className="mt-4">
@@ -244,11 +255,9 @@ export function SyncPanel({ initialStatus, initialConfig, initialCredentials }: 
                 </div>
               </div>
               <div className="flex items-center gap-2">
-                <Button variant="outline" size="sm" asChild>
-                  <a href="/api/auth/chat-connect">
-                    <LinkIcon className="mr-2 h-4 w-4" />
-                    アカウントを変更
-                  </a>
+                <Button variant="outline" size="sm" onClick={handleChatConnect}>
+                  <LinkIcon className="mr-2 h-4 w-4" />
+                  アカウントを変更
                 </Button>
                 <Button
                   variant="ghost"
@@ -270,11 +279,9 @@ export function SyncPanel({ initialStatus, initialConfig, initialCredentials }: 
                   未連携（サーバー既定の認証を使用中）
                 </p>
               </div>
-              <Button variant="outline" size="sm" asChild>
-                <a href="/api/auth/chat-connect">
-                  <LinkIcon className="mr-2 h-4 w-4" />
-                  アカウントを連携
-                </a>
+              <Button variant="outline" size="sm" onClick={handleChatConnect}>
+                <LinkIcon className="mr-2 h-4 w-4" />
+                アカウントを連携
               </Button>
             </div>
           )}

--- a/apps/web/src/app/api/auth/chat-connect/callback/route.ts
+++ b/apps/web/src/app/api/auth/chat-connect/callback/route.ts
@@ -4,6 +4,7 @@ import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { getSessionRole } from "@/lib/access-control";
+import { getBaseUrl } from "@/lib/server-url";
 
 const TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token";
 const USERINFO_ENDPOINT = "https://www.googleapis.com/oauth2/v3/userinfo";
@@ -23,7 +24,7 @@ export async function GET(request: Request) {
   const state = url.searchParams.get("state");
   const error = url.searchParams.get("error");
 
-  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3005";
+  const baseUrl = await getBaseUrl();
   const syncPageUrl = `${baseUrl}/admin/sync`;
 
   // ユーザーが同意をキャンセルした場合

--- a/apps/web/src/app/api/auth/chat-connect/route.ts
+++ b/apps/web/src/app/api/auth/chat-connect/route.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto";
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import { getSessionRole } from "@/lib/access-control";
+import { getBaseUrl } from "@/lib/server-url";
 
 const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 
@@ -24,7 +25,7 @@ export async function GET() {
   }
 
   const clientId = process.env.GOOGLE_CLIENT_ID ?? "";
-  const baseUrl = process.env.NEXTAUTH_URL ?? "http://localhost:3005";
+  const baseUrl = await getBaseUrl();
   const redirectUri = `${baseUrl}/api/auth/chat-connect/callback`;
 
   // CSRF トークン

--- a/apps/web/src/lib/server-url.ts
+++ b/apps/web/src/lib/server-url.ts
@@ -1,0 +1,13 @@
+import { headers } from "next/headers";
+
+/**
+ * リクエストヘッダーから baseUrl を構築する。
+ * Cloud Run では x-forwarded-* ヘッダーが自動注入される。
+ * ローカル開発時は host ヘッダーにフォールバック。
+ */
+export async function getBaseUrl(): Promise<string> {
+  const h = await headers();
+  const host = h.get("x-forwarded-host") ?? h.get("host") ?? "localhost:3005";
+  const proto = h.get("x-forwarded-proto") ?? "http";
+  return `${proto}://${host}`;
+}


### PR DESCRIPTION
## Summary
- 本番で `redirect_uri_mismatch` エラーが発生していた問題を修正（`NEXTAUTH_URL` → request headers ベースの baseUrl 取得）
- OAuth 遷移前に確認ダイアログを追加し、誤クリックによる意図しない認証フローを防止
- 連携アカウントの説明文を拡充（対象スペースのメンバーである必要がある旨を明示）
- スペースページの注意文をハードコード email から Firestore `chat_credentials` の動的取得に変更

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `apps/web/src/lib/server-url.ts` | **新規**: `getBaseUrl()` ユーティリティ（headers から baseUrl 構築） |
| `apps/web/src/app/api/auth/chat-connect/route.ts` | redirect_uri を `getBaseUrl()` ベースに変更 |
| `apps/web/src/app/api/auth/chat-connect/callback/route.ts` | 同上 |
| `apps/web/src/app/(protected)/admin/sync/sync-panel.tsx` | 確認ダイアログ追加 + 説明文拡充 |
| `apps/web/src/app/(protected)/admin/spaces/page.tsx` | 動的 email 表示 + 未連携時の案内メッセージ |

## GCP 手動作業
OAuth クライアントの「承認済みのリダイレクト URI」に追加が必要:
- `https://hr-web-1021020088552.asia-northeast1.run.app/api/auth/chat-connect/callback`

## Test plan
- [x] `pnpm typecheck` — 11/11 全 PASS
- [x] `pnpm test` — 7パッケージ全 PASS
- [x] `pnpm lint` — 7/7 全 PASS
- [ ] ローカルで「アカウントを連携」→ 確認ダイアログ表示 → キャンセルで遷移しない
- [ ] 本番で OAuth フロー完了 → email 表示
- [ ] スペースページで連携 email が動的に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)