### PR TITLE
chore: ルートのスクリーンショット画像を整理

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ dist/
 .DS_Store
 Thumbs.db
 
+# Screenshots (PR確認用の一時ファイル)
+/*.png
+
 # GCP
 service-account-key*.json
 *.key.json


### PR DESCRIPTION
## Summary
- PR確認用の一時スクリーンショット8枚をルートから削除
- `.gitignore` にルートの `/*.png` パターンを追加し、今後の未追跡表示を防止

## Test plan
- [ ] `git status` で未追跡の `.png` ファイルが表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)