### PR TITLE
feat: SmartHR MCP HTTP Shell + Dockerfile（Phase B）

### DIFF
--- a/packages/mcp-smarthr/.env.example
+++ b/packages/mcp-smarthr/.env.example
@@ -1,0 +1,12 @@
+# SmartHR API（必須）
+SMARTHR_API_KEY=your-smarthr-api-key
+SMARTHR_TENANT_ID=your-tenant-id
+
+# stdio モード用（任意）
+MCP_USER_EMAIL=local@aozora-cg.com
+MCP_USER_ROLE=readonly
+
+# HTTP モード用（pnpm serve 時に必須）
+GOOGLE_CLIENT_ID=your-google-oauth-client-id.apps.googleusercontent.com
+ALLOWED_DOMAIN=aozora-cg.com
+PORT=8080

--- a/packages/mcp-smarthr/Dockerfile
+++ b/packages/mcp-smarthr/Dockerfile
@@ -1,0 +1,54 @@
+# ============================================================================
+# SmartHR MCP Server — Multi-stage Docker Build
+# Base: node:22-slim
+# Package manager: pnpm (version from packageManager field in package.json)
+#
+# Stage 1 (builder): pnpm install + turbo build --filter=@hr-system/mcp-smarthr...
+# Stage 2 (runner):  pnpm install --prod + dist/ のみコピー
+# ============================================================================
+
+FROM node:22-slim AS base
+WORKDIR /app
+
+# corepack 有効化（package.json の packageManager フィールドに従い pnpm を使用）
+RUN corepack enable
+
+# ===== Stage 1: builder =====
+FROM base AS builder
+
+# 依存関係のキャッシュ効率化
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json turbo.json ./
+COPY packages/mcp-smarthr/package.json ./packages/mcp-smarthr/
+
+# 全依存関係をインストール（devDeps 含む: tsc が必要）
+RUN pnpm install --frozen-lockfile
+
+# ソースコードをコピー
+COPY packages/mcp-smarthr/src ./packages/mcp-smarthr/src
+COPY packages/mcp-smarthr/tsconfig.json ./packages/mcp-smarthr/
+COPY packages/mcp-smarthr/tsconfig.build.json ./packages/mcp-smarthr/
+COPY tsconfig.json ./
+
+# ビルド
+RUN pnpm turbo build --filter=@hr-system/mcp-smarthr
+
+# ===== Stage 2: runner =====
+FROM base AS runner
+
+ENV NODE_ENV=production
+
+# 本番依存のみインストール（devDeps 除外）
+COPY pnpm-workspace.yaml pnpm-lock.yaml package.json ./
+COPY packages/mcp-smarthr/package.json ./packages/mcp-smarthr/
+
+RUN pnpm install --frozen-lockfile --prod
+
+# ビルド済み JS ファイルのみコピー
+COPY --from=builder /app/packages/mcp-smarthr/dist ./packages/mcp-smarthr/dist
+
+EXPOSE 8080
+
+# 非 root ユーザーで実行
+USER node
+
+CMD ["node", "packages/mcp-smarthr/dist/serve.js"]

--- a/packages/mcp-smarthr/package.json
+++ b/packages/mcp-smarthr/package.json
@@ -11,10 +11,17 @@
     "lint": "biome check src/",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "start": "tsx src/index.ts"
