### PR TITLE
feat: OAuth 2.1 Authorization Server + セキュリティ強化（Phase E+F1）

### DIFF
--- a/packages/mcp-smarthr/package.json
+++ b/packages/mcp-smarthr/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@cfworker/json-schema": "^4.1.1",
+    "@google-cloud/firestore": "^8.3.0",
     "@hono/node-server": "^1.19.9",
     "@modelcontextprotocol/hono": "2.0.0-alpha.2",
     "@modelcontextprotocol/sdk": "1.26.0",

--- a/packages/mcp-smarthr/package.json
+++ b/packages/mcp-smarthr/package.json
@@ -18,10 +18,11 @@
     "@cfworker/json-schema": "^4.1.1",
     "@hono/node-server": "^1.19.9",
     "@modelcontextprotocol/hono": "2.0.0-alpha.2",
-    "@modelcontextprotocol/sdk": "^1.12.0",
+    "@modelcontextprotocol/sdk": "1.26.0",
     "@modelcontextprotocol/server": "2.0.0-alpha.2",
     "google-auth-library": "^10.5.0",
     "hono": "^4.11.10",
+    "jose": "^6.2.2",
     "zod": "^3.25.0"
   },
   "devDependencies": {

--- a/packages/mcp-smarthr/src/__tests__/oauth-jwt.test.ts
+++ b/packages/mcp-smarthr/src/__tests__/oauth-jwt.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import { buildAuthServerMetadata, buildProtectedResourceMetadata } from "../core/oauth/config.js";
+import { issueAccessToken, verifyAccessToken } from "../core/oauth/jwt.js";
+
+const TEST_SECRET = "test-secret-key-for-jwt-signing-at-least-32-chars";
+const TEST_SERVER_URL = "https://mcp-smarthr.example.com";
+
+describe("JWT issueAccessToken / verifyAccessToken", () => {
+  it("正常: 発行したトークンを検証できる", async () => {
+    const token = await issueAccessToken(
+      { email: "user@aozora-cg.com", domain: "aozora-cg.com", role: "readonly" },
+      TEST_SECRET,
+      { serverUrl: TEST_SERVER_URL },
+    );
+
+    const claims = await verifyAccessToken(token, TEST_SECRET, TEST_SERVER_URL);
+    expect(claims.email).toBe("user@aozora-cg.com");
+    expect(claims.domain).toBe("aozora-cg.com");
+    expect(claims.role).toBe("readonly");
+    expect(claims.sub).toBe("user@aozora-cg.com");
+    expect(claims.iss).toBe(TEST_SERVER_URL);
+    expect(claims.aud).toBe(TEST_SERVER_URL);
+  });
+
+  it("正常: admin ロールのトークン", async () => {
+    const token = await issueAccessToken(
+      { email: "admin@aozora-cg.com", domain: "aozora-cg.com", role: "admin" },
+      TEST_SECRET,
+      { serverUrl: TEST_SERVER_URL },
+    );
+
+    const claims = await verifyAccessToken(token, TEST_SECRET, TEST_SERVER_URL);
+    expect(claims.role).toBe("admin");
+  });
+
+  it("異常: 不正なシークレットで検証失敗", async () => {
+    const token = await issueAccessToken(
+      { email: "user@aozora-cg.com", domain: "aozora-cg.com", role: "readonly" },
+      TEST_SECRET,
+      { serverUrl: TEST_SERVER_URL },
+    );
+
+    await expect(
+      verifyAccessToken(token, "wrong-secret-key-that-does-not-match!!", TEST_SERVER_URL),
+    ).rejects.toThrow();
+  });
+
+  it("異常: 不正な audience で検証失敗", async () => {
+    const token = await issueAccessToken(
+      { email: "user@aozora-cg.com", domain: "aozora-cg.com", role: "readonly" },
+      TEST_SECRET,
+      { serverUrl: TEST_SERVER_URL },
+    );
+
+    await expect(
+      verifyAccessToken(token, TEST_SECRET, "https://other-server.example.com"),
+    ).rejects.toThrow();
+  });
+
+  it("異常: 有効期限切れのトークン", async () => {
+    const token = await issueAccessToken(
+      { email: "user@aozora-cg.com", domain: "aozora-cg.com", role: "readonly" },
+      TEST_SECRET,
+      { serverUrl: TEST_SERVER_URL, expiresIn: 0 },
+    );
+
+    // jose は 0 秒 JWT を即座に期限切れと判断するが、
+    // clockTolerance があるため 1 秒待つ
+    await new Promise((r) => setTimeout(r, 1100));
+
+    await expect(verifyAccessToken(token, TEST_SECRET, TEST_SERVER_URL)).rejects.toThrow();
+  });
+});
+
+describe("OAuth Metadata builders", () => {
+  it("Protected Resource Metadata に必須フィールドが含まれる", () => {
+    const meta = buildProtectedResourceMetadata(TEST_SERVER_URL);
+    expect(meta.resource).toBe(TEST_SERVER_URL);
+    expect(meta.authorization_servers).toContain(TEST_SERVER_URL);
+    expect(meta.bearer_methods_supported).toContain("header");
+  });
+
+  it("Auth Server Metadata に必須エンドポイントが含まれる", () => {
+    const meta = buildAuthServerMetadata(TEST_SERVER_URL);
+    expect(meta.issuer).toBe(TEST_SERVER_URL);
+    expect(meta.authorization_endpoint).toBe(`${TEST_SERVER_URL}/authorize`);
+    expect(meta.token_endpoint).toBe(`${TEST_SERVER_URL}/token`);
+    expect(meta.registration_endpoint).toBe(`${TEST_SERVER_URL}/register`);
+    expect(meta.code_challenge_methods_supported).toContain("S256");
+    expect(meta.response_types_supported).toContain("code");
+  });
+
+  it("末尾スラッシュが正規化される", () => {
+    const meta = buildProtectedResourceMetadata(`${TEST_SERVER_URL}/`);
+    expect(meta.resource).toBe(TEST_SERVER_URL);
+  });
+});

--- a/packages/mcp-smarthr/src/__tests__/oauth-routes.test.ts
+++ b/packages/mcp-smarthr/src/__tests__/oauth-routes.test.ts
@@ -1,0 +1,171 @@
+import { createHash, randomBytes } from "node:crypto";
+import { describe, expect, it } from "vitest";
+import type { UserStore } from "../core/middleware/auth.js";
+import { createOAuthRoutes } from "../core/oauth/routes.js";
+
+const TEST_CONFIG = {
+  serverUrl: "https://mcp-smarthr.example.com",
+  googleClientId: "test-google-client-id",
+  googleClientSecret: "test-google-client-secret",
+  jwtSecret: "test-secret-key-for-jwt-signing-at-least-32-chars",
+  allowedDomain: "aozora-cg.com",
+};
+
+const testUserStore: UserStore = {
+  async getUser(_email: string) {
+    return { role: "readonly" as const, enabled: true };
+  },
+};
+
+function createApp() {
+  return createOAuthRoutes(TEST_CONFIG, testUserStore);
+}
+
+describe("OAuth Routes — .well-known endpoints", () => {
+  it("GET /.well-known/oauth-protected-resource → 200 + メタデータ", async () => {
+    const app = createApp();
+    const res = await app.request("/.well-known/oauth-protected-resource");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.resource).toBe(TEST_CONFIG.serverUrl);
+    expect(body.authorization_servers).toContain(TEST_CONFIG.serverUrl);
+    expect(body.bearer_methods_supported).toContain("header");
+  });
+
+  it("GET /.well-known/oauth-authorization-server → 200 + AS メタデータ", async () => {
+    const app = createApp();
+    const res = await app.request("/.well-known/oauth-authorization-server");
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.issuer).toBe(TEST_CONFIG.serverUrl);
+    expect(body.authorization_endpoint).toContain("/authorize");
+    expect(body.token_endpoint).toContain("/token");
+    expect(body.registration_endpoint).toContain("/register");
+    expect(body.code_challenge_methods_supported).toContain("S256");
+  });
+});
+
+describe("OAuth Routes — /authorize", () => {
+  it("PKCE なしのリクエスト → 400", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/authorize?response_type=code&client_id=test&redirect_uri=http://localhost:3000/callback",
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("invalid_request");
+  });
+
+  it("response_type が code 以外 → 400", async () => {
+    const app = createApp();
+    const res = await app.request(
+      "/authorize?response_type=token&client_id=test&redirect_uri=http://localhost:3000/callback&code_challenge=abc&code_challenge_method=S256",
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("unsupported_response_type");
+  });
+
+  it("正しいパラメータ → Google OIDC にリダイレクト", async () => {
+    const app = createApp();
+    const codeVerifier = randomBytes(32).toString("base64url");
+    const codeChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
+    const res = await app.request(
+      `/authorize?response_type=code&client_id=test&redirect_uri=http://localhost:3000/callback&code_challenge=${codeChallenge}&code_challenge_method=S256&state=mystate`,
+      { redirect: "manual" },
+    );
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("accounts.google.com");
+    expect(location).toContain("openid");
+  });
+});
+
+describe("OAuth Routes — /token", () => {
+  it("grant_type が authorization_code 以外 → 400", async () => {
+    const app = createApp();
+    const res = await app.request("/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({ grant_type: "client_credentials" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("unsupported_grant_type");
+  });
+
+  it("無効な認可コード → 400", async () => {
+    const app = createApp();
+    const res = await app.request("/token", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "authorization_code",
+        code: "invalid-code",
+        code_verifier: "test-verifier",
+        client_id: "test-client",
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("invalid_grant");
+  });
+});
+
+describe("OAuth Routes — /register", () => {
+  it("正常: Dynamic Client Registration", async () => {
+    const app = createApp();
+    const res = await app.request("/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: ["http://localhost:3000/callback"],
+        client_name: "Test Client",
+        token_endpoint_auth_method: "none",
+      }),
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.client_id).toBeTruthy();
+    expect(body.redirect_uris).toContain("http://localhost:3000/callback");
+    expect(body.grant_types).toContain("authorization_code");
+  });
+
+  it("redirect_uris なし → 400", async () => {
+    const app = createApp();
+    const res = await app.request("/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ client_name: "No URIs" }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("invalid_client_metadata");
+  });
+
+  it("HTTP redirect_uri（localhost 以外）→ 400", async () => {
+    const app = createApp();
+    const res = await app.request("/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: ["http://evil.com/callback"],
+      }),
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBe("invalid_client_metadata");
+  });
+
+  it("HTTPS redirect_uri → OK", async () => {
+    const app = createApp();
+    const res = await app.request("/register", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        redirect_uris: ["https://app.example.com/callback"],
+      }),
+    });
+    expect(res.status).toBe(201);
+  });
+});

