### PR TITLE
fix: SmartHR MCP レビュー指摘修正（セキュリティ・品質強化）

### DIFF
--- a/packages/mcp-smarthr/src/__tests__/audit-logger.test.ts
+++ b/packages/mcp-smarthr/src/__tests__/audit-logger.test.ts
@@ -3,50 +3,7 @@ import {
   type AuditLogEntry,
   AuditLogger,
   type AuditLogStore,
-  maskPII,
 } from "../core/middleware/audit-logger.js";
-
-describe("maskPII", () => {
-  it("should mask PII fields", () => {
-    const input = {
-      email: "taro@example.com",
-      phone: "090-1234-5678",
-      department: "engineering",
-    };
-    const result = maskPII(input);
-    expect(result).toEqual({
-      email: "***",
-      phone: "***",
-      department: "engineering",
-    });
-  });
-
-  it("should mask nested PII fields recursively", () => {
-    const input = {
-      crew: {
-        first_name: "Taro",
-        department: "engineering",
-      },
-    };
-    const result = maskPII(input);
-    expect(result).toEqual({
-      crew: {
-        first_name: "***",
-        department: "engineering",
-      },
-    });
-  });
-
-  it("should not mask non-PII fields", () => {
-    const input = { department: "engineering", page: 1, per_page: 10 };
-    const result = maskPII(input);
-    expect(result).toEqual(input);
-  });
-
-  it("should handle empty object", () => {
-    expect(maskPII({})).toEqual({});
-  });
-});
 
 describe("AuditLogger", () => {
   let consoleSpy: ReturnType<typeof vi.spyOn>;
@@ -126,7 +83,7 @@ describe("AuditLogger", () => {
     );
 
     const entry: AuditLogEntry = JSON.parse(consoleSpy.mock.calls[0]?.[0] as string);
-    expect(entry.params.email).toBe("***");
+    expect(entry.params.email).toBe("[REDACTED]");
     expect(entry.params.department).toBe("engineering");
   });
 
@@ -156,5 +113,26 @@ describe("AuditLogger", () => {
 
     expect(result).toEqual({ data: [1, 2, 3] });
     expect(store.write).toHaveBeenCalledOnce();
+  });
+
+  it("should log error to console.error when store.write fails", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const store: AuditLogStore = {
+      write: vi.fn().mockRejectedValue(new Error("Firestore unavailable")),
+    };
+    const logger = new AuditLogger(store);
+
+    await logger.logToolCall("list_crews", "admin@example.com", {}, async () => ({}));
+
+    // persistLog は非同期なので microtask を待つ
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const logOutput = JSON.parse(errorSpy.mock.calls[0]?.[0] as string);
+    expect(logOutput.severity).toBe("ERROR");
+    expect(logOutput.message).toBe("Audit log persistence failed");
+    expect(logOutput.error).toBe("Firestore unavailable");
+
+    errorSpy.mockRestore();
   });
 });

--- a/packages/mcp-smarthr/src/__tests__/auth.test.ts
+++ b/packages/mcp-smarthr/src/__tests__/auth.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { type AuthContext, Authorizer, type UserStore } from "../core/middleware/auth.js";
+import {
+  type AuthContext,
+  Authorizer,
+  createAuthContext,
+  type UserStore,
+} from "../core/middleware/auth.js";
 
 /** テスト用モック UserStore */
 function createMockUserStore(
@@ -233,5 +238,28 @@ describe("Authorizer", () => {
       expect(result.authorized).toBe(false);
       expect(result.reason).toBe("権限不足");
     });
+  });
+});
+
+describe("createAuthContext", () => {
+  it("email からドメインを自動導出する", () => {
+    const ctx = createAuthContext("user@aozora-cg.com", "http");
+    expect(ctx.email).toBe("user@aozora-cg.com");
+    expect(ctx.domain).toBe("aozora-cg.com");
+    expect(ctx.transport).toBe("http");
+  });
+
+  it("hdOverride でドメインを上書きできる", () => {
+    const ctx = createAuthContext("user@aozora-cg.com", "http", "custom-domain.com");
+    expect(ctx.domain).toBe("custom-domain.com");
+  });
+
+  it("不正な email 形式でエラーを投げる", () => {
+    expect(() => createAuthContext("invalid-email", "stdio")).toThrow("Invalid email format");
+  });
+
+  it("返されるオブジェクトが frozen である", () => {
+    const ctx = createAuthContext("user@aozora-cg.com", "stdio");
+    expect(Object.isFrozen(ctx)).toBe(true);
   });
 });