+    "start": "tsx src/index.ts",
+    "serve": "tsx src/serve.ts"
   },
   "dependencies": {
+    "@cfworker/json-schema": "^4.1.1",
+    "@hono/node-server": "^1.19.9",
+    "@modelcontextprotocol/hono": "2.0.0-alpha.2",
     "@modelcontextprotocol/sdk": "^1.12.0",
+    "@modelcontextprotocol/server": "2.0.0-alpha.2",
+    "google-auth-library": "^10.5.0",
+    "hono": "^4.11.10",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/mcp-smarthr/src/__tests__/http-shell.test.ts
+++ b/packages/mcp-smarthr/src/__tests__/http-shell.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from "vitest";
+import { verifyGoogleToken } from "../shells/http.js";
+
+// google-auth-library のモック
+vi.mock("google-auth-library", () => {
+  return {
+    OAuth2Client: vi.fn().mockImplementation(() => ({
+      verifyIdToken: vi.fn(),
+    })),
+  };
+});
+
+import { OAuth2Client } from "google-auth-library";
+
+function createMockOAuthClient(
+  payload: Record<string, unknown> | null = null,
+  shouldThrow = false,
+) {
+  const client = new OAuth2Client("test-client-id");
+  const verifyMock = client.verifyIdToken as ReturnType<typeof vi.fn>;
+
+  if (shouldThrow) {
+    verifyMock.mockRejectedValue(new Error("Token verification failed"));
+  } else {
+    verifyMock.mockResolvedValue({
+      getPayload: () => payload,
+    });
+  }
+
+  return client;
+}
+
+const GOOGLE_CLIENT_ID = "test-client-id.apps.googleusercontent.com";
+
+describe("verifyGoogleToken", () => {
+  it("有効なトークン → authContext を返す", async () => {
+    const client = createMockOAuthClient({
+      email: "user@aozora-cg.com",
+      hd: "aozora-cg.com",
+    });
+
+    const result = await verifyGoogleToken(client, GOOGLE_CLIENT_ID, "Bearer valid-token");
+
+    expect("authContext" in result).toBe(true);
+    if ("authContext" in result) {
+      expect(result.authContext.email).toBe("user@aozora-cg.com");
+      expect(result.authContext.domain).toBe("aozora-cg.com");
+      expect(result.authContext.transport).toBe("http");
+    }
+  });
+
+  it("hd クレームがない場合は email からドメインを導出", async () => {
+    const client = createMockOAuthClient({
+      email: "user@gmail.com",
+    });
+
+    const result = await verifyGoogleToken(client, GOOGLE_CLIENT_ID, "Bearer valid-token");
+
+    expect("authContext" in result).toBe(true);
+    if ("authContext" in result) {
+      expect(result.authContext.domain).toBe("gmail.com");
+    }
+  });
+
+  it("Authorization ヘッダーなし → 401 エラー", async () => {
+    const client = createMockOAuthClient();
+
+    const result = await verifyGoogleToken(client, GOOGLE_CLIENT_ID, undefined);
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toBe("Authorization header required");
+      expect(result.status).toBe(401);
+    }
+  });
+
+  it("Bearer プレフィックスなし → 401 エラー", async () => {
+    const client = createMockOAuthClient();
+
+    const result = await verifyGoogleToken(client, GOOGLE_CLIENT_ID, "Basic abc123");
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toBe("Authorization header required");
+    }
+  });
+
+  it("email クレームがないトークン → 401 エラー", async () => {
+    const client = createMockOAuthClient({ sub: "12345" });
+
+    const result = await verifyGoogleToken(client, GOOGLE_CLIENT_ID, "Bearer no-email-token");
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toBe("Invalid token: no email claim");
+    }
+  });
+
+  it("無効なトークン → 401 エラー", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const client = createMockOAuthClient(null, true);
+
+    const result = await verifyGoogleToken(client, GOOGLE_CLIENT_ID, "Bearer invalid-token");
+
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error).toBe("Invalid or expired token");
+    }
+
+    // 検証失敗時にエラーログが出力されること
+    expect(errorSpy).toHaveBeenCalledOnce();
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/mcp-smarthr/src/serve.ts
+++ b/packages/mcp-smarthr/src/serve.ts
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * HTTP エントリポイント — Cloud Run / ローカル開発用
+ *
+ * 環境変数:
+ *   SMARTHR_API_KEY (必須)
+ *   SMARTHR_TENANT_ID (必須)
+ *   GOOGLE_CLIENT_ID (必須)
+ *   ALLOWED_DOMAIN (任意, デフォルト: aozora-cg.com)
+ *   PORT (任意, デフォルト: 8080)
+ */
+
+import type { UserStore } from "./core/middleware/auth.js";
+import { startHttp } from "./shells/http.js";
+
+/** HTTP 用の簡易 UserStore（将来 Firestore に差し替え） */
+const httpUserStore: UserStore = {
+  async getUser(_email: string) {
+    // Phase C で Firestore ベースの実装に差し替え予定
+    // 現時点では全ドメイン内ユーザーを readonly として許可
+    return { role: "readonly" as const, enabled: true };
+  },
+};
+
+const apiKey = process.env.SMARTHR_API_KEY;
+const tenantId = process.env.SMARTHR_TENANT_ID;
+const googleClientId = process.env.GOOGLE_CLIENT_ID;
+
+if (!apiKey || !tenantId || !googleClientId) {
+  console.error(
+    "Error: SMARTHR_API_KEY, SMARTHR_TENANT_ID, and GOOGLE_CLIENT_ID environment variables are required.",
+  );
+  process.exit(1);
+}
+
+startHttp({
+  smarthrApiKey: apiKey,
+  smarthrTenantId: tenantId,
+  googleClientId,
+  allowedDomain: process.env.ALLOWED_DOMAIN ?? "aozora-cg.com",
+  userStore: httpUserStore,
+  port: Number(process.env.PORT) || 8080,
+}).catch((error) => {
+  console.error(
+    JSON.stringify({
+      severity: "CRITICAL",
+      message: "MCP HTTP server failed to start",
+      error: error instanceof Error ? error.message : String(error),
+      source: "mcp-smarthr",
+    }),
+  );
+  process.exit(1);
+});

