### PR TITLE
ui: スペース追加の案内文を案内トーンに変更

### DIFF
--- a/apps/web/src/app/(protected)/admin/spaces/chat-spaces-section.tsx
+++ b/apps/web/src/app/(protected)/admin/spaces/chat-spaces-section.tsx
@@ -140,9 +140,8 @@ export function ChatSpacesSection({ initialSpaces, initialCredentials }: ChatSpa
           <p className="text-xs text-amber-800">
             {credentials?.email ? (
               <>
-                ⚠ 連携アカウント（
-                <span className="font-mono font-medium">{credentials.email}</span>
-                ）が参加しているスペースのみ同期できます。
+                <span className="font-mono font-medium">{credentials.email}</span>{" "}
+                が参加しているスペースを追加できます。
               </>
             ) : (
               <>


### PR DESCRIPTION
## Summary
- 「〜のみ同期できます」→「〜を追加できます」に変更
- ⚠マーク除去で制限ではなく案内として表示

## Test plan
- [ ] 管理設定 > スペース > Google Chat タブで警告バナーの文言確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)