### PR TITLE
chore: GitHub Actions を Node.js 24 対応バージョンに更新

### DIFF
--- a/.github/workflows/backfill-line-category.yml
+++ b/.github/workflows/backfill-line-category.yml
@@ -21,11 +21,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "pnpm"
@@ -37,7 +37,7 @@ jobs:
         run: pnpm build
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "pnpm"

--- a/.github/workflows/deploy-service.yml
+++ b/.github/workflows/deploy-service.yml
@@ -36,16 +36,16 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
 
       - name: Configure Docker
         run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,7 +31,7 @@ jobs:
       worker: ${{ steps.filter.outputs.worker }}
       firestore-indexes: ${{ steps.filter.outputs.firestore-indexes }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -111,10 +111,10 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           workload_identity_provider: ${{ secrets.WIF_PROVIDER }}
           service_account: ${{ secrets.WIF_SERVICE_ACCOUNT }}


### PR DESCRIPTION
## Summary
- Node.js 20 非推奨（期限: 2026-06-02）に対応し、全ワークフローのアクションを更新
- `actions/checkout`: v4 → v6
- `actions/setup-node`: v4 → v6
- `google-github-actions/auth`: v2 → v3
- `google-github-actions/setup-gcloud`: v2 → v3

## Test plan
- [ ] CI ワークフロー（ci.yml）が正常に動作すること ← **このPRのCIで検証**
- [ ] デプロイワークフロー（deploy.yml）がマージ後に正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)