### PR TITLE
ui: 割り振りフィールドをクリックでリスト選択に変更

### DIFF
--- a/apps/web/src/__tests__/task-board.test.tsx
+++ b/apps/web/src/__tests__/task-board.test.tsx
@@ -270,8 +270,8 @@ describe("TaskList", () => {
     expect(text).toContain("元のメッセージ");
   });
 
-  it("担当者がある場合にinputのvalueに表示される", () => {
-    const html = renderToHtml(
+  it("担当者がある場合にボタンテキストに表示される", () => {
+    const text = renderToText(
       React.createElement(TaskList, {
         tasks: [makeTask({ assignees: "佐藤花子" })],
         selectedId: null,
@@ -279,8 +279,8 @@ describe("TaskList", () => {
         onOpenDialog: mockOnOpenDialog,
       }),
     );
-    // 担当者はインラインinputで編集可能
-    expect(html).toContain('value="佐藤花子"');
+    // 担当者はクリックでリスト選択
+    expect(text).toContain("佐藤花子");
   });
 
   it("対応状況ラベルが表示される", () => {

--- a/apps/web/src/app/(protected)/task-board/page.tsx
+++ b/apps/web/src/app/(protected)/task-board/page.tsx
@@ -2,7 +2,7 @@ import type { ChatCategory, ResponseStatus, TaskPriority } from "@hr-system/shar
 
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import Link from "next/link";
-import { getChatMessages, getLineMessages, getManualTasks } from "@/lib/api";
+import { getAdminUsers, getChatMessages, getLineMessages, getManualTasks } from "@/lib/api";
 import {
   CATEGORY_CONFIG,
   CATEGORY_OPTIONS,
@@ -69,7 +69,7 @@ export default async function TaskBoardPage({ searchParams }: Props) {
   const selectedId = params.id ?? null;
 
   // 全ソースを並列取得（hasTaskPriority でタスク優先度付きのみ取得）
-  const [chatResult, lineResult, manualResult] = await Promise.all([
+  const [chatResult, lineResult, manualResult, usersResult] = await Promise.all([
     sourceFilter === "all" || sourceFilter === "gchat"
       ? getChatMessages({ hasTaskPriority: true, limit: 200 })
       : null,
@@ -77,7 +77,13 @@ export default async function TaskBoardPage({ searchParams }: Props) {
       ? getLineMessages({ hasTaskPriority: true, limit: 200 })
       : null,
     sourceFilter === "all" || sourceFilter === "manual" ? getManualTasks({ limit: 200 }) : null,
+    getAdminUsers().catch(() => ({ data: [] })),
   ]);
+
+  const memberNames = usersResult.data
+    .filter((u) => u.isActive)
+    .sort((a, b) => a.sortOrder - b.sortOrder)
+    .map((u) => u.displayName);
 
   // タスク優先度付きメッセージを抽出・統合
   const tasks: TaskItem[] = [];
@@ -201,7 +207,12 @@ export default async function TaskBoardPage({ searchParams }: Props) {
 
   return (
     <div className="-m-6 flex h-[calc(100vh-52px)] flex-col">
-      <TaskBoardContent tasks={paged} initialSelectedId={selectedId} pageOffset={offset}>
+      <TaskBoardContent
+        tasks={paged}
+        initialSelectedId={selectedId}
+        pageOffset={offset}
+        memberNames={memberNames}
+      >
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-3">
             <h1 className="text-base font-bold tracking-tight">タスク一覧</h1>

--- a/apps/web/src/app/(protected)/task-board/task-board-content.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-board-content.tsx
@@ -50,6 +50,7 @@ interface Props {
   tasks: TaskItem[];
   initialSelectedId: string | null;
   pageOffset?: number;
+  memberNames?: string[];
   children: React.ReactNode;
 }
 
@@ -64,7 +65,13 @@ export const useSelectTask = () => useContext(SelectTaskContext);
  * タスク選択時に Server Action 経由で詳細データを取得し、受信箱と同等の
  * DetailPane を表示する。
  */
-export function TaskBoardContent({ tasks, initialSelectedId, pageOffset = 0, children }: Props) {
+export function TaskBoardContent({
+  tasks,
+  initialSelectedId,
+  pageOffset = 0,
+  memberNames = [],
+  children,
+}: Props) {
   const router = useRouter();
   const [selectedId, setSelectedId] = useState(initialSelectedId);
   const [dialogTaskId, setDialogTaskId] = useState<string | null>(null);
@@ -182,6 +189,7 @@ export function TaskBoardContent({ tasks, initialSelectedId, pageOffset = 0, chi
             onSelect={setSelectedId}
             onOpenDialog={handleOpenDialog}
             pageOffset={pageOffset}
+            memberNames={memberNames}
           />
         </div>
       </div>

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -97,12 +97,14 @@ export function TaskList({
   onSelect,
   onOpenDialog,
   pageOffset = 0,
+  memberNames = [],
 }: {
   tasks: TaskItem[];
   selectedId: string | null;
   onSelect: (id: string | null) => void;
   onOpenDialog: (id: string) => void;
   pageOffset?: number;
+  memberNames?: string[];
 }) {
   if (tasks.length === 0) {
     return (
@@ -175,6 +177,7 @@ export function TaskList({
               selectedId={selectedId}
               onSelect={onSelect}
               onOpenDialog={onOpenDialog}
+              memberNames={memberNames}
             />
           ))}
         </tbody>
@@ -190,6 +193,7 @@ function TaskRow({
   selectedId,
   onSelect,
   onOpenDialog,
+  memberNames,
 }: {
   task: TaskItem;
   index: number;
@@ -197,6 +201,7 @@ function TaskRow({
   selectedId: string | null;
   onSelect: (id: string | null) => void;
   onOpenDialog: (id: string) => void;
+  memberNames: string[];
 }) {
   const isCritical = task.taskPriority === "critical";
   const compositeId = taskCompositeId(task);
@@ -210,7 +215,8 @@ function TaskRow({
   const [localTaskSummary, setLocalTaskSummary] = useState(task.taskSummary ?? "");
   const [savedTaskSummary, setSavedTaskSummary] = useState(task.taskSummary ?? "");
   const [localAssignees, setLocalAssignees] = useState(task.assignees ?? "");
-  const [savedAssignees, setSavedAssignees] = useState(task.assignees ?? "");
+  const [assigneesOpen, setAssigneesOpen] = useState(false);
+  const assigneesRef = useRef<HTMLDivElement>(null);
   const [priorityOpen, setPriorityOpen] = useState(false);
   const priorityRef = useRef<HTMLDivElement>(null);
   const [categoryOpen, setCategoryOpen] = useState(false);
@@ -223,12 +229,11 @@ function TaskRow({
     setLocalTaskSummary(task.taskSummary ?? "");
     setSavedTaskSummary(task.taskSummary ?? "");
     setLocalAssignees(task.assignees ?? "");
-    setSavedAssignees(task.assignees ?? "");
   }, [task.workflowSteps, task.notes, task.taskSummary, task.assignees]);
 
   // Popover外クリックで閉じる
   useEffect(() => {
-    if (!priorityOpen && !categoryOpen) return;
+    if (!priorityOpen && !categoryOpen && !assigneesOpen) return;
     const handler = (e: MouseEvent) => {
       if (priorityOpen && priorityRef.current && !priorityRef.current.contains(e.target as Node)) {
         setPriorityOpen(false);
@@ -236,10 +241,17 @@ function TaskRow({
       if (categoryOpen && categoryRef.current && !categoryRef.current.contains(e.target as Node)) {
         setCategoryOpen(false);
       }
+      if (
+        assigneesOpen &&
+        assigneesRef.current &&
+        !assigneesRef.current.contains(e.target as Node)
+      ) {
+        setAssigneesOpen(false);
+      }
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
-  }, [priorityOpen, categoryOpen]);
+  }, [priorityOpen, categoryOpen, assigneesOpen]);
 
   const saveWorkflow = async (body: { workflowSteps?: WorkflowSteps; notes?: string | null }) => {
     switch (task.source) {
@@ -345,12 +357,12 @@ function TaskRow({
     });
   };
 
-  // --- 担当者変更 ---
-  const handleAssigneesBlur = () => {
-    if (localAssignees === savedAssignees) return;
-    setSavedAssignees(localAssignees);
+  // --- 担当者選択 ---
+  const handleAssigneeSelect = (name: string) => {
+    setLocalAssignees(name);
+    setAssigneesOpen(false);
     startTransition(async () => {
-      const value = localAssignees || null;
+      const value = name || null;
       switch (task.source) {
         case "gchat":
           await updateChatAssigneesFromTaskBoard(task.id, value);
@@ -646,17 +658,59 @@ function TaskRow({
         </div>
       </td>
 
-      {/* 割り振り（インライン編集） */}
-      <td className="px-2 py-1">
-        <input
-          type="text"
-          value={localAssignees}
-          onChange={(e) => setLocalAssignees(e.target.value)}
-          onBlur={handleAssigneesBlur}
-          onClick={(e) => e.stopPropagation()}
-          placeholder="担当者"
-          className="w-full rounded border border-transparent bg-transparent px-1 py-0.5 text-xs text-muted-foreground placeholder:text-muted-foreground/40 focus:border-border focus:bg-card focus:outline-none"
-        />
+      {/* 割り振り（クリックでリスト選択） */}
+      <td className="px-2 py-2.5">
+        <div className="relative" ref={assigneesRef}>
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              setAssigneesOpen(!assigneesOpen);
+            }}
+            disabled={isPending}
+            className="w-full cursor-pointer rounded px-1 py-0.5 text-left text-xs hover:bg-accent/50 transition-colors min-h-[20px]"
+          >
+            {localAssignees ? (
+              <span className="text-foreground">{localAssignees}</span>
+            ) : (
+              <span className="text-muted-foreground/40">—</span>
+            )}
+          </button>
+          {assigneesOpen && (
+            <div className="absolute left-0 top-full z-50 mt-1 w-32 rounded-md border bg-card shadow-lg">
+              <div className="max-h-48 overflow-y-auto py-1">
+                {memberNames.map((name) => (
+                  <button
+                    key={name}
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleAssigneeSelect(name);
+                    }}
+                    className={cn(
+                      "flex w-full items-center px-2 py-1 text-[11px] hover:bg-accent transition-colors",
+                      localAssignees === name && "font-bold",
+                    )}
+                  >
+                    {name}
+                  </button>
+                ))}
+                {localAssignees && (
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      handleAssigneeSelect("");
+                    }}
+                    className="flex w-full items-center px-2 py-1 text-[11px] text-muted-foreground hover:bg-accent transition-colors border-t"
+                  >
+                    クリア
+                  </button>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
       </td>
 
       {/* ステータス（インライン編集） */}


### PR DESCRIPTION
## Summary
- 割り振りフィールドをテキスト入力からクリックでPopoverリスト選択に変更
- AdminUsersからメンバー名リストを取得し候補として表示
- 既存の担当者名がある場合もクリックでリスト表示（太字でハイライト）
- クリア機能付き

## Test plan
- [x] `pnpm typecheck` — 全PASS
- [x] `pnpm lint` — エラーなし
- [x] `pnpm test` — 221テストPASS
- [ ] ローカル起動で割り振りリスト選択の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)