### PR TITLE
docs: ハンドオフ更新（Phase A+B 完了）

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,8 +1,8 @@
 # HR-AI Agent — Session Handoff
 
 **最終更新**: 2026-04-12（セッション終了時点）
-**ブランチ**: `feature/smarthr-mcp-core-security`（PR #412 レビュー待ち）
-**main 最新**: `f562e41` — docs: ハンドオフ更新（Phase 12 進行中）
+**ブランチ**: `main`
+**main 最新**: `7abe1ea` — feat: SmartHR MCP HTTP Shell + Dockerfile（Phase B）(#414)
 
 ---
 
@@ -12,58 +12,42 @@
 
 ### 今セッションの成果
 
-SmartHR MCP サーバーの **Core + Shell アーキテクチャ（Phase A）** を完成。
+1. **PR #412 レビュー + マージ**（Phase A）
+   - 6エージェント並列レビュー実施（code-reviewer, test-analyzer, failure-hunter, type-analyzer, comment-analyzer, code-simplifier）
+   - Critical 4件 + Important 2件の指摘を修正（PR #413）
+   - 修正内容: 空catch除去、JSON二重シリアライズ解消、PII マスキング統合、AuthContext ファクトリ、fail-closed、TOOL_PERMISSIONS 型安全化
+   - テスト: 62→63件
 
-1. **徹底調査**（6並列エージェント）
-   - SmartHR API 公式ドキュメント、ベストプラクティス、MCP 構築 BP、SmartHR 社 MCP 活用事例、既存 OSS 分析、セキュリティ設計
-   - 結果: `docs/research/smarthr-mcp-server-research.md`
+2. **Phase B 実装 + マージ**（PR #414）
+   - HTTP Shell: Hono + MCP Streamable HTTP + Google OAuth ID トークン検証
+   - Dockerfile: multi-stage build（node:22-slim）
+   - serve.ts: HTTP エントリポイント（Cloud Run 用）
+   - テスト: 63→69件（HTTP Shell 6件追加）
 
-2. **実装計画 v2**
-   - Core + Shell パターン、4層認証、Phase A-D の WBS
-   - 結果: `docs/plans/smarthr-mcp-server-impl-plan.md`
+### マージ済み PR
 
-3. **Phase A 実装**（Core 基盤強化）
-   - A1: Core ディレクトリ構造リファクタ
-   - A2: レート制限（100ms間隔 + x-rate-limit監視 + 429 Exponential Backoff）
-   - A3: PII フィルタ（ロール別フィールド除去）
-   - A4: 監査ログ（Cloud Logging + Firestore AuditLog DI）
-   - A5: 4層認証（トランスポート→ドメイン→許可リスト→ツール権限）
-   - A6: ミドルウェアパイプライン統合（Codex 設計レビュー H1-H4, M1 修正）
-
-4. **品質**
-   - テスト: 62件全PASS / lint: PASS / typecheck: PASS
-   - Codex セカンドオピニオン完了（指摘5件全修正）
-
-### PR #412（レビュー待ち）
-
-- `feature/smarthr-mcp-core-security` → `main`
-- +2437行 / 17ファイル
-- **次セッションで `/review-pr` 実施後マージ**
+| PR | 内容 | 状態 |
+|----|------|------|
+| #412 | Phase A: Core + Shell アーキテクチャ | マージ済 |
+| #413 | Phase A レビュー指摘修正 | マージ済 |
+| #414 | Phase B: HTTP Shell + Dockerfile | マージ済 |
 
 ---
 
-## 次のアクション（WBS Phase B-D）
+## 次のアクション（WBS Phase C-D）
 
-### Phase B: Shell 実装（未着手）
-- B1: stdio Shell（既存 index.ts リファクタ済み、動作確認のみ）
-- B2: HTTP Shell（Hono + Streamable HTTP + Google OAuth）← 最大の実装タスク
-- B3: Dockerfile + Cloud Run デプロイ設定
-
-### Phase C: GCP インフラ（未着手）
-- C1: Secret Manager にトークン登録
-- C2: サービスアカウント + IAM 設定
-- C3: Cloud Run デプロイ
+### Phase C: GCP インフラ（未着手）← 次セッションで着手
+- C1: Secret Manager にトークン登録（SMARTHR_API_KEY, SMARTHR_TENANT_ID, GOOGLE_CLIENT_ID）
+- C2: サービスアカウント作成 + IAM 設定（Secret Accessor, Cloud Run 用）
+- C3: Cloud Run デプロイ（`mcp-smarthr`, asia-northeast1）
+- 品質ゲート: `/codex review` (security)
 
 ### Phase D: 接続テスト + 検証（未着手）
 - D1: Claude Code stdio 接続テスト
 - D2: Claude Desktop stdio 接続テスト
 - D3: claude.ai カスタムコネクタ登録 + テスト
 - D4: E2E 全 AC 検証
-
-### 品質ゲート
-- Phase B 完了後: lint + typecheck + test
-- Phase C 完了後: `/codex review` (security)
-- Phase D 完了後: `/simplify` + `/safe-refactor` + Evaluator 分離 + `/review-pr`
+- 品質ゲート: `/simplify` + `/safe-refactor` + Evaluator 分離 + `/review-pr`
 
 ---
 
@@ -75,10 +59,13 @@ SmartHR MCP サーバーの **Core + Shell アーキテクチャ（Phase A）** 
 | アーキテクチャ | Core + Shell パターン | Claude Code / claude.ai / 自社アプリ全対応 |
 | 接続パターン | パブリック Cloud Run + アプリ内 OAuth | IAP は claude.ai コネクタと共存不可 |
 | 認証 | 4層（トランスポート→ドメイン→許可リスト→ツール権限） | SmartHR API トークンがスコープなし |
+| HTTP フレームワーク | Hono + @modelcontextprotocol/hono | MCP SDK 公式サポート、既存 apps/ と統一 |
+| OAuth 検証 | google-auth-library | Google ID トークン直接検証 |
+| セッション管理 | ステートレス | Cloud Run スケーリングとの相性 |
 | 監査ログ | Cloud Logging + Firestore 両方 | 7年保持 + 運用性 |
-| PII フィルタ | readonly: 個人情報+custom_fields除外 / admin: my_number除外 | Codex レビュー M1 対応 |
-| 未登録ツール | default deny | Codex レビュー H3 対応 |
-| stdio 未登録ユーザー | readonly（admin にしない） | Codex レビュー H2 対応 |
+| PII フィルタ | pii-filter.ts に統合（maskPII 1系統） | レビュー指摘 C3 対応 |
+| AuthContext | ファクトリ関数 createAuthContext で email/domain 整合保証 | レビュー指摘 C4 対応 |
+| TOOL_PERMISSIONS | Record<ToolName, Role> で型安全化 | レビュー指摘 I5 対応 |
 
 ---
 
@@ -93,7 +80,7 @@ SmartHR MCP サーバーの **Core + Shell アーキテクチャ（Phase A）** 
 | Phase 9 | 担当者・期限インライン編集・手動タスクUI改善・AI判定パネル削除 | 完了 |
 | Phase 10 | タスクテーブルビュー拡充 | 完了 |
 | Phase 11 | 受信箱・タスクボードのメモ機能統一 | 完了 |
-| Phase 12 | SmartHR MCP サーバー構築 | **Phase A 完了、B-D 未着手** |
+| Phase 12 | SmartHR MCP サーバー構築 | **Phase A+B 完了、C-D 未着手** |
 
 ---
 
@@ -101,7 +88,6 @@ SmartHR MCP サーバーの **Core + Shell アーキテクチャ（Phase A）** 
 
 | # | タイトル | ラベル |
 |---|---------|--------|
-| #412 | feat: SmartHR MCP サーバー Core + Shell アーキテクチャ（Phase A） | PR |
 | #408 | Phase 3: 本番AIエージェント + 実験UI（/agent-lab） | enhancement |
 | #407 | Phase 2: Anthropic HR Plugin 導入（開発用ツール） | enhancement |
 
@@ -122,7 +108,7 @@ SmartHR MCP サーバーの **Core + Shell アーキテクチャ（Phase A）** 
 
 | パッケージ | テスト数 | 状態 |
 |-----------|---------|------|
-| packages/mcp-smarthr | **62** | ✅ 全PASS |
+| packages/mcp-smarthr | **69** | ✅ 全PASS |
 | apps/api | 22+ | ✅ |
 | apps/worker | 80 | ✅ |
 | apps/web | 207 | ✅ |
@@ -134,11 +120,17 @@ SmartHR MCP サーバーの **Core + Shell アーキテクチャ（Phase A）** 
 ```bash
 cd /Users/yyyhhh/Projects/ACG/hr-system
 
-# PR #412 のレビュー・マージ
-gh pr view 412
-# → /review-pr 実行後にマージ
+# main ブランチで最新状態
+git checkout main && git pull
 
-# Phase B 着手
-git checkout feature/smarthr-mcp-core-security  # or main after merge
-# → docs/plans/smarthr-mcp-server-impl-plan.md の Phase B から再開
+# Phase C 着手
+# → docs/plans/smarthr-mcp-server-impl-plan.md の Phase C セクションを参照
+# → C1: Secret Manager、C2: SA+IAM、C3: Cloud Run デプロイ
+# → GCP プロジェクト: hr-system-487809, リージョン: asia-northeast1
+
+# 参考: 実装計画
+cat docs/plans/smarthr-mcp-server-impl-plan.md
+
+# 参考: Dockerfile
+cat packages/mcp-smarthr/Dockerfile
 ```


### PR DESCRIPTION
## Summary
- Phase A+B 完了を反映したハンドオフ更新
- 次セッションの再開手順を Phase C（GCP インフラ）に更新

## Test plan
- [x] ドキュメントのみの変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)