### PR TITLE
fix: ソート関数テスト追加・aria-sort・ORDER二重定義解消

### DIFF
--- a/apps/web/src/__tests__/task-sort.test.ts
+++ b/apps/web/src/__tests__/task-sort.test.ts
@@ -1,0 +1,237 @@
+import { describe, expect, it } from "vitest";
+import type { TaskItem } from "../app/(protected)/task-board/task-list";
+import { compareNullable, sortTasks } from "../app/(protected)/task-board/task-sort";
+
+// --- テスト用ヘルパー ---
+function makeTask(overrides: Partial<TaskItem> = {}): TaskItem {
+  return {
+    id: "1",
+    source: "gchat",
+    senderName: "太郎",
+    content: "テスト",
+    taskPriority: "medium",
+    responseStatus: "unresponded",
+    taskSummary: null,
+    assignees: null,
+    deadline: null,
+    groupName: null,
+    categories: [],
+    workflowSteps: null,
+    notes: null,
+    createdAt: "2026-03-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// --- compareNullable ---
+describe("compareNullable", () => {
+  const numCmp = (a: number, b: number) => a - b;
+
+  it("both null → 0", () => {
+    expect(compareNullable(null, null, numCmp, "asc")).toBe(0);
+  });
+
+  it("a=null → 末尾(1)", () => {
+    expect(compareNullable(null, 5, numCmp, "asc")).toBe(1);
+  });
+
+  it("b=null → 前方(-1)", () => {
+    expect(compareNullable(5, null, numCmp, "asc")).toBe(-1);
+  });
+
+  it("null末尾はソート方向に依存しない", () => {
+    expect(compareNullable(null, 5, numCmp, "desc")).toBe(1);
+    expect(compareNullable(5, null, numCmp, "desc")).toBe(-1);
+  });
+
+  it("asc: a < b → 負", () => {
+    expect(compareNullable(1, 2, numCmp, "asc")).toBeLessThan(0);
+  });
+
+  it("desc: a < b → 正", () => {
+    expect(compareNullable(1, 2, numCmp, "desc")).toBeGreaterThan(0);
+  });
+
+  it("both undefined → 0", () => {
+    expect(compareNullable(undefined, undefined, numCmp, "asc")).toBe(0);
+  });
+});
+
+// --- sortTasks ---
+describe("sortTasks", () => {
+  it("key=null → 元の順序を維持", () => {
+    const tasks = [makeTask({ id: "a" }), makeTask({ id: "b" })];
+    const result = sortTasks(tasks, null, "asc");
+    expect(result).toBe(tasks); // 同一参照
+  });
+
+  it("元配列を変更しない（immutable）", () => {
+    const tasks = [
+      makeTask({ id: "1", createdAt: "2026-03-02T00:00:00Z" }),
+      makeTask({ id: "2", createdAt: "2026-03-01T00:00:00Z" }),
+    ];
+    const original = [...tasks];
+    sortTasks(tasks, "createdAt", "asc");
+    expect(tasks).toEqual(original);
+  });
+
+  describe("createdAt", () => {
+    const tasks = [
+      makeTask({ id: "a", createdAt: "2026-03-03T00:00:00Z" }),
+      makeTask({ id: "b", createdAt: "2026-03-01T00:00:00Z" }),
+      makeTask({ id: "c", createdAt: "2026-03-02T00:00:00Z" }),
+    ];
+
+    it("asc", () => {
+      const result = sortTasks(tasks, "createdAt", "asc");
+      expect(result.map((t) => t.id)).toEqual(["b", "c", "a"]);
+    });
+
+    it("desc", () => {
+      const result = sortTasks(tasks, "createdAt", "desc");
+      expect(result.map((t) => t.id)).toEqual(["a", "c", "b"]);
+    });
+  });
+
+  describe("taskPriority", () => {
+    const tasks = [
+      makeTask({ id: "low", taskPriority: "low" }),
+      makeTask({ id: "critical", taskPriority: "critical" }),
+      makeTask({ id: "high", taskPriority: "high" }),
+      makeTask({ id: "medium", taskPriority: "medium" }),
+    ];
+
+    it("asc: critical → high → medium → low", () => {
+      const result = sortTasks(tasks, "taskPriority", "asc");
+      expect(result.map((t) => t.id)).toEqual(["critical", "high", "medium", "low"]);
+    });
+
+    it("desc: low → medium → high → critical", () => {
+      const result = sortTasks(tasks, "taskPriority", "desc");
+      expect(result.map((t) => t.id)).toEqual(["low", "medium", "high", "critical"]);
+    });
+  });
+
+  describe("taskSummary（null末尾）", () => {
+    const tasks = [
+      makeTask({ id: "null", taskSummary: null }),
+      makeTask({ id: "b", taskSummary: "タスクB" }),
+      makeTask({ id: "a", taskSummary: "タスクA" }),
+    ];
+
+    it("asc: A → B → null", () => {
+      const result = sortTasks(tasks, "taskSummary", "asc");
+      expect(result.map((t) => t.id)).toEqual(["a", "b", "null"]);
+    });
+
+    it("desc: B → A → null", () => {
+      const result = sortTasks(tasks, "taskSummary", "desc");
+      expect(result.map((t) => t.id)).toEqual(["b", "a", "null"]);
+    });
+  });
+
+  describe("source", () => {
+    const tasks = [
+      makeTask({ id: "manual", source: "manual" }),
+      makeTask({ id: "gchat", source: "gchat" }),
+      makeTask({ id: "line", source: "line" }),
+    ];
+
+    it("asc: gchat → line → manual", () => {
+      const result = sortTasks(tasks, "source", "asc");
+      expect(result.map((t) => t.id)).toEqual(["gchat", "line", "manual"]);
+    });
+  });
+
+  describe("categories（空配列末尾）", () => {
+    const tasks = [
+      makeTask({ id: "empty", categories: [] }),
+      makeTask({ id: "salary", categories: ["salary_insurance"] }),
+      makeTask({ id: "attend", categories: ["attendance_leave"] }),
+    ];
+
+    it("asc: 先頭カテゴリでソート、空配列は末尾", () => {
+      const result = sortTasks(tasks, "categories", "asc");
+      expect(result.map((t) => t.id)).toEqual(["attend", "salary", "empty"]);
+    });
+
+    it("desc: 逆順、空配列は末尾", () => {
+      const result = sortTasks(tasks, "categories", "desc");
+      expect(result.map((t) => t.id)).toEqual(["salary", "attend", "empty"]);
+    });
+  });
+
+  describe("assignees（null末尾）", () => {
+    const tasks = [
+      makeTask({ id: "null", assignees: null }),
+      makeTask({ id: "tanaka", assignees: "田中" }),
+      makeTask({ id: "suzuki", assignees: "鈴木" }),
+    ];
+
+    it("asc: 日本語ロケール順でソート、null末尾", () => {
+      const result = sortTasks(tasks, "assignees", "asc");
+      // localeCompare("ja") による順序: 田中 < 鈴木
+      expect(result.map((t) => t.id)).toEqual(["tanaka", "suzuki", "null"]);
+    });
+  });
+
+  describe("responseStatus", () => {
+    const tasks = [
+      makeTask({ id: "responded", responseStatus: "responded" }),
+      makeTask({ id: "unresponded", responseStatus: "unresponded" }),
+      makeTask({ id: "in_progress", responseStatus: "in_progress" }),
+      makeTask({ id: "not_required", responseStatus: "not_required" }),
+    ];
+
+    it("asc: unresponded → in_progress → responded → not_required", () => {
+      const result = sortTasks(tasks, "responseStatus", "asc");
+      expect(result.map((t) => t.id)).toEqual([
+        "unresponded",
+        "in_progress",
+        "responded",
+        "not_required",
+      ]);
+    });
+  });
+
+  describe("deadline（null末尾）", () => {
+    const tasks = [
+      makeTask({ id: "null", deadline: null }),
+      makeTask({ id: "later", deadline: "2026-04-01T00:00:00Z" }),
+      makeTask({ id: "earlier", deadline: "2026-03-01T00:00:00Z" }),
+    ];
+
+    it("asc: earlier → later → null", () => {
+      const result = sortTasks(tasks, "deadline", "asc");
+      expect(result.map((t) => t.id)).toEqual(["earlier", "later", "null"]);
+    });
+
+    it("desc: later → earlier → null", () => {
+      const result = sortTasks(tasks, "deadline", "desc");
+      expect(result.map((t) => t.id)).toEqual(["later", "earlier", "null"]);
+    });
+  });
+
+  describe("全null", () => {
+    it("taskSummary 全null → 順序変わらず", () => {
+      const tasks = [
+        makeTask({ id: "a", taskSummary: null }),
+        makeTask({ id: "b", taskSummary: null }),
+      ];
+      const result = sortTasks(tasks, "taskSummary", "asc");
+      expect(result.map((t) => t.id)).toEqual(["a", "b"]);
+    });
+  });
+
+  describe("同値", () => {
+    it("同じ優先度 → 安定ソート（元の順序維持）", () => {
+      const tasks = [
+        makeTask({ id: "a", taskPriority: "high" }),
+        makeTask({ id: "b", taskPriority: "high" }),
+        makeTask({ id: "c", taskPriority: "high" }),
+      ];
+      const result = sortTasks(tasks, "taskPriority", "asc");
+      expect(result.map((t) => t.id)).toEqual(["a", "b", "c"]);
+    });
+  });
+});

--- a/apps/web/src/app/(protected)/task-board/task-list.tsx
+++ b/apps/web/src/app/(protected)/task-board/task-list.tsx
@@ -49,6 +49,7 @@ import {
   updateWorkflowFromTaskBoard,
 } from "./actions";
 import { taskCompositeId } from "./task-composite-id";
+import { type SortDir, type SortKey, sortTasks } from "./task-sort";
 
 export interface TaskItem {
   id: string;
@@ -90,81 +91,6 @@ const STATUS_OPTIONS: { value: ResponseStatus; label: string }[] = RESPONSE_STAT
   value: s,
   label: RESPONSE_STATUS_LABELS[s],
 }));