--- a/packages/mcp-smarthr/src/core/middleware/audit-logger.ts
+++ b/packages/mcp-smarthr/src/core/middleware/audit-logger.ts
@@ -19,6 +19,8 @@ export interface AuditLogEntry {
   result: "success" | "error" | "denied";
   durationMs: number;
   requestId: string;
+  /** 拒否理由（result === "denied" 時のみ） */
+  reason?: string;
   source: "mcp-smarthr";
 }
 
@@ -37,6 +39,32 @@ export class AuditLogger {
    * - params は PII マスク済みでログに含める
    * - store が提供されている場合は Firestore にも非同期書き込み（失敗してもツール実行には影響しない）
    */
+  /**
+   * 認可拒否を記録する（fn を実行しない）。
+   * server.ts で denied と error を明確に分離するために使用。
+   */
+  async logDenied(
+    tool: string,
+    userEmail: string,
+    params: Record<string, unknown>,
+    reason: string,
+  ): Promise<void> {
+    const entry: AuditLogEntry = {
+      timestamp: new Date().toISOString(),
+      severity: "WARNING",
+      tool,
+      userEmail,
+      params: maskPII(params) as Record<string, unknown>,
+      result: "denied",
+      durationMs: 0,
+      requestId: randomUUID(),
+      reason,
+      source: "mcp-smarthr",
+    };
+    this.emitLog(entry);
+    this.persistLog(entry);
+  }
+
   async logToolCall<T>(
     tool: string,
     userEmail: string,

--- a/packages/mcp-smarthr/src/core/oauth/config.ts
+++ b/packages/mcp-smarthr/src/core/oauth/config.ts
@@ -1,0 +1,60 @@
+/**
+ * OAuth 2.1 Authorization Server 設定
+ *
+ * MCP 仕様準拠:
+ *   - RFC 9728: Protected Resource Metadata
+ *   - RFC 8414: Authorization Server Metadata
+ *   - OAuth 2.1 + PKCE
+ *   - Google OIDC への認証委譲
+ */
+
+export interface OAuthConfig {
+  /** MCP サーバーの公開 URL（例: https://mcp-smarthr-xxx.run.app） */
+  serverUrl: string;
+  /** Google OAuth Client ID */
+  googleClientId: string;
+  /** Google OAuth Client Secret */
+  googleClientSecret: string;
+  /** JWT 署名用シークレット（HS256） */
+  jwtSecret: string;
+  /** JWT の有効期間（秒）。デフォルト 3600（1時間） */
+  jwtExpiresIn?: number;
+  /** 許可ドメイン */
+  allowedDomain?: string;
+}
+
+/** Google OIDC エンドポイント */
+export const GOOGLE_OIDC = {
+  authorizationEndpoint: "https://accounts.google.com/o/oauth2/v2/auth",
+  tokenEndpoint: "https://oauth2.googleapis.com/token",
+  userinfoEndpoint: "https://openidconnect.googleapis.com/v1/userinfo",
+  issuer: "https://accounts.google.com",
+} as const;
+
+/** RFC 9728: Protected Resource Metadata */
+export function buildProtectedResourceMetadata(serverUrl: string) {
+  const resource = serverUrl.replace(/\/$/, "");
+  return {
+    resource,
+    authorization_servers: [`${resource}`],
+    bearer_methods_supported: ["header"],
+    scopes_supported: ["mcp:read", "mcp:write"],
+  };
+}
+
+/** RFC 8414: Authorization Server Metadata */
+export function buildAuthServerMetadata(serverUrl: string) {
+  const base = serverUrl.replace(/\/$/, "");
+  return {
+    issuer: base,
+    authorization_endpoint: `${base}/authorize`,
+    token_endpoint: `${base}/token`,
+    registration_endpoint: `${base}/register`,
+    response_types_supported: ["code"],
+    grant_types_supported: ["authorization_code"],
+    code_challenge_methods_supported: ["S256"],
+    scopes_supported: ["mcp:read", "mcp:write"],
+    token_endpoint_auth_methods_supported: ["client_secret_post", "none"],
+    client_id_metadata_document_supported: true,
+  };
+}

--- a/packages/mcp-smarthr/src/core/oauth/jwt.ts
+++ b/packages/mcp-smarthr/src/core/oauth/jwt.ts
@@ -1,0 +1,100 @@
+/**
+ * JWT 発行・検証（jose ライブラリ使用）
+ *
+ * MCP アクセストークンとして使用:
+ *   - HS256 署名（シークレットキー）
+ *   - 短寿命（デフォルト 1 時間）
+ *   - リフレッシュトークンなし（Codex セカンドオピニオンに基づく意図的な制限）
+ *   - aud クレームで MCP リソースにバインド（RFC 8707）
+ */
+
+import * as jose from "jose";
+
+export interface McpTokenPayload {
+  /** ユーザーメールアドレス */
+  email: string;
+  /** Google Workspace ドメイン */
+  domain: string;
+  /** ユーザーロール */
+  role: "admin" | "readonly";
+}
+
+export interface McpTokenClaims extends McpTokenPayload {
+  /** Subject（email と同一） */
+  sub: string;
+  /** Audience（MCP サーバー URL） */
+  aud: string;
+  /** Issuer（MCP サーバー URL） */
+  iss: string;
+}
+
+/**
+ * MCP アクセストークン（JWT）を発行する。
+ */
+export async function issueAccessToken(
+  payload: McpTokenPayload,
+  secret: string,
+  options: {
+    serverUrl: string;
+    expiresIn?: number;
+  },
+): Promise<string> {
+  const secretKey = new TextEncoder().encode(secret);
+  const expiresIn = options.expiresIn ?? 3600;
+
+  return new jose.SignJWT({
+    email: payload.email,
+    domain: payload.domain,
+    role: payload.role,
+  })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(payload.email)
+    .setIssuer(options.serverUrl)
+    .setAudience(options.serverUrl)
+    .setIssuedAt()
+    .setExpirationTime(`${expiresIn}s`)
+    .sign(secretKey);
+}
+
+/**
+ * MCP アクセストークン（JWT）を検証し、クレームを返す。
+ *
+ * 検証項目:
+ *   - 署名（HS256）
+ *   - 有効期限（exp）
+ *   - Audience（MCP サーバー URL と一致）
+ *   - Issuer（MCP サーバー URL と一致）
+ */
+export async function verifyAccessToken(
+  token: string,
+  secret: string,
+  serverUrl: string,
+): Promise<McpTokenClaims> {
+  const secretKey = new TextEncoder().encode(secret);
+
+  const { payload } = await jose.jwtVerify(token, secretKey, {
+    issuer: serverUrl,
+    audience: serverUrl,
+  });
+
+  const email = payload.email as string | undefined;
+  const domain = payload.domain as string | undefined;
+  const role = payload.role as string | undefined;
+
+  if (!email || !domain || !role) {
+    throw new Error("Invalid token: missing required claims (email, domain, role)");
+  }
+
+  if (role !== "admin" && role !== "readonly") {
+    throw new Error(`Invalid token: invalid role claim: ${role}`);
+  }
+
+  return {
+    sub: payload.sub ?? email,
+    iss: payload.iss ?? serverUrl,
+    aud: typeof payload.aud === "string" ? payload.aud : serverUrl,
+    email,
+    domain,
+    role,
+  };
+}

--- a/packages/mcp-smarthr/src/core/oauth/jwt.ts
+++ b/packages/mcp-smarthr/src/core/oauth/jwt.ts
@@ -9,6 +9,7 @@
  */
 
 import * as jose from "jose";
+import type { Role } from "../middleware/pii-filter.js";
 
 export interface McpTokenPayload {
   /** ユーザーメールアドレス */
@@ -16,7 +17,7 @@ export interface McpTokenPayload {
   /** Google Workspace ドメイン */
   domain: string;
   /** ユーザーロール */
-  role: "admin" | "readonly";
+  role: Role;
 }
 
 export interface McpTokenClaims extends McpTokenPayload {

--- a/packages/mcp-smarthr/src/core/oauth/routes.ts
+++ b/packages/mcp-smarthr/src/core/oauth/routes.ts
@@ -1,0 +1,442 @@
+/**
+ * OAuth 2.1 Authorization Server ルート定義（Hono）
+ *
+ * MCP 仕様準拠の「意図的に狭い AS」:
+ *   - authorization_code + PKCE のみ
+ *   - リフレッシュトークンなし
+ *   - 短寿命アクセストークン（JWT）
+ *   - Google OIDC への認証委譲
+ *   - Dynamic Client Registration（匿名、厳格な登録ポリシー）
+ */
+
+import { createHash, randomBytes } from "node:crypto";
+import { Hono } from "hono";
+import type { UserStore } from "../middleware/auth.js";
+import {
+  buildAuthServerMetadata,
+  buildProtectedResourceMetadata,
+  GOOGLE_OIDC,
+  type OAuthConfig,
+} from "./config.js";
+import { issueAccessToken } from "./jwt.js";
+
+/** 認可コード（一時的、メモリ保持、TTL 付き） */
+interface AuthCodeEntry {
+  /** Google から取得したユーザー email */
+  email: string;
+  /** Google Workspace ドメイン */
+  domain: string;
+  /** PKCE code_challenge（S256） */
+  codeChallenge: string;
+  /** クライアント ID */
+  clientId: string;
+  /** リダイレクト URI */
+  redirectUri: string;
+  /** MCP リソース URI（RFC 8707） */
+  resource?: string;
+  /** 有効期限 */
+  expiresAt: number;
+}
+
+/** Dynamic Client Registration エントリ */
+interface RegisteredClient {
+  clientId: string;
+  clientSecret?: string;
+  redirectUris: string[];
+  clientName?: string;
+  tokenEndpointAuthMethod: string;
+}
+
+const AUTH_CODE_TTL_MS = 5 * 60 * 1000; // 5分
+
+export function createOAuthRoutes(config: OAuthConfig, userStore: UserStore): Hono {
+  const app = new Hono();
+
+  // インメモリストア（Cloud Run 1 インスタンス前提）
+  const authCodes = new Map<string, AuthCodeEntry>();
+  const registeredClients = new Map<string, RegisteredClient>();
+  // state → { codeChallenge, clientId, redirectUri, resource } の一時保存
+  const pendingAuths = new Map<
+    string,
+    {
+      codeChallenge: string;
+      clientId: string;
+      redirectUri: string;
+      resource?: string;
+      expiresAt: number;
+    }
+  >();
+
+  const serverUrl = config.serverUrl.replace(/\/$/, "");
+
+  // 期限切れエントリのクリーンアップ
+  function cleanup() {
+    const now = Date.now();
+    for (const [key, entry] of authCodes) {
+      if (now > entry.expiresAt) authCodes.delete(key);
+    }
+    for (const [key, entry] of pendingAuths) {
+      if (now > entry.expiresAt) pendingAuths.delete(key);
+    }
+  }
+
+  // --- RFC 9728: Protected Resource Metadata ---
+  app.get("/.well-known/oauth-protected-resource", (c) => {
+    return c.json(buildProtectedResourceMetadata(serverUrl));
+  });
+
+  // --- RFC 8414: Authorization Server Metadata ---
+  app.get("/.well-known/oauth-authorization-server", (c) => {
+    return c.json(buildAuthServerMetadata(serverUrl));
+  });
+
+  // --- GET /authorize: OAuth 2.1 Authorization Endpoint ---
+  app.get("/authorize", (c) => {
+    cleanup();
+
+    const responseType = c.req.query("response_type");
+    const clientId = c.req.query("client_id");
+    const redirectUri = c.req.query("redirect_uri");
+    const codeChallenge = c.req.query("code_challenge");
+    const codeChallengeMethod = c.req.query("code_challenge_method");
+    const state = c.req.query("state");
+    const resource = c.req.query("resource");
+
+    // バリデーション
+    if (responseType !== "code") {
+      return c.json({ error: "unsupported_response_type" }, 400);
+    }
+    if (!clientId || !redirectUri) {
+      return c.json(
+        { error: "invalid_request", error_description: "client_id and redirect_uri required" },
+        400,
+      );
+    }
+    if (!codeChallenge || codeChallengeMethod !== "S256") {
+      return c.json(
+        { error: "invalid_request", error_description: "PKCE with S256 required" },
+        400,
+      );
+    }
+
+    // 登録済みクライアントの場合、redirect_uri を検証
+    const client = registeredClients.get(clientId);
+    if (client && !client.redirectUris.includes(redirectUri)) {
+      return c.json({ error: "invalid_request", error_description: "redirect_uri mismatch" }, 400);
+    }
+
+    // state を生成して pending に保存
+    const internalState = randomBytes(32).toString("hex");
+    pendingAuths.set(internalState, {
+      codeChallenge,
+      clientId,
+      redirectUri,
+      resource,
+      expiresAt: Date.now() + AUTH_CODE_TTL_MS,
+    });
+
+    // Google OIDC にリダイレクト
+    const googleParams = new URLSearchParams({
+      client_id: config.googleClientId,
+      redirect_uri: `${serverUrl}/oauth/callback`,
+      response_type: "code",
+      scope: "openid email profile",
+      access_type: "online",
+      state: internalState,
+      hd: config.allowedDomain ?? "aozora-cg.com",
+      prompt: "consent",
+    });
+
+    // 元のクライアント state を callback 時に redirectUri に付与するため一時保管
+    if (state) {
+      const pending = pendingAuths.get(internalState);
+      if (pending) {
+        (pending as Record<string, unknown>).clientState = state;
+      }
+    }
+
+    return c.redirect(`${GOOGLE_OIDC.authorizationEndpoint}?${googleParams}`);
+  });
+
+  // --- GET /oauth/callback: Google OIDC Callback ---
+  app.get("/oauth/callback", async (c) => {
+    const googleCode = c.req.query("code");
+    const internalState = c.req.query("state");
+    const error = c.req.query("error");
+
+    if (error) {
+      return c.json({ error: "access_denied", error_description: error }, 400);
+    }
+
+    if (!googleCode || !internalState) {
+      return c.json({ error: "invalid_request" }, 400);
+    }
+
+    const pending = pendingAuths.get(internalState);
+    if (!pending || Date.now() > pending.expiresAt) {
+      pendingAuths.delete(internalState ?? "");
+      return c.json(
+        { error: "invalid_request", error_description: "expired or invalid state" },
+        400,
+      );
+    }
+    pendingAuths.delete(internalState);
+
+    // Google 認可コードをトークンに交換してユーザー情報を取得
+    let email: string;
+    let domain: string;
+    try {
+      const tokenRes = await fetch(GOOGLE_OIDC.tokenEndpoint, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          code: googleCode,
+          client_id: config.googleClientId,
+          client_secret: config.googleClientSecret,
+          redirect_uri: `${serverUrl}/oauth/callback`,
+          grant_type: "authorization_code",
+        }),
+      });
+
+      if (!tokenRes.ok) {
+        const body = await tokenRes.text();
+        console.error(
+          JSON.stringify({
+            severity: "ERROR",
+            message: "Google token exchange failed",
+            status: tokenRes.status,
+            body,
+            source: "mcp-smarthr",
+          }),
+        );
+        return c.json(
+          { error: "server_error", error_description: "Google token exchange failed" },
+          500,
+        );
+      }
+
+      const tokenData = (await tokenRes.json()) as { access_token: string; id_token?: string };
+
+      // userinfo で email と hd を取得
+      const userinfoRes = await fetch(GOOGLE_OIDC.userinfoEndpoint, {
+        headers: { Authorization: `Bearer ${tokenData.access_token}` },
+      });
+
+      if (!userinfoRes.ok) {
+        return c.json(
+          { error: "server_error", error_description: "Failed to fetch user info" },
+          500,
+        );
+      }
+
+      const userinfo = (await userinfoRes.json()) as { email: string; hd?: string };
+      email = userinfo.email;
+      domain = userinfo.hd ?? email.split("@")[1] ?? "";
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          severity: "ERROR",
+          message: "OAuth callback error",
+          error: err instanceof Error ? err.message : String(err),
+          source: "mcp-smarthr",
+        }),
+      );
+      return c.json({ error: "server_error" }, 500);
+    }
+
+    // ドメイン検証
+    const allowedDomain = config.allowedDomain ?? "aozora-cg.com";
+    if (domain !== allowedDomain) {
+      return c.json(
+        {
+          error: "access_denied",
+          error_description: `Domain ${domain} is not allowed. Only ${allowedDomain} users can access.`,
+        },
+        403,
+      );
+    }
+
+    // 認可コード発行（一回限り使用）
+    const authCode = randomBytes(32).toString("hex");
+    authCodes.set(authCode, {
+      email,
+      domain,
+      codeChallenge: pending.codeChallenge,
+      clientId: pending.clientId,
+      redirectUri: pending.redirectUri,
+      resource: pending.resource,
+      expiresAt: Date.now() + AUTH_CODE_TTL_MS,
+    });
+
+    // クライアントの redirect_uri に認可コードを返す
+    const redirectUrl = new URL(pending.redirectUri);
+    redirectUrl.searchParams.set("code", authCode);
+    const clientState = (pending as Record<string, unknown>).clientState as string | undefined;
+    if (clientState) {
+      redirectUrl.searchParams.set("state", clientState);
+    }
+
+    return c.redirect(redirectUrl.toString());
+  });
+
+  // --- POST /token: Token Endpoint ---
+  app.post("/token", async (c) => {
+    cleanup();
+
+    const body = await c.req.parseBody();
+    const grantType = body.grant_type as string | undefined;
+    const code = body.code as string | undefined;
+    const codeVerifier = body.code_verifier as string | undefined;
+    const clientId = body.client_id as string | undefined;
+    const redirectUri = body.redirect_uri as string | undefined;
+
+    if (grantType !== "authorization_code") {
+      return c.json({ error: "unsupported_grant_type" }, 400);
+    }
+
+    if (!code || !codeVerifier || !clientId) {
+      return c.json(
+        { error: "invalid_request", error_description: "code, code_verifier, client_id required" },
+        400,
+      );
+    }
+
+    const entry = authCodes.get(code);
+    if (!entry) {
+      return c.json(
+        { error: "invalid_grant", error_description: "invalid or expired authorization code" },
+        400,
+      );
+    }
+
+    // 一回限り使用 — 即座に削除
+    authCodes.delete(code);
+
+    // 有効期限チェック
+    if (Date.now() > entry.expiresAt) {
+      return c.json(
+        { error: "invalid_grant", error_description: "authorization code expired" },
+        400,
+      );
+    }
+
+    // クライアント ID 一致チェック
+    if (entry.clientId !== clientId) {
+      return c.json({ error: "invalid_grant", error_description: "client_id mismatch" }, 400);
+    }
+
+    // redirect_uri 一致チェック
+    if (redirectUri && entry.redirectUri !== redirectUri) {
+      return c.json({ error: "invalid_grant", error_description: "redirect_uri mismatch" }, 400);
+    }
+
+    // PKCE 検証（S256）
+    const expectedChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
+    if (expectedChallenge !== entry.codeChallenge) {
+      return c.json({ error: "invalid_grant", error_description: "PKCE verification failed" }, 400);
+    }
+
+    // UserStore からロールを取得
+    const user = await userStore.getUser(entry.email);
+    const role = user?.role ?? "readonly";
+    const enabled = user?.enabled ?? true;
+
+    if (!enabled) {
+      return c.json({ error: "access_denied", error_description: "user is disabled" }, 403);
+    }
+
+    // JWT アクセストークン発行
+    const expiresIn = config.jwtExpiresIn ?? 3600;
+    const accessToken = await issueAccessToken(
+      { email: entry.email, domain: entry.domain, role },
+      config.jwtSecret,
+      { serverUrl, expiresIn },
+    );
+
+    return c.json({
+      access_token: accessToken,
+      token_type: "Bearer",
+      expires_in: expiresIn,
+      scope: role === "admin" ? "mcp:read mcp:write" : "mcp:read",
+    });
+  });
+
+  // --- POST /register: Dynamic Client Registration (RFC 7591) ---
+  app.post("/register", async (c) => {
+    let body: Record<string, unknown>;
+    try {
+      body = (await c.req.json()) as Record<string, unknown>;
+    } catch {
+      return c.json({ error: "invalid_client_metadata" }, 400);
+    }
+
+    const redirectUris = body.redirect_uris;
+    if (!Array.isArray(redirectUris) || redirectUris.length === 0) {
+      return c.json(
+        {
+          error: "invalid_client_metadata",
+          error_description: "redirect_uris required",
+        },
+        400,
+      );
+    }
+
+    // redirect_uri 検証: localhost または HTTPS のみ許可
+    for (const uri of redirectUris) {
+      if (typeof uri !== "string") {
+        return c.json(
+          { error: "invalid_client_metadata", error_description: "invalid redirect_uri" },
+          400,
+        );
+      }
+      try {
+        const parsed = new URL(uri);
+        const isLocalhost = parsed.hostname === "localhost" || parsed.hostname === "127.0.0.1";
+        if (!isLocalhost && parsed.protocol !== "https:") {
+          return c.json(
+            {
+              error: "invalid_client_metadata",
+              error_description: "redirect_uri must use HTTPS or localhost",
+            },
+            400,
+          );
+        }
+      } catch {
+        return c.json(
+          { error: "invalid_client_metadata", error_description: "invalid redirect_uri format" },
+          400,
+        );
+      }
+    }
+
+    const clientId = randomBytes(16).toString("hex");
+    const clientSecret = randomBytes(32).toString("hex");
+    const authMethod = (body.token_endpoint_auth_method as string) ?? "client_secret_post";
+
+    const client: RegisteredClient = {
+      clientId,
+      clientSecret: authMethod === "none" ? undefined : clientSecret,
+      redirectUris: redirectUris as string[],
+      clientName: body.client_name as string | undefined,
+      tokenEndpointAuthMethod: authMethod,
+    };
+
+    registeredClients.set(clientId, client);
+
+    return c.json(
+      {
+        client_id: clientId,
+        client_secret: client.clientSecret,
+        client_id_issued_at: Math.floor(Date.now() / 1000),
+        redirect_uris: client.redirectUris,
+        client_name: client.clientName,
+        token_endpoint_auth_method: client.tokenEndpointAuthMethod,
+        grant_types: ["authorization_code"],
+        response_types: ["code"],
+      },
+      201,
+    );
+  });
+
+  return app;
+}

