### PR TITLE
feat: MCP HTTP Shell に AUTH_DISABLED デモモードを追加

### DIFF
--- a/packages/mcp-smarthr/src/serve.ts
+++ b/packages/mcp-smarthr/src/serve.ts
@@ -40,6 +40,7 @@ startHttp({
   allowedDomain: process.env.ALLOWED_DOMAIN ?? "aozora-cg.com",
   userStore: httpUserStore,
   port: Number(process.env.PORT) || 8080,
+  authDisabled: process.env.AUTH_DISABLED === "true",
 }).catch((error) => {
   console.error(
     JSON.stringify({

--- a/packages/mcp-smarthr/src/shells/http.ts
+++ b/packages/mcp-smarthr/src/shells/http.ts
@@ -26,6 +26,8 @@ export interface HttpShellOptions {
   allowedDomain?: string;
   userStore: UserStore;
   port?: number;
+  /** true にすると OAuth 検証をスキップし、デフォルト AuthContext を使用する（デモ用） */
+  authDisabled?: boolean;
 }
 
 /**
@@ -85,6 +87,7 @@ export async function startHttp(options: HttpShellOptions): Promise<void> {
     allowedDomain = "aozora-cg.com",
     userStore,
     port = 8080,
+    authDisabled = false,
   } = options;
 
   const smarthrClient = new SmartHRClient({
@@ -107,19 +110,35 @@ export async function startHttp(options: HttpShellOptions): Promise<void> {
   // ヘルスチェック（認証不要）
   app.get("/health", (c) => c.json({ status: "ok" }));
 
+  if (authDisabled) {
+    console.log(
+      JSON.stringify({
+        severity: "WARNING",
+        message: "Auth is DISABLED — demo mode. Do NOT use in production.",
+        source: "mcp-smarthr",
+      }),
+    );
+  }
+
   // MCP エンドポイント — 認証 + ステートレス Streamable HTTP
   app.all("/mcp", async (c) => {
-    // Google OAuth トークン検証
-    const result = await verifyGoogleToken(
-      oauthClient,
-      googleClientId,
-      c.req.header("authorization"),
-    );
-    if ("error" in result) {
-      return c.json({ error: result.error }, result.status);
-    }
+    let authContext: AuthContext;
 
-    const { authContext } = result;
+    if (authDisabled) {
+      // デモモード: 認証スキップ、デフォルト AuthContext を使用
+      authContext = createAuthContext("demo@aozora-cg.com", "http");
+    } else {
+      // 本番モード: Google OAuth トークン検証
+      const result = await verifyGoogleToken(
+        oauthClient,
+        googleClientId,
+        c.req.header("authorization"),
+      );
+      if ("error" in result) {
+        return c.json({ error: result.error }, result.status);
+      }
+      authContext = result.authContext;
+    }
 
     const mcpServer = createMcpServer({
       smarthrClient,


### PR DESCRIPTION
## Summary
- HTTP Shell に `AUTH_DISABLED` 環境変数による認証スキップモードを追加
- claude.ai カスタムコネクタからの authless 接続を可能にする
- デモモード時は `demo@aozora-cg.com` の AuthContext を使用

## 背景
claude.ai のカスタムコネクタは Google OAuth ID トークン直接検証をサポートしていない。
社長へのデモ・テスト利用 GO 取得を優先し、一時的に authless で接続可能にする。
本番運用前に OAuth 2.0 Authorization Server を実装予定。

## Test plan
- [x] `pnpm lint` PASS
- [x] `pnpm typecheck` PASS
- [x] `pnpm test` 69件全 PASS
- [ ] Cloud Run デプロイ後に claude.ai コネクタから接続テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)