--- a/packages/mcp-smarthr/src/shells/http.ts
+++ b/packages/mcp-smarthr/src/shells/http.ts
@@ -1,0 +1,149 @@
+/**
+ * HTTP Shell — Hono + Streamable HTTP + Google OAuth ID トークン検証
+ *
+ * Cloud Run 上で動作し、claude.ai / Cowork / 自社アプリからのアクセスを受け付ける。
+ * 認証フロー:
+ *   Authorization: Bearer <Google ID Token>
+ *   → google-auth-library で検証
+ *   → email + hd を抽出 → createAuthContext
+ *   → Core の createMcpServer に委譲
+ */
+
+import { serve } from "@hono/node-server";
+import { createMcpHonoApp } from "@modelcontextprotocol/hono";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/server";
+import { OAuth2Client } from "google-auth-library";
+import { cors } from "hono/cors";
+import type { AuthContext, UserStore } from "../core/middleware/auth.js";
+import { createAuthContext } from "../core/middleware/auth.js";
+import { createMcpServer } from "../core/server.js";
+import { SmartHRClient } from "../core/smarthr-client.js";
+
+export interface HttpShellOptions {
+  smarthrApiKey: string;
+  smarthrTenantId: string;
+  googleClientId: string;
+  allowedDomain?: string;
+  userStore: UserStore;
+  port?: number;
+}
+
+/**
+ * Google OAuth ID トークンを検証し、AuthContext を返す。
+ * 検証失敗時は null を返す。
+ */
+export async function verifyGoogleToken(
+  oauthClient: OAuth2Client,
+  googleClientId: string,
+  authHeader: string | undefined,
+): Promise<{ authContext: AuthContext } | { error: string; status: 401 }> {
+  if (!authHeader?.startsWith("Bearer ")) {
+    return { error: "Authorization header required", status: 401 };
+  }
+
+  const token = authHeader.slice(7);
+
+  try {
+    const ticket = await oauthClient.verifyIdToken({
+      idToken: token,
+      audience: googleClientId,
+    });
+    const payload = ticket.getPayload();
+    if (!payload?.email) {
+      return { error: "Invalid token: no email claim", status: 401 };
+    }
+
+    const authContext = createAuthContext(payload.email, "http", payload.hd);
+    return { authContext };
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        severity: "WARNING",
+        message: "OAuth token verification failed",
+        error: error instanceof Error ? error.message : String(error),
+        source: "mcp-smarthr",
+      }),
+    );
+    return { error: "Invalid or expired token", status: 401 };
+  }
+}
+
+/**
+ * HTTP Shell を起動する。
+ *
+ * 環境変数:
+ *   SMARTHR_API_KEY (必須), SMARTHR_TENANT_ID (必須)
+ *   GOOGLE_CLIENT_ID (必須) — Google OAuth クライアント ID
+ *   ALLOWED_DOMAIN (任意, デフォルト: aozora-cg.com)
+ *   PORT (任意, デフォルト: 8080)
+ */
+export async function startHttp(options: HttpShellOptions): Promise<void> {
+  const {
+    smarthrApiKey,
+    smarthrTenantId,
+    googleClientId,
+    allowedDomain = "aozora-cg.com",
+    userStore,
+    port = 8080,
+  } = options;
+
+  const smarthrClient = new SmartHRClient({
+    accessToken: smarthrApiKey,
+    tenantId: smarthrTenantId,
+  });
+
+  const oauthClient = new OAuth2Client(googleClientId);
+  const app = createMcpHonoApp({ host: "0.0.0.0" });
+
+  // CORS（MCP ヘッダーを expose）
+  app.use(
+    cors({
+      origin: "*",
+      allowHeaders: ["Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"],
+      exposeHeaders: ["WWW-Authenticate", "Mcp-Session-Id", "Mcp-Protocol-Version"],
+    }),
+  );
+
+  // ヘルスチェック（認証不要）
+  app.get("/health", (c) => c.json({ status: "ok" }));
+
+  // MCP エンドポイント — 認証 + ステートレス Streamable HTTP
+  app.all("/mcp", async (c) => {
+    // Google OAuth トークン検証
+    const result = await verifyGoogleToken(
+      oauthClient,
+      googleClientId,
+      c.req.header("authorization"),
+    );
+    if ("error" in result) {
+      return c.json({ error: result.error }, result.status);
+    }
+
+    const { authContext } = result;
+
+    const mcpServer = createMcpServer({
+      smarthrClient,
+      resolveAuthContext: () => authContext,
+      userStore,
+      allowedDomain,
+    });
+
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    await mcpServer.connect(transport);
+    return transport.handleRequest(c.req.raw);
+  });
+
+  serve({ fetch: app.fetch, port }, () => {
+    console.log(
+      JSON.stringify({
+        severity: "INFO",
+        message: `MCP HTTP server listening on port ${port}`,
+        allowedDomain,
+        source: "mcp-smarthr",
+      }),
+    );
+  });
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,7 +144,7 @@ importers:
         version: 20.8.3
       shadcn:
         specifier: ^3.8.5
-        version: 3.8.5(@types/node@22.19.11)(typescript@5.9.3)
+        version: 3.8.5(@cfworker/json-schema@4.1.1)(@types/node@22.19.11)(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.0.0
         version: 4.1.18
@@ -238,9 +238,27 @@ importers:
 
   packages/mcp-smarthr:
     dependencies:
+      '@cfworker/json-schema':
+        specifier: ^4.1.1
+        version: 4.1.1
+      '@hono/node-server':
+        specifier: ^1.19.9
+        version: 1.19.9(hono@4.11.10)
+      '@modelcontextprotocol/hono':
+        specifier: 2.0.0-alpha.2
+        version: 2.0.0-alpha.2(@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1))(hono@4.11.10)
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.0
-        version: 1.26.0(zod@3.25.76)
+        version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
+      '@modelcontextprotocol/server':
+        specifier: 2.0.0-alpha.2
+        version: 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
+      google-auth-library:
+        specifier: ^10.5.0
+        version: 10.5.0
+      hono:
+        specifier: ^4.11.10
+        version: 4.11.10
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -508,6 +526,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@date-fns/tz@1.4.1':
     resolution: {integrity: sha512-P5LUNhtbj6YfI3iJjw5EL9eUAG6OitD0W3fWQcpQjDRc/QIsL0tRNuO1PcDvPccWL1fSTXXdE1ds+l95DV/OFA==}
@@ -988,12 +1009,28 @@ packages:
     resolution: {integrity: sha512-4hSpglL/G/cW2JCcohaYz/BS0uOSJNV9IEYdMm0EiPEvDLayoI2hGq2D86uYPQFD2gvgkyhmzdShpWLG3P5r3w==}
     engines: {node: '>=20'}
 
+  '@modelcontextprotocol/hono@2.0.0-alpha.2':
+    resolution: {integrity: sha512-X6Rg5F6eXlLsahl9HYSNJ3/7/w7SxbkZUtDKp0FBjS3p4Tydr0rKh3iorRPVC5f/Z5UfV83ARFxfRlnOgMZuDA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@modelcontextprotocol/server': ^2.0.0-alpha.2
+      hono: ^4.11.4
+
   '@modelcontextprotocol/sdk@1.26.0':
     resolution: {integrity: sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==}
     engines: {node: '>=18'}
     peerDependencies:
       '@cfworker/json-schema': ^4.1.1
       zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@modelcontextprotocol/server@2.0.0-alpha.2':
+    resolution: {integrity: sha512-gmLgdHzlYM8L7Aw/+VE0kxjT25WKamtUSLNhdOgrJq5CrESvqVSoAfWSJJeNPUXNTluQ+dYDGFbKVitdsJtbPA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
@@ -4484,6 +4521,9 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
+
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
@@ -4742,6 +4782,8 @@ snapshots:
 
   '@biomejs/cli-win32-x64@2.4.2':
     optional: true
+
+  '@cfworker/json-schema@4.1.1': {}
 
   '@date-fns/tz@1.4.1': {}
 
@@ -5189,7 +5231,12 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@modelcontextprotocol/sdk@1.26.0(zod@3.25.76)':
+  '@modelcontextprotocol/hono@2.0.0-alpha.2(@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1))(hono@4.11.10)':
+    dependencies:
+      '@modelcontextprotocol/server': 2.0.0-alpha.2(@cfworker/json-schema@4.1.1)
+      hono: 4.11.10
+
+  '@modelcontextprotocol/sdk@1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.10)
       ajv: 8.18.0
@@ -5208,8 +5255,16 @@ snapshots:
       raw-body: 3.0.2
       zod: 3.25.76
       zod-to-json-schema: 3.25.1(zod@3.25.76)
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
     transitivePeerDependencies:
       - supports-color
+
+  '@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1)':
+    dependencies:
+      zod: 4.3.6
+    optionalDependencies:
+      '@cfworker/json-schema': 4.1.1
 
   '@mswjs/interceptors@0.41.3':
     dependencies:
@@ -8263,7 +8318,7 @@ snapshots:
 
   setprototypeof@1.2.0: {}
 
-  shadcn@3.8.5(@types/node@22.19.11)(typescript@5.9.3):
+  shadcn@3.8.5(@cfworker/json-schema@4.1.1)(@types/node@22.19.11)(typescript@5.9.3):
     dependencies:
       '@antfu/ni': 25.0.0
       '@babel/core': 7.29.0
@@ -8271,7 +8326,7 @@ snapshots:
       '@babel/plugin-transform-typescript': 7.28.6(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.28.5(@babel/core@7.29.0)
       '@dotenvx/dotenvx': 1.52.0
-      '@modelcontextprotocol/sdk': 1.26.0(zod@3.25.76)
+      '@modelcontextprotocol/sdk': 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@types/validate-npm-package-name': 4.0.2
       browserslist: 4.28.1
       commander: 14.0.3
@@ -8910,3 +8965,5 @@ snapshots:
       zod: 3.25.76
 
   zod@3.25.76: {}
+
+  zod@4.3.6: {}


### PR DESCRIPTION
## Summary

SmartHR MCP サーバーの Phase B: Shell 実装を完了。

- **HTTP Shell**: Hono + MCP Streamable HTTP + Google OAuth ID トークン検証
- **Dockerfile**: multi-stage build（node:22-slim、Cloud Run デプロイ用）
- **認証フロー**: Bearer Token → google-auth-library 検証 → email/hd 抽出 → createAuthContext → Core 4層認証に委譲
- **ステートレス設計**: Cloud Run スケーリング対応（セッション管理なし）

### 新規ファイル
| ファイル | 概要 |
|---------|------|
| `shells/http.ts` | HTTP Shell（Hono + OAuth + Streamable HTTP） |
| `serve.ts` | HTTP エントリポイント（Cloud Run 用） |
| `Dockerfile` | multi-stage Docker build |
| `.env.example` | 環境変数テンプレート |
| `__tests__/http-shell.test.ts` | 認証フロー6テスト |

### 依存追加
`@modelcontextprotocol/hono`, `@modelcontextprotocol/server`, `hono`, `@hono/node-server`, `google-auth-library`, `@cfworker/json-schema`

## Test plan
- [x] `pnpm typecheck` — PASS
- [x] `pnpm lint` — PASS
- [x] `pnpm test` — 69件全PASS（既存63 + 新規6）
- [ ] `pnpm serve` でローカル HTTP サーバー起動確認（Phase D で実施）
- [ ] `docker build` でイメージビルド確認（Phase C で実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)