### PR TITLE
fix: LINE Bot招待ヘルプのBot名をACG人事Botに修正

### DIFF
--- a/apps/web/src/app/(protected)/admin/spaces/line-group-help.tsx
+++ b/apps/web/src/app/(protected)/admin/spaces/line-group-help.tsx
@@ -30,7 +30,7 @@ export function LineGroupHelp() {
             <ol className="list-none space-y-1.5 text-blue-800">
               <li>① LINE アプリでグループのトーク画面を開く</li>
               <li>② 右上の ≡ メニュー →「招待」をタップ</li>
-              <li>③「HR AI Agent」を検索して招待</li>
+              <li>③「ACG人事Bot」を検索して招待</li>
             </ol>
             <Image
               src="/screenshots/help/line-bot-invite-guide.png"


### PR DESCRIPTION
## Summary
- ヘルプのステップ③「HR AI Agent」→「ACG人事Bot」に修正（LINE Developers設定に合わせる）

## Test plan
- [x] `pnpm typecheck` — 全PASS
- [x] `pnpm lint` — エラーなし
- [x] `pnpm test` — 全PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)