### PR TITLE
ui: スペース追加バナーを汎用ルール表示に変更

### DIFF
--- a/apps/web/src/app/(protected)/admin/spaces/chat-spaces-section.tsx
+++ b/apps/web/src/app/(protected)/admin/spaces/chat-spaces-section.tsx
@@ -140,8 +140,7 @@ export function ChatSpacesSection({ initialSpaces, initialCredentials }: ChatSpa
           <p className="text-xs text-amber-800">
             {credentials?.email ? (
               <>
-                <span className="font-mono font-medium">{credentials.email}</span>{" "}
-                が参加しているスペースを追加できます。
+                スペースを追加するには、連携アカウントがそのスペースのメンバーである必要があります。
               </>
             ) : (
               <>


### PR DESCRIPTION
## Summary
- バナーから具体的なメールアドレスを除去
- 「連携アカウントがそのスペースのメンバーである必要があります」という汎用ルールに変更

## Test plan
- [ ] 管理設定 > スペース > Google Chat タブでバナー文言確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)