--- a/packages/mcp-smarthr/src/core/oauth/routes.ts
+++ b/packages/mcp-smarthr/src/core/oauth/routes.ts
@@ -63,11 +63,25 @@ export function createOAuthRoutes(config: OAuthConfig, userStore: UserStore): Ho
       clientId: string;
       redirectUri: string;
       resource?: string;
+      clientState?: string;
       expiresAt: number;
     }
   >();
 
   const serverUrl = config.serverUrl.replace(/\/$/, "");
+  const MAX_REGISTERED_CLIENTS = 100;
+
+  /** セキュリティイベントをログに記録する */
+  function logSecurityEvent(event: string, details?: Record<string, unknown>) {
+    console.log(
+      JSON.stringify({
+        severity: "WARNING",
+        message: event,
+        ...details,
+        source: "mcp-smarthr",
+      }),
+    );
+  }
 
   // 期限切れエントリのクリーンアップ
   function cleanup() {
@@ -151,7 +165,7 @@ export function createOAuthRoutes(config: OAuthConfig, userStore: UserStore): Ho
     if (state) {
       const pending = pendingAuths.get(internalState);
       if (pending) {
-        (pending as Record<string, unknown>).clientState = state;
+        pending.clientState = state;
       }
     }
 
@@ -247,10 +261,19 @@ export function createOAuthRoutes(config: OAuthConfig, userStore: UserStore): Ho
     // ドメイン検証
     const allowedDomain = config.allowedDomain ?? "aozora-cg.com";
     if (domain !== allowedDomain) {
+      console.log(
+        JSON.stringify({
+          severity: "WARNING",
+          message: "Domain validation failed",
+          userDomain: domain,
+          allowedDomain,
+          source: "mcp-smarthr",
+        }),
+      );
       return c.json(
         {
           error: "access_denied",
-          error_description: `Domain ${domain} is not allowed. Only ${allowedDomain} users can access.`,
+          error_description: "Your account is not authorized to access this resource.",
         },
         403,
       );
@@ -271,7 +294,7 @@ export function createOAuthRoutes(config: OAuthConfig, userStore: UserStore): Ho
     // クライアントの redirect_uri に認可コードを返す
     const redirectUrl = new URL(pending.redirectUri);
     redirectUrl.searchParams.set("code", authCode);
-    const clientState = (pending as Record<string, unknown>).clientState as string | undefined;
+    const clientState = pending.clientState;
     if (clientState) {
       redirectUrl.searchParams.set("state", clientState);
     }
@@ -314,6 +337,7 @@ export function createOAuthRoutes(config: OAuthConfig, userStore: UserStore): Ho
 
     // 有効期限チェック
     if (Date.now() > entry.expiresAt) {
+      logSecurityEvent("Authorization code expired", { clientId });
       return c.json(
         { error: "invalid_grant", error_description: "authorization code expired" },
         400,
@@ -322,51 +346,109 @@ export function createOAuthRoutes(config: OAuthConfig, userStore: UserStore): Ho
 
     // クライアント ID 一致チェック
     if (entry.clientId !== clientId) {
+      logSecurityEvent("Client ID mismatch in token exchange", {
+        expected: entry.clientId,
+        received: clientId,
+      });
       return c.json({ error: "invalid_grant", error_description: "client_id mismatch" }, 400);
     }
 
-    // redirect_uri 一致チェック
-    if (redirectUri && entry.redirectUri !== redirectUri) {
+    // redirect_uri 一致チェック（OAuth 2.1: 必須）
+    if (!redirectUri || entry.redirectUri !== redirectUri) {
+      logSecurityEvent("redirect_uri mismatch in token exchange", { clientId });
       return c.json({ error: "invalid_grant", error_description: "redirect_uri mismatch" }, 400);
     }
 
     // PKCE 検証（S256）
     const expectedChallenge = createHash("sha256").update(codeVerifier).digest("base64url");
     if (expectedChallenge !== entry.codeChallenge) {
+      logSecurityEvent("PKCE verification failed", { clientId });
       return c.json({ error: "invalid_grant", error_description: "PKCE verification failed" }, 400);
     }
 
-    // UserStore からロールを取得
-    const user = await userStore.getUser(entry.email);
-    const role = user?.role ?? "readonly";
-    const enabled = user?.enabled ?? true;
+    // UserStore からロールを取得（fail-closed: エラー時はアクセス拒否）
+    let user: Awaited<ReturnType<typeof userStore.getUser>>;
+    try {
+      user = await userStore.getUser(entry.email);
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          severity: "ERROR",
+          message: "UserStore lookup failed",
+          email: entry.email,
+          error: err instanceof Error ? err.message : String(err),
+          source: "mcp-smarthr",
+        }),
+      );
+      return c.json(
+        { error: "server_error", error_description: "Unable to verify user permissions" },
+        500,
+      );
+    }
 
-    if (!enabled) {
-      return c.json({ error: "access_denied", error_description: "user is disabled" }, 403);
+    // fail-closed: 未登録ユーザーはアクセス拒否
+    if (!user) {
+      console.log(
+        JSON.stringify({
+          severity: "WARNING",
+          message: "User not found in store",
+          email: entry.email,
+          source: "mcp-smarthr",
+        }),
+      );
+      return c.json({ error: "access_denied", error_description: "User not provisioned" }, 403);
+    }
+
+    if (!user.enabled) {
+      return c.json({ error: "access_denied", error_description: "User account is disabled" }, 403);
     }
 
     // JWT アクセストークン発行
     const expiresIn = config.jwtExpiresIn ?? 3600;
-    const accessToken = await issueAccessToken(
-      { email: entry.email, domain: entry.domain, role },
-      config.jwtSecret,
-      { serverUrl, expiresIn },
-    );
+    let accessToken: string;
+    try {
+      accessToken = await issueAccessToken(
+        { email: entry.email, domain: entry.domain, role: user.role },
+        config.jwtSecret,
+        { serverUrl, expiresIn },
+      );
+    } catch (err) {
+      console.error(
+        JSON.stringify({
+          severity: "ERROR",
+          message: "JWT issuance failed",
+          error: err instanceof Error ? err.message : String(err),
+          source: "mcp-smarthr",
+        }),
+      );
+      return c.json({ error: "server_error" }, 500);
+    }
 
     return c.json({
       access_token: accessToken,
       token_type: "Bearer",
       expires_in: expiresIn,
-      scope: role === "admin" ? "mcp:read mcp:write" : "mcp:read",
+      scope: user.role === "admin" ? "mcp:read mcp:write" : "mcp:read",
     });
   });
 
   // --- POST /register: Dynamic Client Registration (RFC 7591) ---
   app.post("/register", async (c) => {
+    // サイズ上限チェック（DoS 防止）
+    if (registeredClients.size >= MAX_REGISTERED_CLIENTS) {
+      return c.json(
+        { error: "server_error", error_description: "Registration limit reached" },
+        503,
+      );
+    }
+
     let body: Record<string, unknown>;
     try {
       body = (await c.req.json()) as Record<string, unknown>;
-    } catch {
+    } catch (err) {
+      logSecurityEvent("Invalid JSON in client registration", {
+        error: err instanceof Error ? err.message : String(err),
+      });
       return c.json({ error: "invalid_client_metadata" }, 400);
     }
 

--- a/packages/mcp-smarthr/src/core/server.ts
+++ b/packages/mcp-smarthr/src/core/server.ts
@@ -99,7 +99,11 @@ export function createMcpServer(options: CreateServerOptions): McpServer {
 
         if (!authResult.authorized) {
           const reason = authResult.reason ?? "アクセスが拒否されました";
-          await auditLogger.logDenied(name, authContext.email, params, reason);
+          try {
+            await auditLogger.logDenied(name, authContext.email, params, reason);
+          } catch {
+            // 監査ログの失敗がツールレスポンスをブロックしないようにする
+          }
           return {
             content: [{ type: "text" as const, text: `アクセス拒否: ${reason}` }],
             isError: true,

--- a/packages/mcp-smarthr/src/core/server.ts
+++ b/packages/mcp-smarthr/src/core/server.ts
@@ -49,89 +49,93 @@ export function createMcpServer(options: CreateServerOptions): McpServer {
   for (const [name, tool] of Object.entries(tools)) {
     if (!(name in TOOL_PERMISSIONS)) continue;
 
-    server.tool(name, tool.description, tool.shape, async (params: Record<string, unknown>) => {
-      // --- fail-closed: 認証コンテキスト解決・認可チェックの失敗はアクセス拒否 ---
-      let authContext: AuthContext;
-      try {
-        authContext = resolveAuthContext();
-      } catch (error) {
-        console.error(
-          JSON.stringify({
-            severity: "ERROR",
-            message: "Failed to resolve auth context",
-            tool: name,
-            error: error instanceof Error ? error.message : String(error),
-            source: "mcp-smarthr",
-          }),
-        );
-        return {
-          content: [{ type: "text" as const, text: "Error: 認証コンテキストの解決に失敗しました" }],
-          isError: true,
-        };
-      }
-
-      let authResult: Awaited<ReturnType<typeof authorizer.authorize>>;
-      try {
-        authResult = await authorizer.authorize(authContext, name);
-      } catch (error) {
-        console.error(
-          JSON.stringify({
-            severity: "ERROR",
-            message: "Authorization system failure - denying access",
-            tool: name,
-            email: authContext.email,
-            error: error instanceof Error ? error.message : String(error),
-            source: "mcp-smarthr",
-          }),
-        );
-        return {
-          content: [{ type: "text" as const, text: "Error: 認証システムエラー" }],
-          isError: true,
-        };
-      }
-
-      if (!authResult.authorized) {
-        // 拒否時も監査ログを記録（失敗しても拒否レスポンスは返す）
+    server.tool(
+      name,
+      tool.description,
+      tool.shape,
+      tool.annotations,
+      async (params: Record<string, unknown>) => {
+        // --- fail-closed: 認証コンテキスト解決・認可チェックの失敗はアクセス拒否 ---
+        let authContext: AuthContext;
         try {
-          await auditLogger.logToolCall(name, authContext.email, params, async () => {
-            throw new Error(authResult.reason ?? "アクセスが拒否されました");
-          });
-        } catch {
-          // logToolCall は内部で fn の throw を re-throw するため、ここで捕捉する
-          // 監査ログの出力自体は logToolCall の finally ブロックで完了済み
+          authContext = resolveAuthContext();
+        } catch (error) {
+          console.error(
+            JSON.stringify({
+              severity: "ERROR",
+              message: "Failed to resolve auth context",
+              tool: name,
+              error: error instanceof Error ? error.message : String(error),
+              source: "mcp-smarthr",
+            }),
+          );
+          return {
+            content: [
+              { type: "text" as const, text: "Error: 認証コンテキストの解決に失敗しました" },
+            ],
+            isError: true,
+          };
         }
-        return {
-          content: [{ type: "text" as const, text: `アクセス拒否: ${authResult.reason}` }],
-          isError: true,
-        };
-      }
 
-      // 認可OK → 監査ログ付きでハンドラ実行 → PII フィルタ適用
-      try {
-        const result: unknown = await auditLogger.logToolCall(name, authContext.email, params, () =>
-          tool.handler(params as never),
-        );
+        let authResult: Awaited<ReturnType<typeof authorizer.authorize>>;
+        try {
+          authResult = await authorizer.authorize(authContext, name);
+        } catch (error) {
+          console.error(
+            JSON.stringify({
+              severity: "ERROR",
+              message: "Authorization system failure - denying access",
+              tool: name,
+              email: authContext.email,
+              error: error instanceof Error ? error.message : String(error),
+              source: "mcp-smarthr",
+            }),
+          );
+          return {
+            content: [{ type: "text" as const, text: "Error: 認証システムエラー" }],
+            isError: true,
+          };
+        }
 
-        // handler はオブジェクトを返すため、直接 PII フィルタを適用
-        const filtered = filterPII(result, authResult.role);
-        return { content: [{ type: "text" as const, text: JSON.stringify(filtered, null, 2) }] };
-      } catch (error) {
-        // エラーメッセージに PII が含まれる可能性があるため、汎用メッセージを返す
-        console.error(
-          JSON.stringify({
-            severity: "ERROR",
-            message: error instanceof Error ? error.message : String(error),
-            tool: name,
-            email: authContext.email,
-            source: "mcp-smarthr",
-          }),
-        );
-        return {
-          content: [{ type: "text" as const, text: "Error: ツール実行中にエラーが発生しました" }],
-          isError: true,
-        };
-      }
-    });
+        if (!authResult.authorized) {
+          const reason = authResult.reason ?? "アクセスが拒否されました";
+          await auditLogger.logDenied(name, authContext.email, params, reason);
+          return {
+            content: [{ type: "text" as const, text: `アクセス拒否: ${reason}` }],
+            isError: true,
+          };
+        }
+
+        // 認可OK → 監査ログ付きでハンドラ実行 → PII フィルタ適用
+        try {
+          const result: unknown = await auditLogger.logToolCall(
+            name,
+            authContext.email,
+            params,
+            () => tool.handler(params as never),
+          );
+
+          // handler はオブジェクトを返すため、直接 PII フィルタを適用
+          const filtered = filterPII(result, authResult.role);
+          return { content: [{ type: "text" as const, text: JSON.stringify(filtered, null, 2) }] };
+        } catch (error) {
+          // エラーメッセージに PII が含まれる可能性があるため、汎用メッセージを返す
+          console.error(
+            JSON.stringify({
+              severity: "ERROR",
+              message: error instanceof Error ? error.message : String(error),
+              tool: name,
+              email: authContext.email,
+              source: "mcp-smarthr",
+            }),
+          );
+          return {
+            content: [{ type: "text" as const, text: "Error: ツール実行中にエラーが発生しました" }],
+            isError: true,
+          };
+        }
+      },
+    );
   }
 
   return server;

--- a/packages/mcp-smarthr/src/core/stores/firestore-user-store.ts
+++ b/packages/mcp-smarthr/src/core/stores/firestore-user-store.ts
@@ -1,0 +1,70 @@
+/**
+ * Firestore ベースの UserStore 実装
+ *
+ * コレクション: mcp-users/{email}
+ * ドキュメント構造: { role: "admin" | "readonly", enabled: boolean, createdAt, updatedAt }
+ *
+ * Cloud Run 上では ADC（Application Default Credentials）で認証。
+ * SA `mcp-smarthr@` に Firestore User 権限が付与済み。
+ */
+
+import { Firestore } from "@google-cloud/firestore";
+import type { Role } from "../middleware/pii-filter.js";
+
+const COLLECTION = "mcp-users";
+
+export interface UserDocument {
+  role: Role;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export class FirestoreUserStore {
+  private readonly db: Firestore;
+  private readonly collection: string;
+
+  constructor(options?: { projectId?: string; collection?: string }) {
+    this.db = new Firestore({
+      projectId: options?.projectId,
+      // Cloud Run 上では ADC で自動認証
+    });
+    this.collection = options?.collection ?? COLLECTION;
+  }
+
+  async getUser(email: string): Promise<{ role: Role; enabled: boolean } | null> {
+    const doc = await this.db.collection(this.collection).doc(email).get();
+    if (!doc.exists) return null;
+
+    const data = doc.data() as UserDocument | undefined;
+    if (!data) return null;
+
+    return {
+      role: data.role,
+      enabled: data.enabled,
+    };
+  }
+
+  /** ユーザーを追加・更新する（管理用） */
+  async setUser(email: string, role: Role, enabled = true): Promise<void> {
+    const now = new Date().toISOString();
+    const ref = this.db.collection(this.collection).doc(email);
+    const existing = await ref.get();
+
+    if (existing.exists) {
+      await ref.update({ role, enabled, updatedAt: now });
+    } else {
+      const doc: UserDocument = { role, enabled, createdAt: now, updatedAt: now };
+      await ref.set(doc);
+    }
+  }
+
+  /** ユーザー一覧を取得する（管理用） */
+  async listUsers(): Promise<Array<{ email: string } & UserDocument>> {
+    const snapshot = await this.db.collection(this.collection).get();
+    return snapshot.docs.map((doc) => ({
+      email: doc.id,
+      ...(doc.data() as UserDocument),
+    }));
+  }
+}

--- a/packages/mcp-smarthr/src/core/tools.ts
+++ b/packages/mcp-smarthr/src/core/tools.ts
@@ -19,9 +19,22 @@ const TOOL_NAMES = [
 
 export type ToolName = (typeof TOOL_NAMES)[number];
 
+/** MCP ツールアノテーション（readOnlyHint, destructiveHint 等） */
+export interface ToolAnnotation {
+  /** true = 読み取り専用（副作用なし） */
+  readOnlyHint?: boolean;
+  /** true = 破壊的操作（データ削除等） */
+  destructiveHint?: boolean;
+  /** true = 同じパラメータで複数回呼んでも結果が変わらない */
+  idempotentHint?: boolean;
+  /** ツール表示名（人間向け） */
+  title?: string;
+}
+
 interface ToolDefinition {
   description: string;
-  shape: Record<string, unknown>;
+  shape: Record<string, z.ZodTypeAny>;
+  annotations: ToolAnnotation;
   handler: (params: never) => Promise<unknown>;
 }
 
@@ -31,6 +44,7 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
     list_employees: {
       description: "SmartHRの従業員一覧を取得します。ページネーション対応。",
       shape: paginationShape,
+      annotations: { readOnlyHint: true, idempotentHint: true, title: "従業員一覧" },
       handler: async (params: { page?: number; per_page?: number }) => {
         const result = await client.listEmployees(params);
         return formatListResult("従業員", result.data, result.totalCount);
@@ -42,6 +56,7 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
       shape: {
         id: z.string().describe("SmartHR従業員ID"),
       },
+      annotations: { readOnlyHint: true, idempotentHint: true, title: "従業員詳細" },
       handler: async (params: { id: string }) => {
         return await client.getEmployee(params.id);
       },
@@ -53,6 +68,7 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
         query: z.string().describe("検索キーワード（名前、社員番号等）"),
         ...paginationShape,
       },
+      annotations: { readOnlyHint: true, idempotentHint: true, title: "従業員検索" },
       handler: async (params: { query: string; page?: number; per_page?: number }) => {
         const result = await client.searchEmployees(params.query, {
           page: params.page,
@@ -63,7 +79,9 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
     },
 
     get_pay_statements: {
-      description: "SmartHRの給与明細を取得します。従業員ID・年・月で絞り込み可能。",
+      description:
+        "SmartHRの給与明細を取得します。従業員ID・年・月で絞り込み可能。admin権限が必要です。",
+      annotations: { readOnlyHint: true, idempotentHint: true, title: "給与明細" },
       shape: {
         crew_id: z.string().optional().describe("従業員ID（絞り込み）"),
         year: z.number().int().optional().describe("年（例: 2026）"),
@@ -85,6 +103,7 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
     list_departments: {
       description: "SmartHRの部署一覧を取得します。",
       shape: paginationShape,
+      annotations: { readOnlyHint: true, idempotentHint: true, title: "部署一覧" },
       handler: async (params: { page?: number; per_page?: number }) => {
         const result = await client.listDepartments(params);
         return formatListResult("部署", result.data, result.totalCount);
@@ -94,6 +113,7 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
     list_positions: {
       description: "SmartHRの役職一覧を取得します。",
       shape: paginationShape,
+      annotations: { readOnlyHint: true, idempotentHint: true, title: "役職一覧" },
       handler: async (params: { page?: number; per_page?: number }) => {
         const result = await client.listPositions(params);
         return formatListResult("役職", result.data, result.totalCount);

--- a/packages/mcp-smarthr/src/serve.ts
+++ b/packages/mcp-smarthr/src/serve.ts
@@ -11,16 +11,31 @@
  */
 
 import type { UserStore } from "./core/middleware/auth.js";
+import { FirestoreUserStore } from "./core/stores/firestore-user-store.js";
 import { startHttp } from "./shells/http.js";
 
-/** HTTP 用の簡易 UserStore（将来 Firestore に差し替え） */
-const httpUserStore: UserStore = {
-  async getUser(_email: string) {
-    // Phase C で Firestore ベースの実装に差し替え予定
-    // 現時点では全ドメイン内ユーザーを readonly として許可
-    return { role: "readonly" as const, enabled: true };
-  },
-};
+/** UserStore を環境変数で切り替え */
+function createUserStore(): UserStore {
+  if (process.env.USE_FIRESTORE_USER_STORE === "true") {
+    console.log(
+      JSON.stringify({
+        severity: "INFO",
+        message: "Using Firestore UserStore",
+        source: "mcp-smarthr",
+      }),
+    );
+    return new FirestoreUserStore();
+  }
+
+  // フォールバック: 全ドメイン内ユーザーを readonly として許可
+  return {
+    async getUser(_email: string) {
+      return { role: "readonly" as const, enabled: true };
+    },
+  };
+}
+
+const userStore = createUserStore();
 
 const apiKey = process.env.SMARTHR_API_KEY;
 const tenantId = process.env.SMARTHR_TENANT_ID;
@@ -55,7 +70,7 @@ startHttp({
   smarthrTenantId: tenantId,
   googleClientId,
   allowedDomain: process.env.ALLOWED_DOMAIN ?? "aozora-cg.com",
-  userStore: httpUserStore,
+  userStore,
   port: Number(process.env.PORT) || 8080,
   authDisabled: process.env.AUTH_DISABLED === "true",
   ipRestrictionEnabled: process.env.IP_RESTRICTION_ENABLED === "true",

--- a/packages/mcp-smarthr/src/serve.ts
+++ b/packages/mcp-smarthr/src/serve.ts
@@ -27,7 +27,15 @@ function createUserStore(): UserStore {
     return new FirestoreUserStore();
   }
 
-  // フォールバック: 全ドメイン内ユーザーを readonly として許可
+  // フォールバック: 全ドメイン内ユーザーを readonly として許可（開発/デモ用）
+  console.log(
+    JSON.stringify({
+      severity: "WARNING",
+      message:
+        "Using in-memory UserStore — all domain users get readonly access. Set USE_FIRESTORE_USER_STORE=true for production.",
+      source: "mcp-smarthr",
+    }),
+  );
   return {
     async getUser(_email: string) {
       return { role: "readonly" as const, enabled: true };

--- a/packages/mcp-smarthr/src/serve.ts
+++ b/packages/mcp-smarthr/src/serve.ts
@@ -33,6 +33,23 @@ if (!apiKey || !tenantId || !googleClientId) {
   process.exit(1);
 }
 
+// OAuth 設定（環境変数が揃っている場合のみ有効化）
+const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+const jwtSecret = process.env.JWT_SECRET;
+const serverUrl = process.env.SERVER_URL;
+
+const oauthEnabled = !!(googleClientSecret && jwtSecret && serverUrl);
+if (oauthEnabled) {
+  console.log(
+    JSON.stringify({
+      severity: "INFO",
+      message: "OAuth 2.1 mode enabled",
+      serverUrl,
+      source: "mcp-smarthr",
+    }),
+  );
+}
+
 startHttp({
   smarthrApiKey: apiKey,
   smarthrTenantId: tenantId,
@@ -42,6 +59,15 @@ startHttp({
   port: Number(process.env.PORT) || 8080,
   authDisabled: process.env.AUTH_DISABLED === "true",
   ipRestrictionEnabled: process.env.IP_RESTRICTION_ENABLED === "true",
+  oauth:
+    oauthEnabled && googleClientSecret && jwtSecret && serverUrl
+      ? {
+          googleClientSecret,
+          jwtSecret,
+          serverUrl,
+          jwtExpiresIn: Number(process.env.JWT_EXPIRES_IN) || 3600,
+        }
+      : undefined,
 }).catch((error) => {
   console.error(
     JSON.stringify({

--- a/packages/mcp-smarthr/src/shells/http.ts
+++ b/packages/mcp-smarthr/src/shells/http.ts
@@ -173,10 +173,20 @@ export async function startHttp(options: HttpShellOptions): Promise<void> {
     );
   }
 
-  // CORS（MCP ヘッダーを expose）
+  // CORS（許可オリジンリスト + MCP ヘッダーを expose）
+  // claude.ai / Cowork からのサーバー間通信は CORS 対象外だが、
+  // ブラウザベースクライアント（自社アプリ等）のために設定
+  const allowedOrigins = [
+    "https://claude.ai",
+    "https://app.cowork.com",
+    ...(oauthConfig ? [oauthConfig.serverUrl] : []),
+  ];
   app.use(
     cors({
-      origin: "*",
+      origin: (origin) => {
+        if (!origin) return origin; // サーバー間通信（Origin なし）は許可
+        return allowedOrigins.includes(origin) ? origin : null;
+      },
       allowHeaders: ["Content-Type", "Authorization", "Mcp-Session-Id", "Mcp-Protocol-Version"],
       exposeHeaders: ["WWW-Authenticate", "Mcp-Session-Id", "Mcp-Protocol-Version"],
     }),

--- a/packages/mcp-smarthr/src/shells/http.ts
+++ b/packages/mcp-smarthr/src/shells/http.ts
@@ -19,6 +19,9 @@ import { OAuth2Client } from "google-auth-library";
 import { cors } from "hono/cors";
 import type { AuthContext, UserStore } from "../core/middleware/auth.js";
 import { createAuthContext } from "../core/middleware/auth.js";
+import type { OAuthConfig } from "../core/oauth/config.js";
+import { verifyAccessToken } from "../core/oauth/jwt.js";
+import { createOAuthRoutes } from "../core/oauth/routes.js";
 import { createMcpServer } from "../core/server.js";
 import { SmartHRClient } from "../core/smarthr-client.js";
 
@@ -33,6 +36,13 @@ export interface HttpShellOptions {
   authDisabled?: boolean;
   /** true にすると Anthropic IP 範囲のみ /mcp へのアクセスを許可する */
   ipRestrictionEnabled?: boolean;
+  /** OAuth 設定（指定時は OAuth 2.1 AS を有効化） */
+  oauth?: {
+    googleClientSecret: string;
+    jwtSecret: string;
+    serverUrl: string;
+    jwtExpiresIn?: number;
+  };
 }
 
 /**
@@ -138,6 +148,31 @@ export async function startHttp(options: HttpShellOptions): Promise<void> {
   const oauthClient = new OAuth2Client(googleClientId);
   const app = createMcpHonoApp({ host: "0.0.0.0" });
 
+  // OAuth 2.1 Authorization Server ルート（指定時のみ有効化）
+  const oauthConfig: OAuthConfig | undefined = options.oauth
+    ? {
+        serverUrl: options.oauth.serverUrl,
+        googleClientId,
+        googleClientSecret: options.oauth.googleClientSecret,
+        jwtSecret: options.oauth.jwtSecret,
+        jwtExpiresIn: options.oauth.jwtExpiresIn,
+        allowedDomain,
+      }
+    : undefined;
+
+  if (oauthConfig) {
+    const oauthRoutes = createOAuthRoutes(oauthConfig, userStore);
+    app.route("", oauthRoutes);
+    console.log(
+      JSON.stringify({
+        severity: "INFO",
+        message: "OAuth 2.1 Authorization Server enabled",
+        serverUrl: oauthConfig.serverUrl,
+        source: "mcp-smarthr",
+      }),
+    );
+  }
+
   // CORS（MCP ヘッダーを expose）
   app.use(
     cors({
@@ -213,8 +248,40 @@ export async function startHttp(options: HttpShellOptions): Promise<void> {
     if (authDisabled) {
       // デモモード: 認証スキップ、デフォルト AuthContext を使用
       authContext = createAuthContext("demo@aozora-cg.com", "http");
+    } else if (oauthConfig) {
+      // OAuth モード: 自前 JWT 検証
+      const authHeader = c.req.header("authorization");
+      if (!authHeader?.startsWith("Bearer ")) {
+        const resourceMetadataUrl = `${oauthConfig.serverUrl}/.well-known/oauth-protected-resource`;
+        c.header(
+          "WWW-Authenticate",
+          `Bearer resource_metadata="${resourceMetadataUrl}", scope="mcp:read"`,
+        );
+        return c.json({ error: "Authorization required" }, 401);
+      }
+
+      const token = authHeader.slice(7);
+      try {
+        const claims = await verifyAccessToken(token, oauthConfig.jwtSecret, oauthConfig.serverUrl);
+        authContext = createAuthContext(claims.email, "http", claims.domain);
+      } catch (error) {
+        console.error(
+          JSON.stringify({
+            severity: "WARNING",
+            message: "JWT verification failed",
+            error: error instanceof Error ? error.message : String(error),
+            source: "mcp-smarthr",
+          }),
+        );
+        const resourceMetadataUrl = `${oauthConfig.serverUrl}/.well-known/oauth-protected-resource`;
+        c.header(
+          "WWW-Authenticate",
+          `Bearer error="invalid_token", resource_metadata="${resourceMetadataUrl}"`,
+        );
+        return c.json({ error: "Invalid or expired token" }, 401);
+      }
     } else {
-      // 本番モード: Google OAuth トークン検証
+      // レガシーモード: Google ID トークン直接検証
       const result = await verifyGoogleToken(
         oauthClient,
         googleClientId,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -241,6 +241,9 @@ importers:
       '@cfworker/json-schema':
         specifier: ^4.1.1
         version: 4.1.1
+      '@google-cloud/firestore':
+        specifier: ^8.3.0
+        version: 8.3.0
       '@hono/node-server':
         specifier: ^1.19.9
         version: 1.19.9(hono@4.11.10)
@@ -758,6 +761,10 @@ packages:
   '@google-cloud/firestore@7.11.6':
     resolution: {integrity: sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==}
     engines: {node: '>=14.0.0'}
+
+  '@google-cloud/firestore@8.3.0':
+    resolution: {integrity: sha512-OYadXaHxx8J5GQtCwDNjaVu2+O9Ozdst4Iqi+vDTI/WmLTO56XX3QBOXp4T+qh3tyQzl9YzDBrmA7o8n1xTouA==}
+    engines: {node: '>=18'}
 
   '@google-cloud/paginator@5.0.2':
     resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
@@ -2976,6 +2983,10 @@ packages:
     resolution: {integrity: sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==}
     engines: {node: '>=14'}
 
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
+    engines: {node: '>=18'}
+
   google-logging-utils@0.0.2:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
     engines: {node: '>=14'}
@@ -3050,6 +3061,10 @@ packages:
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -3767,6 +3782,10 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
   protobufjs@7.5.4:
     resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
     engines: {node: '>=12.0.0'}
@@ -3918,6 +3937,10 @@ packages:
   retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
     engines: {node: '>=14'}
+
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
+    engines: {node: '>=18'}
 
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
@@ -4142,6 +4165,10 @@ packages:
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
+
+  teeny-request@10.1.2:
+    resolution: {integrity: sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==}
+    engines: {node: '>=18'}
 
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
@@ -4966,6 +4993,16 @@ snapshots:
       - supports-color
     optional: true
 
+  '@google-cloud/firestore@8.3.0':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      fast-deep-equal: 3.1.3
+      functional-red-black-tree: 1.0.1
+      google-gax: 5.0.6
+      protobufjs: 7.5.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@google-cloud/paginator@5.0.2':
     dependencies:
       arrify: 2.0.1
@@ -5017,7 +5054,6 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.8.0
       '@js-sdsl/ordered-map': 4.4.2
-    optional: true
 
   '@grpc/proto-loader@0.7.15':
     dependencies:
@@ -5033,7 +5069,6 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.4
       yargs: 17.7.2
-    optional: true
 
   '@hono/node-server@1.19.9(hono@4.11.10)':
     dependencies:
@@ -5226,8 +5261,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@js-sdsl/ordered-map@4.4.2':
-    optional: true
+  '@js-sdsl/ordered-map@4.4.2': {}
 
   '@line/bot-sdk@10.6.0':
     dependencies:
@@ -5336,8 +5370,7 @@ snapshots:
 
   '@open-draft/until@2.1.0': {}
 
-  '@opentelemetry/api@1.9.0':
-    optional: true
+  '@opentelemetry/api@1.9.0': {}
 
   '@panva/hkdf@1.2.1': {}
 
@@ -5348,38 +5381,28 @@ snapshots:
     dependencies:
       playwright: 1.58.2
 
-  '@protobufjs/aspromise@1.1.2':
-    optional: true
+  '@protobufjs/aspromise@1.1.2': {}
 
-  '@protobufjs/base64@1.1.2':
-    optional: true
+  '@protobufjs/base64@1.1.2': {}
 
-  '@protobufjs/codegen@2.0.4':
-    optional: true
+  '@protobufjs/codegen@2.0.4': {}
 
-  '@protobufjs/eventemitter@1.1.0':
-    optional: true
+  '@protobufjs/eventemitter@1.1.0': {}
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.0
-    optional: true
 
-  '@protobufjs/float@1.0.2':
-    optional: true
+  '@protobufjs/float@1.0.2': {}
 
-  '@protobufjs/inquire@1.1.0':
-    optional: true
+  '@protobufjs/inquire@1.1.0': {}
 
-  '@protobufjs/path@1.1.2':
-    optional: true
+  '@protobufjs/path@1.1.2': {}
 
-  '@protobufjs/pool@1.1.0':
-    optional: true
+  '@protobufjs/pool@1.1.0': {}
 
-  '@protobufjs/utf8@1.1.0':
-    optional: true
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/number@1.1.1': {}
 
@@ -6825,7 +6848,6 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
-    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -6855,7 +6877,6 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   enhanced-resolve@5.19.0:
     dependencies:
@@ -7135,8 +7156,7 @@ snapshots:
 
   function-bind@1.1.2: {}
 
-  functional-red-black-tree@1.0.1:
-    optional: true
+  functional-red-black-tree@1.0.1: {}
 
   fuzzysort@3.1.0: {}
 
@@ -7274,6 +7294,22 @@ snapshots:
       - supports-color
     optional: true
 
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.5.0
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.4
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
   google-logging-utils@0.0.2: {}
 
   google-logging-utils@1.1.3: {}
@@ -7361,6 +7397,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@5.0.1:
     dependencies:
@@ -7610,8 +7653,7 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  lodash.camelcase@4.3.0:
-    optional: true
+  lodash.camelcase@4.3.0: {}
 
   lodash.clonedeep@4.5.0: {}
 
@@ -7634,8 +7676,7 @@ snapshots:
       chalk: 5.6.2
       is-unicode-supported: 1.3.0
 
-  long@5.3.2:
-    optional: true
+  long@5.3.2: {}
 
   loupe@3.2.1: {}
 
@@ -7847,8 +7888,7 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  object-hash@3.0.0:
-    optional: true
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -8006,6 +8046,10 @@ snapshots:
       protobufjs: 7.5.4
     optional: true
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.5.4
+
   protobufjs@7.5.4:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -8020,7 +8064,6 @@ snapshots:
       '@protobufjs/utf8': 1.1.0
       '@types/node': 22.19.11
       long: 5.3.2
-    optional: true
 
   proxy-addr@2.0.7:
     dependencies:
@@ -8168,7 +8211,6 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
 
   recast@0.23.11:
     dependencies:
@@ -8228,6 +8270,13 @@ snapshots:
       - encoding
       - supports-color
     optional: true
+
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   retry@0.13.1:
     optional: true
@@ -8464,10 +8513,8 @@ snapshots:
   stream-events@1.0.5:
     dependencies:
       stubs: 3.0.0
-    optional: true
 
-  stream-shift@1.0.3:
-    optional: true
+  stream-shift@1.0.3: {}
 
   strict-event-emitter@0.5.1: {}
 
@@ -8492,7 +8539,6 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   stringify-object@5.0.0:
     dependencies:
@@ -8521,8 +8567,7 @@ snapshots:
   strnum@2.1.2:
     optional: true
 
-  stubs@3.0.0:
-    optional: true
+  stubs@3.0.0: {}
 
   styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
@@ -8542,6 +8587,15 @@ snapshots:
   tailwindcss@4.1.18: {}
 
   tapable@2.3.0: {}
+
+  teeny-request@10.1.2:
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   teeny-request@9.0.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -248,7 +248,7 @@ importers:
         specifier: 2.0.0-alpha.2
         version: 2.0.0-alpha.2(@modelcontextprotocol/server@2.0.0-alpha.2(@cfworker/json-schema@4.1.1))(hono@4.11.10)
       '@modelcontextprotocol/sdk':
-        specifier: ^1.12.0
+        specifier: 1.26.0
         version: 1.26.0(@cfworker/json-schema@4.1.1)(zod@3.25.76)
       '@modelcontextprotocol/server':
         specifier: 2.0.0-alpha.2
@@ -259,6 +259,9 @@ importers:
       hono:
         specifier: ^4.11.10
         version: 4.11.10
+      jose:
+        specifier: ^6.2.2
+        version: 6.2.2
       zod:
         specifier: ^3.25.0
         version: 3.25.76
@@ -3211,6 +3214,9 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
+  jose@6.2.2:
+    resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
   js-tokens@10.0.0:
     resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
 
@@ -5249,7 +5255,7 @@ snapshots:
       express: 5.2.1
       express-rate-limit: 8.2.1(express@5.2.1)
       hono: 4.11.10
-      jose: 6.1.3
+      jose: 6.2.2
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
       raw-body: 3.0.2
@@ -7480,6 +7486,8 @@ snapshots:
   jose@5.10.0: {}
 
   jose@6.1.3: {}
+
+  jose@6.2.2: {}
 
   js-tokens@10.0.0: {}
 


### PR DESCRIPTION
## Summary

- MCP 仕様準拠の OAuth 2.1 Authorization Server を実装し、AUTH_DISABLED=true のデモモードから本番認証に移行
- Google OIDC に認証を委譲し、自前 JWT でユーザー特定・ロール管理を実現
- CORS をホワイトリスト化し、セキュリティを強化

## 変更内容

### Phase E0: 前準備
- ツールアノテーション追加（`readOnlyHint`, `idempotentHint`）— Anthropic ディレクトリ審査対応
- 監査ログ: `denied` を `error` と分離（`logDenied` メソッド追加）
- MCP SDK バージョンピン（`@modelcontextprotocol/sdk` 1.26.0）

### Phase E1: OAuth 2.1 Authorization Server
- `/.well-known/oauth-protected-resource`（RFC 9728）
- `/.well-known/oauth-authorization-server`（RFC 8414）
- `/authorize` → Google OIDC リダイレクト（PKCE S256 必須）
- `/oauth/callback` → Google コールバック → 認可コード発行
- `/token` → 認可コード → JWT 交換（一回限り使用、PKCE 検証）
- `/register` → Dynamic Client Registration（RFC 7591）
- JWT: `jose` ライブラリ（HS256, 1時間有効, aud/iss バインド）

### Phase E2: Firestore UserStore
- `mcp-users` コレクションでユーザーロール（admin/readonly）と有効フラグを管理
- `USE_FIRESTORE_USER_STORE=true` で有効化

### Phase E3: JWT 検証
- `/mcp` の認証を OAuth JWT 検証モードに切り替え
- 401 レスポンスに `WWW-Authenticate` ヘッダー（RFC 9728 準拠）
- AUTH_DISABLED / レガシー Google ID Token / OAuth JWT の 3 モード対応

### Phase F1: CORS ホワイトリスト
- `origin: "*"` → 許可オリジンリスト（claude.ai, Cowork, 自サーバー）

## Cloud Run デプロイ状態

| 環境変数 | 値 | 備考 |
|---------|-----|------|
| AUTH_DISABLED | **false** | 本番認証有効 |
| SERVER_URL | https://mcp-smarthr-bdr4g3rk2q-an.a.run.app | OAuth issuer/audience |
| GOOGLE_CLIENT_SECRET | Secret Manager | OAuth コード交換用 |
| JWT_SECRET | Secret Manager | JWT 署名用 |
| USE_FIRESTORE_USER_STORE | false | 現時点はフォールバック UserStore |
| min-instances | 1 | コールドスタート防止 + インメモリ OAuth 状態保持 |
| max-instances | 1 | インメモリ状態の一貫性保証 |

## 検証結果

- Cowork（個人 Pro）から OAuth 認証 → ツール実行成功（従業員一覧 2,413 件取得）
- OAuth 自動検出（.well-known）→ Google ログイン → JWT 発行 → MCP 通信の全フロー確認
- 未認証リクエスト → 401 + WWW-Authenticate ヘッダー
- テスト: **88 件全 PASS**（+19 新規）
- Lint / TypeCheck: 全 PASS

## Test plan

- [x] `pnpm --filter @hr-system/mcp-smarthr test` — 88 件全 PASS
- [x] `pnpm --filter @hr-system/mcp-smarthr typecheck` — PASS
- [x] `pnpm --filter @hr-system/mcp-smarthr lint` — PASS
- [x] curl: `/.well-known/oauth-protected-resource` → 200 + メタデータ
- [x] curl: `/.well-known/oauth-authorization-server` → 200 + AS メタデータ
- [x] curl: `/authorize` → Google OIDC リダイレクト
- [x] ブラウザ: OAuth フロー全体（authorize → Google ログイン → callback → token）
- [x] curl: JWT 付き `/mcp` → MCP initialize 成功
- [x] curl: 認証なし `/mcp` → 401
- [x] Cowork: カスタムコネクタ再追加 → OAuth ログイン → ツール実行成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)