### PR TITLE
docs: ADR-006/007 のDB選定参照テキストを修正

### DIFF
--- a/docs/adr/ADR-006-human-in-the-loop.md
+++ b/docs/adr/ADR-006-human-in-the-loop.md
@@ -196,6 +196,6 @@ CREATE TABLE approval_history (
 
 - [ADR-001: 全体アーキテクチャ — GCPベース構成](./ADR-001-gcp-architecture.md)
 - [ADR-002: LLM選定 — Vertex AI (Gemini)](./ADR-002-llm-selection.md)
-- [ADR-003: データベース選定 — Cloud SQL (PostgreSQL)](./ADR-003-database-selection.md)
+- [ADR-003: データベース選定 — Firestore + BigQuery ハイブリッド](./ADR-003-database-selection.md)
 - [ADR-005: フロントエンド技術 — Next.js (React)](./ADR-005-frontend-technology.md)
 - [ADR-007: AI役割分離 — LLMはパラメータ抽出、計算は確定コード](./ADR-007-ai-role-separation.md)

--- a/docs/adr/ADR-007-ai-role-separation.md
+++ b/docs/adr/ADR-007-ai-role-separation.md
@@ -238,5 +238,5 @@ graph TD
 
 - [ADR-001: 全体アーキテクチャ — GCPベース構成](./ADR-001-gcp-architecture.md)
 - [ADR-002: LLM選定 — Vertex AI (Gemini)](./ADR-002-llm-selection.md)
-- [ADR-003: データベース選定 — Cloud SQL (PostgreSQL)](./ADR-003-database-selection.md)
+- [ADR-003: データベース選定 — Firestore + BigQuery ハイブリッド](./ADR-003-database-selection.md)
 - [ADR-006: Human-in-the-loop 設計パターン](./ADR-006-human-in-the-loop.md)


### PR DESCRIPTION
## Summary
- ADR-006, ADR-007 の関連ADRセクションで、ADR-003 のリンクテキストが旧決定「Cloud SQL (PostgreSQL)」のままだったため、実態の「Firestore + BigQuery ハイブリッド」に修正

## Test plan
- [ ] ドキュメント変更のみ — コード変更なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)