### PR TITLE
feat: SmartHR MCPサーバー構築（Phase 1）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,3 +18,8 @@ NODE_ENV=development
 # 開発用トークンバイパス（dev:{email} 形式）を許可するフラグ
 # 本番環境では絶対に true にしないこと
 ALLOW_DEV_TOKEN=true
+
+# SmartHR API（MCP サーバー用）
+# https://developer.smarthr.jp/api/about_api
+SMARTHR_API_KEY=""
+SMARTHR_TENANT_ID=""

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "smarthr": {
+      "command": "npx",
+      "args": ["tsx", "packages/mcp-smarthr/src/index.ts"],
+      "env": {
+        "SMARTHR_API_KEY": "${SMARTHR_API_KEY}",
+        "SMARTHR_TENANT_ID": "${SMARTHR_TENANT_ID}"
+      }
+    }
+  }
+}

--- a/packages/mcp-smarthr/package.json
+++ b/packages/mcp-smarthr/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@hr-system/mcp-smarthr",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "mcp-smarthr": "./dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "biome check src/",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.25.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/mcp-smarthr/src/__tests__/smarthr-client.test.ts
+++ b/packages/mcp-smarthr/src/__tests__/smarthr-client.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SmartHRApiError, SmartHRClient } from "../smarthr-client.js";
+
+const TEST_CONFIG = {
+  accessToken: "test-token",
+  tenantId: "test-tenant",
+  cacheTtlMs: 1000,
+};
+
+function mockFetchResponse(data: unknown, headers?: Record<string, string>) {
+  return vi.fn().mockResolvedValue({
+    ok: true,
+    json: () => Promise.resolve(data),
+    headers: new Headers(headers ?? {}),
+  });
+}
+
+function mockFetchError(status: number, statusText: string, body: string) {
+  return vi.fn().mockResolvedValue({
+    ok: false,
+    status,
+    statusText,
+    text: () => Promise.resolve(body),
+  });
+}
+
+describe("SmartHRClient", () => {
+  let client: SmartHRClient;
+
+  beforeEach(() => {
+    client = new SmartHRClient(TEST_CONFIG);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("listEmployees", () => {
+    it("従業員一覧を取得できる", async () => {
+      const crews = [
+        { id: "1", last_name: "田中", first_name: "太郎" },
+        { id: "2", last_name: "鈴木", first_name: "花子" },
+      ];
+      vi.stubGlobal("fetch", mockFetchResponse(crews, { "x-total-count": "2" }));
+
+      const result = await client.listEmployees();
+
+      expect(result.data).toHaveLength(2);
+      expect(result.totalCount).toBe(2);
+      expect(result.data[0]?.last_name).toBe("田中");
+    });
+
+    it("ページネーションパラメータを送信する", async () => {
+      const fetchMock = mockFetchResponse([], { "x-total-count": "0" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.listEmployees({ page: 2, per_page: 10 });
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("page=2");
+      expect(calledUrl).toContain("per_page=10");
+    });
+  });
+
+  describe("getEmployee", () => {
+    it("従業員詳細を取得できる", async () => {
+      const crew = { id: "abc", last_name: "田中", first_name: "太郎" };
+      vi.stubGlobal("fetch", mockFetchResponse(crew));
+
+      const result = await client.getEmployee("abc");
+
+      expect(result.last_name).toBe("田中");
+    });
+  });
+
+  describe("searchEmployees", () => {
+    it("検索クエリをURLパラメータとして送信する", async () => {
+      const fetchMock = mockFetchResponse([], { "x-total-count": "0" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.searchEmployees("田中");
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("q=%E7%94%B0%E4%B8%AD");
+    });
+  });
+
+  describe("getPayStatements", () => {
+    it("年月で絞り込みできる", async () => {
+      const fetchMock = mockFetchResponse([], { "x-total-count": "0" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.getPayStatements({ year: 2026, month: 3 });
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("year=2026");
+      expect(calledUrl).toContain("month=3");
+    });
+  });
+
+  describe("listDepartments", () => {
+    it("部署一覧を取得できる", async () => {
+      const departments = [{ id: "d1", name: "人事部" }];
+      vi.stubGlobal("fetch", mockFetchResponse(departments, { "x-total-count": "1" }));
+
+      const result = await client.listDepartments();
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]?.name).toBe("人事部");
+    });
+  });
+
+  describe("listPositions", () => {
+    it("役職一覧を取得できる", async () => {
+      const positions = [{ id: "p1", name: "部長" }];
+      vi.stubGlobal("fetch", mockFetchResponse(positions, { "x-total-count": "1" }));
+
+      const result = await client.listPositions();
+
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]?.name).toBe("部長");
+    });
+  });
+
+  describe("認証", () => {
+    it("Bearerトークンをヘッダーに含める", async () => {
+      const fetchMock = mockFetchResponse([]);
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.listEmployees();
+
+      const calledOptions = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      expect(calledOptions.headers).toEqual(
+        expect.objectContaining({
+          Authorization: "Bearer test-token",
+        }),
+      );
+    });
+  });
+
+  describe("エラーハンドリング", () => {
+    it("APIエラー時にSmartHRApiErrorをスローする", async () => {
+      vi.stubGlobal("fetch", mockFetchError(401, "Unauthorized", '{"error":"invalid_token"}'));
+
+      await expect(client.listEmployees()).rejects.toThrow(SmartHRApiError);
+      await expect(client.listEmployees()).rejects.toMatchObject({
+        statusCode: 401,
+      });
+    });
+  });
+
+  describe("キャッシュ", () => {
+    it("同じリクエストはキャッシュから返す", async () => {
+      const fetchMock = mockFetchResponse([{ id: "1" }], { "x-total-count": "1" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.listEmployees();
+      await client.listEmployees();
+
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("TTL経過後はキャッシュが無効化される", async () => {
+      vi.useFakeTimers();
+      const fetchMock = mockFetchResponse([{ id: "1" }], { "x-total-count": "1" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.listEmployees();
+
+      // TTL超過をシミュレート
+      vi.advanceTimersByTime(1100);
+
+      await client.listEmployees();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      vi.useRealTimers();
+    });
+
+    it("clearCacheでキャッシュをクリアできる", async () => {
+      const fetchMock = mockFetchResponse([{ id: "1" }], { "x-total-count": "1" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.listEmployees();
+      client.clearCache();
+      await client.listEmployees();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("ベースURL", () => {
+    it("tenantIdからベースURLを構築する", async () => {
+      const fetchMock = mockFetchResponse([]);
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.listEmployees();
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("test-tenant.smarthr.jp");
+    });
+
+    it("カスタムbaseUrlを使用できる", async () => {
+      const customClient = new SmartHRClient({
+        ...TEST_CONFIG,
+        baseUrl: "https://custom.example.com/api/v1",
+      });
+      const fetchMock = mockFetchResponse([]);
+      vi.stubGlobal("fetch", fetchMock);
+
+      await customClient.listEmployees();
+
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("https://custom.example.com/api/v1");
+    });
+  });
+});

--- a/packages/mcp-smarthr/src/index.ts
+++ b/packages/mcp-smarthr/src/index.ts
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { SmartHRClient } from "./smarthr-client.js";
+import { defineTools } from "./tools.js";
+
+const SMARTHR_API_KEY = process.env.SMARTHR_API_KEY;
+const SMARTHR_TENANT_ID = process.env.SMARTHR_TENANT_ID;
+
+if (!SMARTHR_API_KEY || !SMARTHR_TENANT_ID) {
+  console.error("Error: SMARTHR_API_KEY and SMARTHR_TENANT_ID environment variables are required.");
+  process.exit(1);
+}
+
+const client = new SmartHRClient({
+  accessToken: SMARTHR_API_KEY,
+  tenantId: SMARTHR_TENANT_ID,
+});
+
+const tools = defineTools(client);
+
+const server = new McpServer({
+  name: "smarthr",
+  version: "0.1.0",
+});
+
+// ツール登録
+for (const [name, tool] of Object.entries(tools)) {
+  server.tool(name, tool.description, tool.shape, async (params: Record<string, unknown>) => {
+    try {
+      const result = await tool.handler(params as never);
+      return { content: [{ type: "text" as const, text: result }] };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return {
+        content: [{ type: "text" as const, text: `Error: ${message}` }],
+        isError: true,
+      };
+    }
+  });
+}
+
+// サーバー起動
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/packages/mcp-smarthr/src/smarthr-client.ts
+++ b/packages/mcp-smarthr/src/smarthr-client.ts
@@ -1,0 +1,188 @@
+import type {
+  SmartHRConfig,
+  SmartHRCrew,
+  SmartHRDepartment,
+  SmartHRPayStatement,
+  SmartHRPosition,
+} from "./types.js";
+
+const DEFAULT_BASE_URL = "https://{tenantId}.smarthr.jp/api/v1";
+const DEFAULT_CACHE_TTL_MS = 5 * 60 * 1000; // 5分
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+/**
+ * SmartHR REST API クライアント（読み取り専用）
+ *
+ * - Bearer トークン認証
+ * - TTL ベースのインメモリキャッシュ（レート制限対策）
+ * - レート制限: 5,000 req/hour, 10 req/sec per token
+ */
+export class SmartHRClient {
+  private readonly baseUrl: string;
+  private readonly accessToken: string;
+  private readonly cacheTtlMs: number;
+  private readonly cache = new Map<string, CacheEntry<unknown>>();
+
+  constructor(config: SmartHRConfig) {
+    this.accessToken = config.accessToken;
+    this.cacheTtlMs = config.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS;
+    this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL.replace("{tenantId}", config.tenantId);
+  }
+
+  /** 従業員一覧取得 */
+  async listEmployees(params?: {
+    page?: number;
+    per_page?: number;
+  }): Promise<{ data: SmartHRCrew[]; totalCount: number }> {
+    const query = new URLSearchParams();
+    if (params?.page) query.set("page", String(params.page));
+    if (params?.per_page) query.set("per_page", String(params.per_page));
+
+    const url = `/crews${query.toString() ? `?${query}` : ""}`;
+    return this.fetchList<SmartHRCrew>(url);
+  }
+
+  /** 従業員詳細取得 */
+  async getEmployee(id: string): Promise<SmartHRCrew> {
+    return this.fetchOne<SmartHRCrew>(`/crews/${id}`);
+  }
+
+  /** 従業員検索 */
+  async searchEmployees(
+    query: string,
+    params?: { page?: number; per_page?: number },
+  ): Promise<{ data: SmartHRCrew[]; totalCount: number }> {
+    const searchParams = new URLSearchParams({ q: query });
+    if (params?.page) searchParams.set("page", String(params.page));
+    if (params?.per_page) searchParams.set("per_page", String(params.per_page));
+
+    return this.fetchList<SmartHRCrew>(`/crews?${searchParams}`);
+  }
+
+  /** 給与明細取得 */
+  async getPayStatements(params?: {
+    crew_id?: string;
+    year?: number;
+    month?: number;
+    page?: number;
+    per_page?: number;
+  }): Promise<{ data: SmartHRPayStatement[]; totalCount: number }> {
+    const query = new URLSearchParams();
+    if (params?.crew_id) query.set("crew_id", params.crew_id);
+    if (params?.year) query.set("year", String(params.year));
+    if (params?.month) query.set("month", String(params.month));
+    if (params?.page) query.set("page", String(params.page));
+    if (params?.per_page) query.set("per_page", String(params.per_page));
+
+    const url = `/pay_statements${query.toString() ? `?${query}` : ""}`;
+    return this.fetchList<SmartHRPayStatement>(url);
+  }
+
+  /** 部署一覧取得 */
+  async listDepartments(params?: {
+    page?: number;
+    per_page?: number;
+  }): Promise<{ data: SmartHRDepartment[]; totalCount: number }> {
+    const query = new URLSearchParams();
+    if (params?.page) query.set("page", String(params.page));
+    if (params?.per_page) query.set("per_page", String(params.per_page));
+
+    const url = `/departments${query.toString() ? `?${query}` : ""}`;
+    return this.fetchList<SmartHRDepartment>(url);
+  }
+
+  /** 役職一覧取得 */
+  async listPositions(params?: {
+    page?: number;
+    per_page?: number;
+  }): Promise<{ data: SmartHRPosition[]; totalCount: number }> {
+    const query = new URLSearchParams();
+    if (params?.page) query.set("page", String(params.page));
+    if (params?.per_page) query.set("per_page", String(params.per_page));
+
+    const url = `/positions${query.toString() ? `?${query}` : ""}`;
+    return this.fetchList<SmartHRPosition>(url);
+  }
+
+  /** キャッシュクリア */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  // --- private ---
+
+  private async fetchOne<T>(path: string): Promise<T> {
+    const cached = this.getFromCache<T>(path);
+    if (cached !== undefined) return cached;
+
+    const response = await this.request(path);
+    const data = (await response.json()) as T;
+    this.setCache(path, data);
+    return data;
+  }
+
+  private async fetchList<T>(path: string): Promise<{ data: T[]; totalCount: number }> {
+    const cached = this.getFromCache<{ data: T[]; totalCount: number }>(path);
+    if (cached !== undefined) return cached;
+
+    const response = await this.request(path);
+    const data = (await response.json()) as T[];
+    const totalCount = Number(response.headers.get("x-total-count") ?? data.length);
+    const result = { data, totalCount };
+    this.setCache(path, result);
+    return result;
+  }
+
+  private async request(path: string): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${this.accessToken}`,
+        Accept: "application/json",
+      },
+    });
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      throw new SmartHRApiError(
+        `SmartHR API error: ${response.status} ${response.statusText}`,
+        response.status,
+        body,
+      );
+    }
+
+    return response;
+  }
+
+  private getFromCache<T>(key: string): T | undefined {
+    const entry = this.cache.get(key) as CacheEntry<T> | undefined;
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+    return entry.data;
+  }
+
+  private setCache<T>(key: string, data: T): void {
+    this.cache.set(key, {
+      data,
+      expiresAt: Date.now() + this.cacheTtlMs,
+    });
+  }
+}
+
+export class SmartHRApiError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+    public readonly responseBody: string,
+  ) {
+    super(message);
+    this.name = "SmartHRApiError";
+  }
+}

--- a/packages/mcp-smarthr/src/tools.ts
+++ b/packages/mcp-smarthr/src/tools.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+import type { SmartHRClient } from "./smarthr-client.js";
+
+/** ページネーション共通パラメータ shape */
+const paginationShape = {
+  page: z.number().int().min(1).optional().describe("ページ番号（1始まり）"),
+  per_page: z.number().int().min(1).max(100).optional().describe("1ページあたりの件数（最大100）"),
+};
+
+/** ツール定義一覧 */
+export function defineTools(client: SmartHRClient) {
+  return {
+    list_employees: {
+      description: "SmartHRの従業員一覧を取得します。ページネーション対応。",
+      shape: paginationShape,
+      handler: async (params: { page?: number; per_page?: number }) => {
+        const result = await client.listEmployees(params);
+        return formatListResult("従業員", result.data.length, result.totalCount, result.data);
+      },
+    },
+
+    get_employee: {
+      description: "SmartHRの従業員詳細を従業員IDで取得します。",
+      shape: {
+        id: z.string().describe("SmartHR従業員ID"),
+      },
+      handler: async (params: { id: string }) => {
+        const crew = await client.getEmployee(params.id);
+        return formatResult(crew);
+      },
+    },
+
+    search_employees: {
+      description: "SmartHRの従業員を名前・社員番号等で検索します。",
+      shape: {
+        query: z.string().describe("検索キーワード（名前、社員番号等）"),
+        ...paginationShape,
+      },
+      handler: async (params: { query: string; page?: number; per_page?: number }) => {
+        const result = await client.searchEmployees(params.query, {
+          page: params.page,
+          per_page: params.per_page,
+        });
+        return formatListResult("従業員", result.data.length, result.totalCount, result.data);
+      },
+    },
+
+    get_pay_statements: {
+      description: "SmartHRの給与明細を取得します。従業員ID・年・月で絞り込み可能。",
+      shape: {
+        crew_id: z.string().optional().describe("従業員ID（絞り込み）"),
+        year: z.number().int().optional().describe("年（例: 2026）"),
+        month: z.number().int().min(1).max(12).optional().describe("月（1-12）"),
+        ...paginationShape,
+      },
+      handler: async (params: {
+        crew_id?: string;
+        year?: number;
+        month?: number;
+        page?: number;
+        per_page?: number;
+      }) => {
+        const result = await client.getPayStatements(params);
+        return formatListResult("給与明細", result.data.length, result.totalCount, result.data);
+      },
+    },
+
+    list_departments: {
+      description: "SmartHRの部署一覧を取得します。",
+      shape: paginationShape,
+      handler: async (params: { page?: number; per_page?: number }) => {
+        const result = await client.listDepartments(params);
+        return formatListResult("部署", result.data.length, result.totalCount, result.data);
+      },
+    },
+
+    list_positions: {
+      description: "SmartHRの役職一覧を取得します。",
+      shape: paginationShape,
+      handler: async (params: { page?: number; per_page?: number }) => {
+        const result = await client.listPositions(params);
+        return formatListResult("役職", result.data.length, result.totalCount, result.data);
+      },
+    },
+  } as const;
+}
+
+function formatResult(data: unknown): string {
+  return JSON.stringify(data, null, 2);
+}
+
+function formatListResult(
+  label: string,
+  count: number,
+  totalCount: number,
+  data: unknown[],
+): string {
+  return JSON.stringify(
+    {
+      summary: `${label}: ${count}件 / 全${totalCount}件`,
+      data,
+    },
+    null,
+    2,
+  );
+}

--- a/packages/mcp-smarthr/src/types.ts
+++ b/packages/mcp-smarthr/src/types.ts
@@ -1,0 +1,101 @@
+/**
+ * SmartHR API レスポンス型定義
+ * @see https://developer.smarthr.jp/api
+ */
+
+/** 従業員（crew） */
+export interface SmartHRCrew {
+  id: string;
+  emp_code: string | null;
+  last_name: string;
+  first_name: string;
+  last_name_yomi: string | null;
+  first_name_yomi: string | null;
+  email: string | null;
+  gender: string | null;
+  birth_at: string | null;
+  entered_at: string | null;
+  resigned_at: string | null;
+  department: SmartHRDepartmentRef | null;
+  position: string | null;
+  employment_type: SmartHREmploymentType | null;
+  custom_fields: SmartHRCustomField[];
+  created_at: string;
+  updated_at: string;
+}
+
+/** 部署参照（crew内の埋め込み） */
+export interface SmartHRDepartmentRef {
+  id: string;
+  name: string;
+  code: string | null;
+}
+
+/** 部署 */
+export interface SmartHRDepartment {
+  id: string;
+  name: string;
+  code: string | null;
+  parent: SmartHRDepartmentRef | null;
+  position: number;
+  created_at: string;
+  updated_at: string;
+}
+
+/** 役職 */
+export interface SmartHRPosition {
+  id: string;
+  name: string;
+  code: string | null;
+  rank: number | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** 雇用形態 */
+export interface SmartHREmploymentType {
+  id: string;
+  name: string;
+  preset_type: string | null;
+}
+
+/** カスタムフィールド */
+export interface SmartHRCustomField {
+  template: { id: string; name: string };
+  value: string | null;
+}
+
+/** 給与明細 */
+export interface SmartHRPayStatement {
+  id: string;
+  crew_id: string;
+  year: number;
+  month: number;
+  pay_type: string;
+  items: SmartHRPayStatementItem[];
+  created_at: string;
+  updated_at: string;
+}
+
+/** 給与明細項目 */
+export interface SmartHRPayStatementItem {
+  name: string;
+  amount: number;
+  category: string;
+}
+
+/** ページネーション付きリストレスポンス */
+export interface SmartHRListResponse<T> {
+  data: T[];
+  total_count: number;
+  page: number;
+  per_page: number;
+}
+
+/** SmartHR APIクライアント設定 */
+export interface SmartHRConfig {
+  accessToken: string;
+  tenantId: string;
+  baseUrl?: string;
+  cacheTtlMs?: number;
+}

--- a/packages/mcp-smarthr/tsconfig.build.json
+++ b/packages/mcp-smarthr/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  }
+}

--- a/packages/mcp-smarthr/tsconfig.json
+++ b/packages/mcp-smarthr/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -236,6 +236,25 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/node@22.19.11)(happy-dom@20.8.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
 
+  packages/mcp-smarthr:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.12.0
+        version: 1.26.0(zod@3.25.76)
+      zod:
+        specifier: ^3.25.0
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.19.11
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/node@22.19.11)(happy-dom@20.8.3)(jiti@2.6.1)(lightningcss@1.30.2)(msw@2.12.10(@types/node@22.19.11)(typescript@5.9.3))(tsx@4.21.0)
+
   packages/salary:
     dependencies:
       '@hr-system/shared':


### PR DESCRIPTION
## Summary

- SmartHR REST APIをMCPサーバーとしてラップ（`packages/mcp-smarthr/`）
- Claude Codeから従業員・部署・役職・給与明細データを直接参照可能に
- 全ツール読み取り専用。本番パイプラインへの影響なし
- ADR-008 Phase 1 の実装

## 提供ツール（6つ）

| ツール | 説明 |
|-------|------|
| `list_employees` | 従業員一覧 |
| `get_employee` | 従業員詳細 |
| `search_employees` | 従業員検索 |
| `get_pay_statements` | 給与明細 |
| `list_departments` | 部署一覧 |
| `list_positions` | 役職一覧 |

## Test plan

- [x] テスト14件全PASS（`pnpm --filter @hr-system/mcp-smarthr test`）
- [x] 型チェックPASS（`pnpm --filter @hr-system/mcp-smarthr typecheck`）
- [x] lintPASS（`pnpm --filter @hr-system/mcp-smarthr lint`）
- [ ] SmartHR APIキー設定後、`/mcp` で接続確認

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)