-
-// --- ソート ---
-type SortKey =
-  | "createdAt"
-  | "taskPriority"
-  | "taskSummary"
-  | "source"
-  | "categories"
-  | "assignees"
-  | "responseStatus"
-  | "deadline";
-type SortDir = "asc" | "desc";
-
-const PRIORITY_ORDER: Record<string, number> = { critical: 0, high: 1, medium: 2, low: 3 };
-const STATUS_ORDER: Record<string, number> = {
-  unresponded: 0,
-  in_progress: 1,
-  responded: 2,
-  pending_confirmation: 3,
-  closed: 4,
-};
-
-function compareNullable<T>(
-  a: T | null | undefined,
-  b: T | null | undefined,
-  cmp: (a: T, b: T) => number,
-  dir: SortDir,
-): number {
-  if (a == null && b == null) return 0;
-  if (a == null) return 1; // null は常に末尾
-  if (b == null) return -1;
-  return dir === "asc" ? cmp(a, b) : cmp(b, a);
-}
-
-function sortTasks(tasks: TaskItem[], key: SortKey | null, dir: SortDir): TaskItem[] {
-  if (!key) return tasks;
-  const sorted = [...tasks];
-  sorted.sort((a, b) => {
-    switch (key) {
-      case "createdAt":
-        return dir === "asc"
-          ? a.createdAt.localeCompare(b.createdAt)
-          : b.createdAt.localeCompare(a.createdAt);
-      case "taskPriority":
-        return dir === "asc"
-          ? (PRIORITY_ORDER[a.taskPriority] ?? 99) - (PRIORITY_ORDER[b.taskPriority] ?? 99)
-          : (PRIORITY_ORDER[b.taskPriority] ?? 99) - (PRIORITY_ORDER[a.taskPriority] ?? 99);
-      case "taskSummary":
-        return compareNullable(
-          a.taskSummary,
-          b.taskSummary,
-          (x, y) => x.localeCompare(y, "ja"),
-          dir,
-        );
-      case "source":
-        return dir === "asc" ? a.source.localeCompare(b.source) : b.source.localeCompare(a.source);
-      case "categories": {
-        const ca = a.categories[0] ?? null;
-        const cb = b.categories[0] ?? null;
-        return compareNullable(ca, cb, (x, y) => x.localeCompare(y, "ja"), dir);
-      }
-      case "assignees":
-        return compareNullable(a.assignees, b.assignees, (x, y) => x.localeCompare(y, "ja"), dir);
-      case "responseStatus":
-        return dir === "asc"
-          ? (STATUS_ORDER[a.responseStatus] ?? 99) - (STATUS_ORDER[b.responseStatus] ?? 99)
-          : (STATUS_ORDER[b.responseStatus] ?? 99) - (STATUS_ORDER[a.responseStatus] ?? 99);
-      case "deadline":
-        return compareNullable(a.deadline, b.deadline, (x, y) => x.localeCompare(y), dir);
-      default:
-        return 0;
-    }
-  });
-  return sorted;
-}
 
 export function TaskList({
   tasks,
@@ -208,6 +134,11 @@ export function TaskList({
     return <span className="ml-0.5 text-[9px]">{sortDir === "asc" ? "▲" : "▼"}</span>;
   };
 
+  const ariaSort = (key: SortKey): "ascending" | "descending" | "none" => {
+    if (sortKey !== key) return "none";
+    return sortDir === "asc" ? "ascending" : "descending";
+  };
+
   if (tasks.length === 0) {
     return (
       <div className="flex h-full items-center justify-center">
@@ -228,12 +159,14 @@ export function TaskList({
             <th
               className="w-20 px-2 py-2.5 text-left font-semibold text-muted-foreground cursor-pointer select-none hover:bg-slate-100 transition-colors"
               onClick={() => handleSort("createdAt")}
+              aria-sort={ariaSort("createdAt")}
             >
               発生日{sortIndicator("createdAt")}
             </th>
             <th
               className="w-14 px-2 py-2.5 text-center font-semibold text-muted-foreground cursor-pointer select-none hover:bg-slate-100 transition-colors"
               onClick={() => handleSort("taskPriority")}
+              aria-sort={ariaSort("taskPriority")}
             >
               優先度{sortIndicator("taskPriority")}
             </th>
@@ -246,36 +179,42 @@ export function TaskList({
             <th
               className="min-w-[140px] px-2 py-2.5 text-left font-semibold text-muted-foreground cursor-pointer select-none hover:bg-slate-100 transition-colors"
               onClick={() => handleSort("taskSummary")}
+              aria-sort={ariaSort("taskSummary")}
             >
               タスク{sortIndicator("taskSummary")}
             </th>
             <th
               className="w-16 px-2 py-2.5 text-center font-semibold text-muted-foreground cursor-pointer select-none hover:bg-slate-100 transition-colors"
               onClick={() => handleSort("source")}
+              aria-sort={ariaSort("source")}
             >
               ソース{sortIndicator("source")}
             </th>
             <th
               className="w-28 px-2 py-2.5 text-center font-semibold text-muted-foreground cursor-pointer select-none hover:bg-slate-100 transition-colors"
               onClick={() => handleSort("categories")}
+              aria-sort={ariaSort("categories")}
             >
               カテゴリ{sortIndicator("categories")}
             </th>
             <th
               className="w-24 px-2 py-2.5 text-left font-semibold text-muted-foreground cursor-pointer select-none hover:bg-slate-100 transition-colors"
               onClick={() => handleSort("assignees")}
+              aria-sort={ariaSort("assignees")}
             >
               割り振り{sortIndicator("assignees")}
             </th>
             <th
               className="w-20 px-2 py-2.5 text-center font-semibold text-muted-foreground cursor-pointer select-none hover:bg-slate-100 transition-colors"
               onClick={() => handleSort("responseStatus")}
+              aria-sort={ariaSort("responseStatus")}
             >
               ステータス{sortIndicator("responseStatus")}
             </th>
             <th
               className="w-24 px-2 py-2.5 text-left font-semibold text-muted-foreground cursor-pointer select-none hover:bg-slate-100 transition-colors"
               onClick={() => handleSort("deadline")}
+              aria-sort={ariaSort("deadline")}
             >
               期限{sortIndicator("deadline")}
             </th>

--- a/apps/web/src/app/(protected)/task-board/task-sort.ts
+++ b/apps/web/src/app/(protected)/task-board/task-sort.ts
@@ -1,0 +1,74 @@
+import { RESPONSE_STATUSES, TASK_PRIORITIES } from "@hr-system/shared";
+import type { TaskItem } from "./task-list";
+
+export type SortKey =
+  | "createdAt"
+  | "taskPriority"
+  | "taskSummary"
+  | "source"
+  | "categories"
+  | "assignees"
+  | "responseStatus"
+  | "deadline";
+export type SortDir = "asc" | "desc";
+
+const PRIORITY_ORDER: Record<string, number> = Object.fromEntries(
+  TASK_PRIORITIES.map((v, i) => [v, i]),
+);
+const STATUS_ORDER: Record<string, number> = Object.fromEntries(
+  RESPONSE_STATUSES.map((v, i) => [v, i]),
+);
+
+export function compareNullable<T>(
+  a: T | null | undefined,
+  b: T | null | undefined,
+  cmp: (a: T, b: T) => number,
+  dir: SortDir,
+): number {
+  if (a == null && b == null) return 0;
+  if (a == null) return 1; // null は常に末尾
+  if (b == null) return -1;
+  return dir === "asc" ? cmp(a, b) : cmp(b, a);
+}
+
+export function sortTasks(tasks: TaskItem[], key: SortKey | null, dir: SortDir): TaskItem[] {
+  if (!key) return tasks;
+  const sorted = [...tasks];
+  sorted.sort((a, b) => {
+    switch (key) {
+      case "createdAt":
+        return dir === "asc"
+          ? a.createdAt.localeCompare(b.createdAt)
+          : b.createdAt.localeCompare(a.createdAt);
+      case "taskPriority":
+        return dir === "asc"
+          ? (PRIORITY_ORDER[a.taskPriority] ?? 99) - (PRIORITY_ORDER[b.taskPriority] ?? 99)
+          : (PRIORITY_ORDER[b.taskPriority] ?? 99) - (PRIORITY_ORDER[a.taskPriority] ?? 99);
+      case "taskSummary":
+        return compareNullable(
+          a.taskSummary,
+          b.taskSummary,
+          (x, y) => x.localeCompare(y, "ja"),
+          dir,
+        );
+      case "source":
+        return dir === "asc" ? a.source.localeCompare(b.source) : b.source.localeCompare(a.source);
+      case "categories": {
+        const ca = a.categories[0] ?? null;
+        const cb = b.categories[0] ?? null;
+        return compareNullable(ca, cb, (x, y) => x.localeCompare(y, "ja"), dir);
+      }
+      case "assignees":
+        return compareNullable(a.assignees, b.assignees, (x, y) => x.localeCompare(y, "ja"), dir);
+      case "responseStatus":
+        return dir === "asc"
+          ? (STATUS_ORDER[a.responseStatus] ?? 99) - (STATUS_ORDER[b.responseStatus] ?? 99)
+          : (STATUS_ORDER[b.responseStatus] ?? 99) - (STATUS_ORDER[a.responseStatus] ?? 99);
+      case "deadline":
+        return compareNullable(a.deadline, b.deadline, (x, y) => x.localeCompare(y), dir);
+      default:
+        return 0;
+    }
+  });
+  return sorted;
+}


### PR DESCRIPTION
## Summary
- `sortTasks` / `compareNullable` を `task-sort.ts` に分離し、24テスト追加（全8カラム + 境界値: 全null、同値、空配列）
- ソート可能ヘッダーに `aria-sort` 属性を追加（スクリーンリーダー対応）
- `PRIORITY_ORDER` / `STATUS_ORDER` を `TASK_PRIORITIES` / `RESPONSE_STATUSES` から自動生成に変更し、shared パッケージとの同期漏れリスクを解消
  - 旧: `STATUS_ORDER` に存在しない `pending_confirmation`, `closed` が含まれ、実在する `not_required` が欠落していた

## Test plan
- [x] `pnpm typecheck` 全PASS（11/11）
- [x] `pnpm lint` 変更ファイル全クリーン
- [x] `pnpm test` 全245テストPASS（+24件追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)