### PR TITLE
fix: claude.ai からの接続で 406 エラーを修正

### DIFF
--- a/packages/mcp-smarthr/src/shells/http.ts
+++ b/packages/mcp-smarthr/src/shells/http.ts
@@ -189,6 +189,23 @@ export async function startHttp(options: HttpShellOptions): Promise<void> {
     );
   }
 
+  // Accept ヘッダー補正（claude.ai は片方のみ送信する場合がある）
+  app.use("/mcp", async (c, next) => {
+    const accept = c.req.header("accept") ?? "";
+    if (
+      c.req.method === "POST" &&
+      (!accept.includes("application/json") || !accept.includes("text/event-stream"))
+    ) {
+      c.req.raw = new Request(c.req.raw, {
+        headers: new Headers([
+          ...Array.from(c.req.raw.headers.entries()).filter(([k]) => k !== "accept"),
+          ["accept", "application/json, text/event-stream"],
+        ]),
+      });
+    }
+    await next();
+  });
+
   // MCP エンドポイント — 認証 + ステートレス Streamable HTTP
   app.all("/mcp", async (c) => {
     let authContext: AuthContext;


### PR DESCRIPTION
## Summary
- claude.ai が Accept ヘッダーに `application/json` と `text/event-stream` の両方を含めないため 406 が返る問題を修正
- Accept ヘッダー補正ミドルウェアを追加

## Test plan
- [x] lint / typecheck / test 全 PASS (69件)
- [ ] claude.ai からの接続確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)