### PR TITLE
fix: LINE group-freshness のインデックス追記 + エラー表示改善

### DIFF
--- a/apps/web/src/app/(protected)/admin/sync/page.tsx
+++ b/apps/web/src/app/(protected)/admin/sync/page.tsx
@@ -1,4 +1,4 @@
-import { CheckCircle2, MessageSquare } from "lucide-react";
+import { AlertCircle, CheckCircle2, MessageSquare } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import {
   Table,
@@ -27,13 +27,20 @@ function formatRelativeTime(iso: string | null): string {
 
 export default async function AdminSyncPage() {
   await requireAdmin();
-  const [status, config, lineGroupFreshness] = await Promise.all([
+  const [status, config, lineGroupResult] = await Promise.all([
     getChatSyncStatus(),
     getChatSyncConfig(),
     getLineGroupFreshness()
-      .then((r) => r.groups)
-      .catch(() => [] as LineGroupFreshness[]),
+      .then((r) => ({ groups: r.groups, error: null }))
+      .catch((err) => {
+        console.error("[admin/sync] getLineGroupFreshness failed:", err);
+        return {
+          groups: [] as LineGroupFreshness[],
+          error: "LINE グループ情報の取得に失敗しました",
+        };
+      }),
   ]);
+  const { groups: lineGroupFreshness, error: lineGroupError } = lineGroupResult;
 
   return (
     <div className="space-y-8">
@@ -74,6 +81,14 @@ export default async function AdminSyncPage() {
             </p>
           </div>
         </div>
+
+        {/* LINE API error banner */}
+        {lineGroupError && (
+          <div className="flex items-start gap-3 rounded-xl border border-amber-200/60 bg-amber-50 p-4">
+            <AlertCircle className="mt-0.5 h-5 w-5 shrink-0 text-amber-600" />
+            <p className="text-sm text-amber-800">{lineGroupError}</p>
+          </div>
+        )}
 
         {/* Webhook ステータス */}
         <div className="rounded-xl border border-border/60 bg-card p-6">

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -164,6 +164,14 @@
       "collectionGroup": "line_messages",
       "queryScope": "COLLECTION",
       "fields": [
+        { "fieldPath": "groupId", "order": "ASCENDING" },
+        { "fieldPath": "createdAt", "order": "DESCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "line_messages",
+      "queryScope": "COLLECTION",
+      "fields": [
         { "fieldPath": "responseStatus", "order": "ASCENDING" },
         { "fieldPath": "createdAt", "order": "DESCENDING" }
       ]


### PR DESCRIPTION
## Summary

- `firestore.indexes.json` に `line_messages` の `groupId + createdAt DESC` 複合インデックスを追記（#383 で追加した group-freshness エンドポイントが必要とする）
- `sync/page.tsx` の `.catch(() => [])` サイレントフォールバックを廃止し、API エラー時にエラーバナーを表示するよう変更

## Context

#383 マージ後、同期タブの LINE グループ一覧が「LINE グループが登録されていません」と誤表示されていた。原因は Firestore 複合インデックス未登録による API 500 エラーを `.catch(() => [])` が握りつぶしていたため。

## Test plan

- [x] `pnpm typecheck` — 11/11 成功
- [x] `pnpm test` — 全パッケージ PASS
- [x] `pnpm lint` — 変更ファイル全てクリーン
- [x] 本番 API で group-freshness レスポンス確認済み（9グループ + lastMessageAt）
- [x] 本番画面で LINE グループ一覧 + 最終取得日時の表示確認済み
- [ ] マージ後 `firebase deploy --only firestore:indexes` を手動実行（CI/CD に含まれないため）

🤖 Generated with [Claude Code](https://claude.com/claude-code)