--- a/packages/mcp-smarthr/src/core/middleware/audit-logger.ts
+++ b/packages/mcp-smarthr/src/core/middleware/audit-logger.ts
@@ -3,10 +3,11 @@
  *
  * - Cloud Logging 互換の JSON 構造化ログを console.log で出力
  * - Firestore AuditLog コレクションへの書き込み（オプション、DI で注入）
- * - PII フィールドをマスキングして安全にログ記録
+ * - PII フィールドをマスキングして安全にログ記録（pii-filter.ts の maskPII を使用）
  */
 
 import { randomUUID } from "node:crypto";
+import { maskPII } from "./pii-filter.js";
 
 /** 監査ログエントリ */
 export interface AuditLogEntry {
@@ -24,49 +25,6 @@ export interface AuditLogEntry {
 /** Firestore 書き込み用のインターフェース（DI） */
 export interface AuditLogStore {
   write(entry: AuditLogEntry): Promise<void>;
-}
-
-/**
- * PII と判定するフィールド名パターン。
- * 値を "***" に置換する。
- */
-const PII_FIELD_PATTERNS = [
-  /email/i,
-  /phone/i,
-  /address/i,
-  /birth/i,
-  /salary/i,
-  /wage/i,
-  /pay/i,
-  /bank/i,
-  /account/i,
-  /password/i,
-  /secret/i,
-  /token/i,
-  /name/i,
-  /my_?number/i,
-  /social.*security/i,
-  /ssn/i,
-];
-
-const PII_MASK = "***";
-
-/**
- * パラメータオブジェクトの PII フィールドをマスクする。
- * ネストされたオブジェクトも再帰的に処理する。
- */
-export function maskPII(params: Record<string, unknown>): Record<string, unknown> {
-  const masked: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(params)) {
-    if (PII_FIELD_PATTERNS.some((p) => p.test(key))) {
-      masked[key] = PII_MASK;
-    } else if (value !== null && typeof value === "object" && !Array.isArray(value)) {
-      masked[key] = maskPII(value as Record<string, unknown>);
-    } else {
-      masked[key] = value;
-    }
-  }
-  return masked;
 }
 
 export class AuditLogger {
@@ -104,7 +62,7 @@ export class AuditLogger {
         severity,
         tool,
         userEmail,
-        params: maskPII(params),
+        params: maskPII(params) as Record<string, unknown>,
         result,
         durationMs,
         requestId,
@@ -123,8 +81,17 @@ export class AuditLogger {
   /** Firestore に非同期書き込み（失敗してもツール実行には影響しない） */
   private persistLog(entry: AuditLogEntry): void {
     if (!this.store) return;
-    this.store.write(entry).catch(() => {
-      // Firestore 書き込み失敗はツール実行に影響させない
+    this.store.write(entry).catch((error) => {
+      console.error(
+        JSON.stringify({
+          severity: "ERROR",
+          message: "Audit log persistence failed",
+          tool: entry.tool,
+          requestId: entry.requestId,
+          error: error instanceof Error ? error.message : String(error),
+          source: "mcp-smarthr",
+        }),
+      );
     });
   }
 }

--- a/packages/mcp-smarthr/src/core/middleware/auth.ts
+++ b/packages/mcp-smarthr/src/core/middleware/auth.ts
@@ -12,14 +12,33 @@
 // Role は pii-filter.ts で定義済み — 重複を避けて re-export
 export type { Role } from "./pii-filter.js";
 
+import type { ToolName } from "../tools.js";
 import type { Role } from "./pii-filter.js";
 
 /** Shell 層から渡される認証コンテキスト */
 export interface AuthContext {
-  email: string;
-  /** hd クレーム or email のドメイン部分 */
-  domain: string;
-  transport: "stdio" | "http";
+  readonly email: string;
+  /** email から自動導出されたドメイン部分（hd クレームがある場合はそちらを優先） */
+  readonly domain: string;
+  readonly transport: "stdio" | "http";
+}
+
+/**
+ * AuthContext を生成するファクトリ関数。
+ * domain は email から自動導出し、email/domain の不整合を防止する。
+ * HTTP トランスポートで hd クレームを優先する場合は hdOverride を指定する。
+ */
+export function createAuthContext(
+  email: string,
+  transport: "stdio" | "http",
+  hdOverride?: string,
+): AuthContext {
+  if (!email.includes("@")) {
+    throw new Error(`Invalid email format: ${email}`);
+  }
+  const emailDomain = email.split("@")[1] ?? "";
+  const domain = hdOverride ?? emailDomain;
+  return Object.freeze({ email, domain, transport });
 }
 
 /** ユーザー許可リスト（DI） */
@@ -27,8 +46,8 @@ export interface UserStore {
   getUser(email: string): Promise<{ role: Role; enabled: boolean } | null>;
 }
 
-/** ツール権限マッピング */
-export const TOOL_PERMISSIONS: Record<string, Role> = {
+/** ツール権限マッピング（defineTools の全ツールに対応を強制） */
+export const TOOL_PERMISSIONS: Record<ToolName, Role> = {
   list_employees: "readonly",
   get_employee: "readonly",
   search_employees: "readonly",
@@ -98,8 +117,8 @@ export class Authorizer {
       };
     }
 
-    // Layer 4: ツール権限（H3修正: 未登録ツールは deny）
-    const requiredRole = TOOL_PERMISSIONS[toolName];
+    // Layer 4: ツール権限（未登録ツールは deny）
+    const requiredRole = TOOL_PERMISSIONS[toolName as ToolName];
     if (!requiredRole) {
       return {
         authorized: false,
@@ -140,8 +159,8 @@ export class Authorizer {
       };
     }
 
-    // H3修正: 未登録ツールは deny
-    const requiredRole = TOOL_PERMISSIONS[toolName];
+    // 未登録ツールは deny
+    const requiredRole = TOOL_PERMISSIONS[toolName as ToolName];
     if (!requiredRole) {
       return {
         authorized: false,

--- a/packages/mcp-smarthr/src/core/server.ts
+++ b/packages/mcp-smarthr/src/core/server.ts
@@ -23,10 +23,10 @@ export interface CreateServerOptions {
  * McpServer インスタンスを生成する（トランスポート非依存）
  *
  * 全ツール呼び出しに対して以下のパイプラインを強制する:
- *   authorize → audit log → handler → filterPII
+ *   resolveAuthContext → authorize → audit log → handler → filterPII
  *
- * - 未登録ツールは default deny
- * - stdio でも許可リストを尊重（未登録ユーザーは readonly）
+ * - 未登録ツールは default deny（TOOL_PERMISSIONS に無いツールは登録しない）
+ * - 認証・認可の失敗時は fail-closed（アクセス拒否）
  */
 export function createMcpServer(options: CreateServerOptions): McpServer {
   const {
@@ -47,21 +47,59 @@ export function createMcpServer(options: CreateServerOptions): McpServer {
   });
 
   for (const [name, tool] of Object.entries(tools)) {
-    // H3修正: 未登録ツールは登録しない（default deny）
     if (!(name in TOOL_PERMISSIONS)) continue;
 
     server.tool(name, tool.description, tool.shape, async (params: Record<string, unknown>) => {
-      const authContext = resolveAuthContext();
+      // --- fail-closed: 認証コンテキスト解決・認可チェックの失敗はアクセス拒否 ---
+      let authContext: AuthContext;
+      try {
+        authContext = resolveAuthContext();
+      } catch (error) {
+        console.error(
+          JSON.stringify({
+            severity: "ERROR",
+            message: "Failed to resolve auth context",
+            tool: name,
+            error: error instanceof Error ? error.message : String(error),
+            source: "mcp-smarthr",
+          }),
+        );
+        return {
+          content: [{ type: "text" as const, text: "Error: 認証コンテキストの解決に失敗しました" }],
+          isError: true,
+        };
+      }
 
-      // Layer 1-4: 認可チェック
-      const authResult = await authorizer.authorize(authContext, name);
+      let authResult: Awaited<ReturnType<typeof authorizer.authorize>>;
+      try {
+        authResult = await authorizer.authorize(authContext, name);
+      } catch (error) {
+        console.error(
+          JSON.stringify({
+            severity: "ERROR",
+            message: "Authorization system failure - denying access",
+            tool: name,
+            email: authContext.email,
+            error: error instanceof Error ? error.message : String(error),
+            source: "mcp-smarthr",
+          }),
+        );
+        return {
+          content: [{ type: "text" as const, text: "Error: 認証システムエラー" }],
+          isError: true,
+        };
+      }
+
       if (!authResult.authorized) {
-        // 拒否時も監査ログを記録
-        await auditLogger
-          .logToolCall(name, authContext.email, params, async () => {
+        // 拒否時も監査ログを記録（失敗しても拒否レスポンスは返す）
+        try {
+          await auditLogger.logToolCall(name, authContext.email, params, async () => {
             throw new Error(authResult.reason ?? "アクセスが拒否されました");
-          })
-          .catch(() => {});
+          });
+        } catch {
+          // logToolCall は内部で fn の throw を re-throw するため、ここで捕捉する
+          // 監査ログの出力自体は logToolCall の finally ブロックで完了済み
+        }
         return {
           content: [{ type: "text" as const, text: `アクセス拒否: ${authResult.reason}` }],
           isError: true,
@@ -70,17 +108,26 @@ export function createMcpServer(options: CreateServerOptions): McpServer {
 
       // 認可OK → 監査ログ付きでハンドラ実行 → PII フィルタ適用
       try {
-        const result = await auditLogger.logToolCall(name, authContext.email, params, () =>
+        const result: unknown = await auditLogger.logToolCall(name, authContext.email, params, () =>
           tool.handler(params as never),
         );
 
-        // H4修正: 結果にPIIフィルタを適用
-        const filtered = filterPII(JSON.parse(result), authResult.role);
+        // handler はオブジェクトを返すため、直接 PII フィルタを適用
+        const filtered = filterPII(result, authResult.role);
         return { content: [{ type: "text" as const, text: JSON.stringify(filtered, null, 2) }] };
       } catch (error) {
-        const message = error instanceof Error ? error.message : "Unknown error";
+        // エラーメッセージに PII が含まれる可能性があるため、汎用メッセージを返す
+        console.error(
+          JSON.stringify({
+            severity: "ERROR",
+            message: error instanceof Error ? error.message : String(error),
+            tool: name,
+            email: authContext.email,
+            source: "mcp-smarthr",
+          }),
+        );
         return {
-          content: [{ type: "text" as const, text: `Error: ${message}` }],
+          content: [{ type: "text" as const, text: "Error: ツール実行中にエラーが発生しました" }],
           isError: true,
         };
       }

--- a/packages/mcp-smarthr/src/core/tools.ts
+++ b/packages/mcp-smarthr/src/core/tools.ts
@@ -7,15 +7,33 @@ const paginationShape = {
   per_page: z.number().int().min(1).max(100).optional().describe("1ページあたりの件数（最大100）"),
 };
 
+/** ツール名一覧（TOOL_PERMISSIONS との同期を型で強制するために定義） */
+const TOOL_NAMES = [
+  "list_employees",
+  "get_employee",
+  "search_employees",
+  "get_pay_statements",
+  "list_departments",
+  "list_positions",
+] as const;
+
+export type ToolName = (typeof TOOL_NAMES)[number];
+
+interface ToolDefinition {
+  description: string;
+  shape: Record<string, unknown>;
+  handler: (params: never) => Promise<unknown>;
+}
+
 /** ツール定義一覧 */
-export function defineTools(client: SmartHRClient) {
+export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinition> {
   return {
     list_employees: {
       description: "SmartHRの従業員一覧を取得します。ページネーション対応。",
       shape: paginationShape,
       handler: async (params: { page?: number; per_page?: number }) => {
         const result = await client.listEmployees(params);
-        return formatListResult("従業員", result.data.length, result.totalCount, result.data);
+        return formatListResult("従業員", result.data, result.totalCount);
       },
     },
 
@@ -25,8 +43,7 @@ export function defineTools(client: SmartHRClient) {
         id: z.string().describe("SmartHR従業員ID"),
       },
       handler: async (params: { id: string }) => {
-        const crew = await client.getEmployee(params.id);
-        return formatResult(crew);
+        return await client.getEmployee(params.id);
       },
     },
 
@@ -41,7 +58,7 @@ export function defineTools(client: SmartHRClient) {
           page: params.page,
           per_page: params.per_page,
         });
-        return formatListResult("従業員", result.data.length, result.totalCount, result.data);
+        return formatListResult("従業員", result.data, result.totalCount);
       },
     },
 
@@ -61,7 +78,7 @@ export function defineTools(client: SmartHRClient) {
         per_page?: number;
       }) => {
         const result = await client.getPayStatements(params);
-        return formatListResult("給与明細", result.data.length, result.totalCount, result.data);
+        return formatListResult("給与明細", result.data, result.totalCount);
       },
     },
 
@@ -70,7 +87,7 @@ export function defineTools(client: SmartHRClient) {
       shape: paginationShape,
       handler: async (params: { page?: number; per_page?: number }) => {
         const result = await client.listDepartments(params);
-        return formatListResult("部署", result.data.length, result.totalCount, result.data);
+        return formatListResult("部署", result.data, result.totalCount);
       },
     },
 
@@ -79,28 +96,19 @@ export function defineTools(client: SmartHRClient) {
       shape: paginationShape,
       handler: async (params: { page?: number; per_page?: number }) => {
         const result = await client.listPositions(params);
-        return formatListResult("役職", result.data.length, result.totalCount, result.data);
+        return formatListResult("役職", result.data, result.totalCount);
       },
     },
-  } as const;
-}
-
-function formatResult(data: unknown): string {
-  return JSON.stringify(data, null, 2);
+  };
 }
 
 function formatListResult(
   label: string,
-  count: number,
-  totalCount: number,
   data: unknown[],
-): string {
-  return JSON.stringify(
-    {
-      summary: `${label}: ${count}件 / 全${totalCount}件`,
-      data,
-    },
-    null,
-    2,
-  );
+  totalCount: number,
+): { summary: string; data: unknown[] } {
+  return {
+    summary: `${label}: ${data.length}件 / 全${totalCount}件`,
+    data,
+  };
 }

--- a/packages/mcp-smarthr/src/shells/stdio.ts
+++ b/packages/mcp-smarthr/src/shells/stdio.ts
@@ -1,5 +1,6 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import type { AuthContext, UserStore } from "../core/middleware/auth.js";
+import type { UserStore } from "../core/middleware/auth.js";
+import { createAuthContext } from "../core/middleware/auth.js";
 import { createMcpServer } from "../core/server.js";
 import { SmartHRClient } from "../core/smarthr-client.js";
 
@@ -32,12 +33,14 @@ export async function startStdio(): Promise<void> {
   }
 
   const userEmail = process.env.MCP_USER_EMAIL ?? "local@aozora-cg.com";
+  if (!process.env.MCP_USER_EMAIL) {
+    console.error(
+      "Warning: MCP_USER_EMAIL not set. Using default identity local@aozora-cg.com. " +
+        "Audit logs will not reflect actual user identity.",
+    );
+  }
 
-  const authContext: AuthContext = {
-    email: userEmail,
-    domain: userEmail.split("@")[1] ?? "",
-    transport: "stdio",
-  };
+  const authContext = createAuthContext(userEmail, "stdio");
 
   const client = new SmartHRClient({ accessToken: apiKey, tenantId });
   const server = createMcpServer({


### PR DESCRIPTION
## Summary

PR #412 の6エージェント並列レビューで検出された Critical/Important 指摘を修正。

### Critical 修正
- **C1**: 空 `.catch(() => {})` を構造化エラーログに修正（audit-logger, server）
- **C2**: handler の JSON 二重シリアライズ解消 → オブジェクト直接返却でPIIフィルタバイパスリスク除去
- **C3**: PII マスキング2系統を `pii-filter.ts` に統合（regex版を削除）
- **C4**: `createAuthContext` ファクトリ関数で email/domain 不整合を型レベルで防止

### Important 修正
- **I1**: `resolveAuthContext`/`authorize` を try-catch で囲み fail-closed に
- **I5**: `TOOL_PERMISSIONS` を `Record<ToolName, Role>` に型安全化（ツール追加漏れをコンパイル時に検出）

### 追加改善
- stdio デフォルト email 未設定時の警告ログ出力
- Firestore 障害時のエラーログ出力テスト追加
- `createAuthContext` テスト4件追加

## Test plan
- [x] `pnpm test` — 63件全PASS
- [x] `pnpm lint` — PASS
- [x] `pnpm typecheck` — PASS
- [x] 新規テスト5件追加（createAuthContext 4件 + Firestore エラーログ 1件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)