### PR TITLE
feat: SmartHR MCP CRUD 操作追加 + パーミッションベース認可（Phase G）

### DIFF
--- a/packages/mcp-smarthr/src/__tests__/auth.test.ts
+++ b/packages/mcp-smarthr/src/__tests__/auth.test.ts
@@ -6,9 +6,14 @@ import {
   type UserStore,
 } from "../core/middleware/auth.js";
 
-/** テスト用モック UserStore */
+import type { Permission } from "../core/middleware/pii-filter.js";
+
+/** テスト用モック UserStore（permissions 対応） */
 function createMockUserStore(
-  users: Record<string, { role: "admin" | "readonly"; enabled: boolean }>,
+  users: Record<
+    string,
+    { role: "admin" | "readonly"; permissions?: Permission[]; enabled: boolean }
+  >,
 ): UserStore {
   return {
     getUser: async (email: string) => users[email] ?? null,
@@ -237,6 +242,108 @@ describe("Authorizer", () => {
 
       expect(result.authorized).toBe(false);
       expect(result.reason).toBe("権限不足");
+    });
+  });
+
+  describe("パーミッションベース認可", () => {
+    it("permissions: ['read', 'write'] → update_employee に成功", async () => {
+      const store = createMockUserStore({
+        "editor@aozora-cg.com": {
+          role: "readonly",
+          permissions: ["read", "write"],
+          enabled: true,
+        },
+      });
+      const authorizer = new Authorizer(ALLOWED_DOMAIN, store);
+      const context: AuthContext = {
+        email: "editor@aozora-cg.com",
+        domain: "aozora-cg.com",
+        transport: "http",
+      };
+
+      const result = await authorizer.authorize(context, "update_employee");
+
+      expect(result.authorized).toBe(true);
+    });
+
+    it("permissions: ['read', 'write'] → get_pay_statements は拒否", async () => {
+      const store = createMockUserStore({
+        "editor@aozora-cg.com": {
+          role: "readonly",
+          permissions: ["read", "write"],
+          enabled: true,
+        },
+      });
+      const authorizer = new Authorizer(ALLOWED_DOMAIN, store);
+      const context: AuthContext = {
+        email: "editor@aozora-cg.com",
+        domain: "aozora-cg.com",
+        transport: "http",
+      };
+
+      const result = await authorizer.authorize(context, "get_pay_statements");
+
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe("権限不足");
+    });
+
+    it("permissions: ['read'] → update_employee は拒否", async () => {
+      const store = createMockUserStore({
+        "reader@aozora-cg.com": {
+          role: "readonly",
+          permissions: ["read"],
+          enabled: true,
+        },
+      });
+      const authorizer = new Authorizer(ALLOWED_DOMAIN, store);
+      const context: AuthContext = {
+        email: "reader@aozora-cg.com",
+        domain: "aozora-cg.com",
+        transport: "http",
+      };
+
+      const result = await authorizer.authorize(context, "update_employee");
+
+      expect(result.authorized).toBe(false);
+      expect(result.reason).toBe("権限不足");
+    });
+
+    it("role: 'admin'（permissions なし）→ 全ツールアクセス可（後方互換）", async () => {
+      const store = createMockUserStore({
+        "admin@aozora-cg.com": { role: "admin", enabled: true },
+      });
+      const authorizer = new Authorizer(ALLOWED_DOMAIN, store);
+      const context: AuthContext = {
+        email: "admin@aozora-cg.com",
+        domain: "aozora-cg.com",
+        transport: "http",
+      };
+
+      const readResult = await authorizer.authorize(context, "list_employees");
+      const writeResult = await authorizer.authorize(context, "update_employee");
+      const payResult = await authorizer.authorize(context, "get_pay_statements");
+
+      expect(readResult.authorized).toBe(true);
+      expect(writeResult.authorized).toBe(true);
+      expect(payResult.authorized).toBe(true);
+    });
+
+    it("role: 'readonly'（permissions なし）→ read のみ（後方互換）", async () => {
+      const store = createMockUserStore({
+        "reader@aozora-cg.com": { role: "readonly", enabled: true },
+      });
+      const authorizer = new Authorizer(ALLOWED_DOMAIN, store);
+      const context: AuthContext = {
+        email: "reader@aozora-cg.com",
+        domain: "aozora-cg.com",
+        transport: "http",
+      };
+
+      const readResult = await authorizer.authorize(context, "list_employees");
+      const writeResult = await authorizer.authorize(context, "update_employee");
+
+      expect(readResult.authorized).toBe(true);
+      expect(writeResult.authorized).toBe(false);
     });
   });
 });

--- a/packages/mcp-smarthr/src/__tests__/smarthr-client.test.ts
+++ b/packages/mcp-smarthr/src/__tests__/smarthr-client.test.ts
@@ -123,6 +123,89 @@ describe("SmartHRClient", () => {
     });
   });
 
+  describe("updateEmployee", () => {
+    it("PATCH メソッドで従業員を更新する", async () => {
+      const updated = { id: "abc", last_name: "佐藤", first_name: "太郎" };
+      const fetchMock = mockFetchResponse(updated);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await client.updateEmployee("abc", { last_name: "佐藤" });
+
+      expect(result.last_name).toBe("佐藤");
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("/crews/abc");
+      const calledOptions = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      expect(calledOptions.method).toBe("PATCH");
+      expect(calledOptions.body).toBe(JSON.stringify({ last_name: "佐藤" }));
+    });
+
+    it("Content-Type: application/json を含める", async () => {
+      const fetchMock = mockFetchResponse({ id: "abc" });
+      vi.stubGlobal("fetch", fetchMock);
+
+      await client.updateEmployee("abc", { last_name: "佐藤" });
+
+      const calledOptions = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      expect(calledOptions.headers).toEqual(
+        expect.objectContaining({
+          "Content-Type": "application/json",
+        }),
+      );
+    });
+
+    it("更新後にキャッシュが無効化される", async () => {
+      // まずキャッシュを作成
+      const fetchMock = mockFetchResponse({ id: "abc", last_name: "田中" });
+      vi.stubGlobal("fetch", fetchMock);
+      await client.getEmployee("abc");
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      // 更新
+      const updateMock = mockFetchResponse({ id: "abc", last_name: "佐藤" });
+      vi.stubGlobal("fetch", updateMock);
+      await client.updateEmployee("abc", { last_name: "佐藤" });
+
+      // 再取得するとキャッシュミスで fetch される
+      const refetchMock = mockFetchResponse({ id: "abc", last_name: "佐藤" });
+      vi.stubGlobal("fetch", refetchMock);
+      await client.getEmployee("abc");
+      expect(refetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it("422 バリデーションエラーを SmartHRApiError としてスロー", async () => {
+      vi.stubGlobal(
+        "fetch",
+        mockFetchError(422, "Unprocessable Entity", '{"errors":["invalid field"]}'),
+      );
+
+      await expect(client.updateEmployee("abc", { last_name: "" })).rejects.toThrow(
+        SmartHRApiError,
+      );
+      await expect(client.updateEmployee("abc", { last_name: "" })).rejects.toMatchObject({
+        statusCode: 422,
+      });
+    });
+  });
+
+  describe("createEmployee", () => {
+    it("POST メソッドで従業員を作成する", async () => {
+      const created = { id: "new-1", last_name: "新入", first_name: "社員" };
+      const fetchMock = mockFetchResponse(created);
+      vi.stubGlobal("fetch", fetchMock);
+
+      const result = await client.createEmployee({
+        last_name: "新入",
+        first_name: "社員",
+      });
+
+      expect(result.id).toBe("new-1");
+      const calledUrl = fetchMock.mock.calls[0]?.[0] as string;
+      expect(calledUrl).toContain("/crews");
+      const calledOptions = fetchMock.mock.calls[0]?.[1] as RequestInit;
+      expect(calledOptions.method).toBe("POST");
+    });
+  });
+
   describe("認証", () => {
     it("Bearerトークンをヘッダーに含める", async () => {
       const fetchMock = mockFetchResponse([]);

--- a/packages/mcp-smarthr/src/core/middleware/auth.ts
+++ b/packages/mcp-smarthr/src/core/middleware/auth.ts
@@ -9,11 +9,12 @@
  * トランスポート非依存: stdio / HTTP 両方で利用可能。
  */
 
-// Role は pii-filter.ts で定義済み — 重複を避けて re-export
-export type { Role } from "./pii-filter.js";
+// Role, Permission は pii-filter.ts で定義済み — 重複を避けて re-export
+export type { Permission, Role } from "./pii-filter.js";
 
 import type { ToolName } from "../tools.js";
-import type { Role } from "./pii-filter.js";
+import type { Permission, Role } from "./pii-filter.js";
+import { ROLE_TO_PERMISSIONS } from "./pii-filter.js";
 
 /** Shell 層から渡される認証コンテキスト */
 export interface AuthContext {
@@ -43,17 +44,21 @@ export function createAuthContext(
 
 /** ユーザー許可リスト（DI） */
 export interface UserStore {
-  getUser(email: string): Promise<{ role: Role; enabled: boolean } | null>;
+  getUser(
+    email: string,
+  ): Promise<{ role: Role; permissions?: Permission[]; enabled: boolean } | null>;
 }
 
 /** ツール権限マッピング（defineTools の全ツールに対応を強制） */
-export const TOOL_PERMISSIONS: Record<ToolName, Role> = {
-  list_employees: "readonly",
-  get_employee: "readonly",
-  search_employees: "readonly",
-  get_pay_statements: "admin",
-  list_departments: "readonly",
-  list_positions: "readonly",
+export const TOOL_PERMISSIONS: Record<ToolName, Permission> = {
+  list_employees: "read",
+  get_employee: "read",
+  search_employees: "read",
+  get_pay_statements: "pay_statements",
+  list_departments: "read",
+  list_positions: "read",
+  update_employee: "write",
+  create_employee: "write",
 };
 
 /** 認可チェック結果 */
@@ -65,10 +70,21 @@ export interface AuthResult {
   reason?: string;
 }
 
-/** ロール階層: admin は readonly の権限を包含する */
-function hasPermission(userRole: Role, requiredRole: Role): boolean {
-  if (userRole === "admin") return true;
-  return userRole === requiredRole;
+/** ユーザーの実効パーミッションを解決する（permissions フィールド優先、なければ role から導出） */
+function resolvePermissions(user: { role: Role; permissions?: Permission[] }): Permission[] {
+  return user.permissions ?? ROLE_TO_PERMISSIONS[user.role];
+}
+
+/** パーミッションベースのアクセス判定 */
+function hasPermission(userPermissions: Permission[], requiredPermission: Permission): boolean {
+  return userPermissions.includes(requiredPermission);
+}
+
+/** PII フィルタ用のロールを導出（admin パーミッションがあれば admin 扱い） */
+function deriveRole(permissions: Permission[]): Role {
+  return permissions.includes("pay_statements") && permissions.includes("write")
+    ? "admin"
+    : "readonly";
 }
 
 /** 認可チェッカー */
@@ -118,8 +134,8 @@ export class Authorizer {
     }
 
     // Layer 4: ツール権限（未登録ツールは deny）
-    const requiredRole = TOOL_PERMISSIONS[toolName as ToolName];
-    if (!requiredRole) {
+    const requiredPermission = TOOL_PERMISSIONS[toolName as ToolName];
+    if (!requiredPermission) {
       return {
         authorized: false,
         role: user.role,
@@ -127,10 +143,11 @@ export class Authorizer {
         reason: "未登録ツール",
       };
     }
-    if (!hasPermission(user.role, requiredRole)) {
+    const userPermissions = resolvePermissions(user);
+    if (!hasPermission(userPermissions, requiredPermission)) {
       return {
         authorized: false,
-        role: user.role,
+        role: deriveRole(userPermissions),
         email: context.email,
         reason: "権限不足",
       };
@@ -138,7 +155,7 @@ export class Authorizer {
 
     return {
       authorized: true,
-      role: user.role,
+      role: deriveRole(userPermissions),
       email: context.email,
     };
   }
@@ -146,8 +163,9 @@ export class Authorizer {
   /** stdio トランスポート用: 許可リストを尊重、未登録は readonly（H2修正） */
   private async authorizeStdio(context: AuthContext, toolName: string): Promise<AuthResult> {
     const user = await this.userStore.getUser(context.email);
-    // H2修正: 未登録ユーザーは readonly（admin にしない）
-    const role: Role = user?.role ?? "readonly";
+    // H2修正: 未登録ユーザーは readonly パーミッション
+    const userPermissions = user ? resolvePermissions(user) : ROLE_TO_PERMISSIONS.readonly;
+    const role = deriveRole(userPermissions);
 
     // H2修正: enabled チェックも stdio で実施
     if (user && !user.enabled) {
@@ -160,8 +178,8 @@ export class Authorizer {
     }
 
     // 未登録ツールは deny
-    const requiredRole = TOOL_PERMISSIONS[toolName as ToolName];
-    if (!requiredRole) {
+    const requiredPermission = TOOL_PERMISSIONS[toolName as ToolName];
+    if (!requiredPermission) {
       return {
         authorized: false,
         role,
@@ -169,7 +187,7 @@ export class Authorizer {
         reason: "未登録ツール",
       };
     }
-    if (!hasPermission(role, requiredRole)) {
+    if (!hasPermission(userPermissions, requiredPermission)) {
       return {
         authorized: false,
         role,

--- a/packages/mcp-smarthr/src/core/middleware/auth.ts
+++ b/packages/mcp-smarthr/src/core/middleware/auth.ts
@@ -4,7 +4,7 @@
  * Layer 1: トランスポート認証（Shell 層で処理、Core には AuthContext として渡る）
  * Layer 2: ドメイン検証（aozora-cg.com）
  * Layer 3: ユーザー許可リスト（UserStore 経由）
- * Layer 4: ツール権限（ロール別アクセス制御）
+ * Layer 4: ツール権限（パーミッションベースのアクセス制御）
  *
  * トランスポート非依存: stdio / HTTP 両方で利用可能。
  */
@@ -70,9 +70,15 @@ export interface AuthResult {
   reason?: string;
 }
 
+const VALID_PERMISSIONS = new Set<string>(["read", "write", "pay_statements"]);
+
 /** ユーザーの実効パーミッションを解決する（permissions フィールド優先、なければ role から導出） */
 function resolvePermissions(user: { role: Role; permissions?: Permission[] }): Permission[] {
-  return user.permissions ?? ROLE_TO_PERMISSIONS[user.role];
+  if (!user.permissions || !Array.isArray(user.permissions)) {
+    return ROLE_TO_PERMISSIONS[user.role];
+  }
+  const valid = user.permissions.filter((p): p is Permission => VALID_PERMISSIONS.has(p));
+  return valid.length > 0 ? valid : ROLE_TO_PERMISSIONS[user.role];
 }
 
 /** パーミッションベースのアクセス判定 */
@@ -80,7 +86,7 @@ function hasPermission(userPermissions: Permission[], requiredPermission: Permis
   return userPermissions.includes(requiredPermission);
 }
 
-/** PII フィルタ用のロールを導出（admin パーミッションがあれば admin 扱い） */
+/** PII フィルタ用のロールを導出（pay_statements + write の両方があれば admin 扱い） */
 function deriveRole(permissions: Permission[]): Role {
   return permissions.includes("pay_statements") && permissions.includes("write")
     ? "admin"

--- a/packages/mcp-smarthr/src/core/middleware/pii-filter.ts
+++ b/packages/mcp-smarthr/src/core/middleware/pii-filter.ts
@@ -7,6 +7,15 @@
 
 export type Role = "admin" | "readonly";
 
+/** 細粒度パーミッション（ツール単位のアクセス制御に使用） */
+export type Permission = "read" | "write" | "pay_statements";
+
+/** ロール → パーミッション変換（permissions フィールドがない既存ユーザー用） */
+export const ROLE_TO_PERMISSIONS: Record<Role, Permission[]> = {
+  admin: ["read", "write", "pay_statements"],
+  readonly: ["read"],
+};
+
 /** readonly ロールで除外するフィールド */
 const READONLY_EXCLUDED_FIELDS: ReadonlySet<string> = new Set([
   "birth_at",

--- a/packages/mcp-smarthr/src/core/smarthr-client.ts
+++ b/packages/mcp-smarthr/src/core/smarthr-client.ts
@@ -17,11 +17,12 @@ interface CacheEntry<T> {
 }
 
 /**
- * SmartHR REST API クライアント（読み取り専用）
+ * SmartHR REST API クライアント
  *
  * - Bearer トークン認証
- * - TTL ベースのインメモリキャッシュ（レート制限対策）
+ * - TTL ベースのインメモリキャッシュ（レート制限対策、読み取りのみ）
  * - レート制限: 5,000 req/hour, 10 req/sec per token
+ * - 書き込み操作（PATCH/POST）はキャッシュ無効化付き
  */
 export class SmartHRClient {
   private readonly baseUrl: string;
@@ -112,6 +113,28 @@ export class SmartHRClient {
     return this.fetchList<SmartHRPosition>(url);
   }
 
+  /** 従業員情報を部分更新（PATCH） */
+  async updateEmployee(id: string, fields: Record<string, unknown>): Promise<SmartHRCrew> {
+    const response = await this.request(`/crews/${id}`, {
+      method: "PATCH",
+      body: fields,
+    });
+    const data = (await response.json()) as SmartHRCrew;
+    this.invalidateCrewCache(id);
+    return data;
+  }
+
+  /** 従業員を新規登録（POST） */
+  async createEmployee(fields: Record<string, unknown>): Promise<SmartHRCrew> {
+    const response = await this.request("/crews", {
+      method: "POST",
+      body: fields,
+    });
+    const data = (await response.json()) as SmartHRCrew;
+    this.invalidateCrewCache();
+    return data;
+  }
+
   /** キャッシュクリア */
   clearCache(): void {
     this.cache.clear();
@@ -141,17 +164,27 @@ export class SmartHRClient {
     return result;
   }
 
-  private async request(path: string): Promise<Response> {
+  private async request(
+    path: string,
+    options?: { method?: string; body?: Record<string, unknown> },
+  ): Promise<Response> {
     const url = `${this.baseUrl}${path}`;
+    const method = options?.method ?? "GET";
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${this.accessToken}`,
+      Accept: "application/json",
+    };
+    if (options?.body) {
+      headers["Content-Type"] = "application/json";
+    }
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       await this.rateLimiter.waitForSlot();
 
       const response = await fetch(url, {
-        headers: {
-          Authorization: `Bearer ${this.accessToken}`,
-          Accept: "application/json",
-        },
+        method,
+        headers,
+        body: options?.body ? JSON.stringify(options.body) : undefined,
       });
 
       this.rateLimiter.onResponse(response.headers);
@@ -193,6 +226,18 @@ export class SmartHRClient {
       data,
       expiresAt: Date.now() + this.cacheTtlMs,
     });
+  }
+
+  /** 書き込み後に従業員関連キャッシュを無効化する */
+  private invalidateCrewCache(id?: string): void {
+    for (const key of this.cache.keys()) {
+      if (key.startsWith("/crews")) {
+        // 特定IDの場合はそのIDと一覧系のみ無効化、IDなしは全crews無効化
+        if (!id || key === `/crews/${id}` || key.includes("?") || key === "/crews") {
+          this.cache.delete(key);
+        }
+      }
+    }
   }
 }
 

--- a/packages/mcp-smarthr/src/core/smarthr-client.ts
+++ b/packages/mcp-smarthr/src/core/smarthr-client.ts
@@ -120,7 +120,11 @@ export class SmartHRClient {
       body: fields,
     });
     const data = (await response.json()) as SmartHRCrew;
-    this.invalidateCrewCache(id);
+    try {
+      this.invalidateCrewCache(id);
+    } catch {
+      // キャッシュ無効化失敗は書き込み成功をブロックしない
+    }
     return data;
   }
 
@@ -131,7 +135,11 @@ export class SmartHRClient {
       body: fields,
     });
     const data = (await response.json()) as SmartHRCrew;
-    this.invalidateCrewCache();
+    try {
+      this.invalidateCrewCache();
+    } catch {
+      // キャッシュ無効化失敗は書き込み成功をブロックしない
+    }
     return data;
   }
 
@@ -190,6 +198,15 @@ export class SmartHRClient {
       this.rateLimiter.onResponse(response.headers);
 
       if (response.status === 429 && attempt < MAX_RETRIES) {
+        // POST は非冪等のためリトライしない（従業員重複作成リスク回避）
+        if (method !== "GET" && method !== "PATCH") {
+          const body = await response.text().catch(() => "");
+          throw new SmartHRApiError(
+            `SmartHR API rate limited on ${method} request (not retrying non-idempotent)`,
+            429,
+            body,
+          );
+        }
         const delay = this.rateLimiter.getRetryDelay(response.headers, attempt);
         await new Promise((resolve) => setTimeout(resolve, delay));
         continue;

--- a/packages/mcp-smarthr/src/core/stores/firestore-user-store.ts
+++ b/packages/mcp-smarthr/src/core/stores/firestore-user-store.ts
@@ -2,7 +2,7 @@
  * Firestore ベースの UserStore 実装
  *
  * コレクション: mcp-users/{email}
- * ドキュメント構造: { role: "admin" | "readonly", enabled: boolean, createdAt, updatedAt }
+ * ドキュメント構造: { role: "admin" | "readonly", permissions?: Permission[], enabled: boolean, createdAt, updatedAt }
  *
  * Cloud Run 上では ADC（Application Default Credentials）で認証。
  * SA `mcp-smarthr@` に Firestore User 権限が付与済み。

--- a/packages/mcp-smarthr/src/core/stores/firestore-user-store.ts
+++ b/packages/mcp-smarthr/src/core/stores/firestore-user-store.ts
@@ -9,12 +9,14 @@
  */
 
 import { Firestore } from "@google-cloud/firestore";
-import type { Role } from "../middleware/pii-filter.js";
+import type { Permission, Role } from "../middleware/pii-filter.js";
 
 const COLLECTION = "mcp-users";
 
 export interface UserDocument {
   role: Role;
+  /** 細粒度パーミッション（省略時は role から自動導出） */
+  permissions?: Permission[];
   enabled: boolean;
   createdAt: string;
   updatedAt: string;
@@ -32,7 +34,9 @@ export class FirestoreUserStore {
     this.collection = options?.collection ?? COLLECTION;
   }
 
-  async getUser(email: string): Promise<{ role: Role; enabled: boolean } | null> {
+  async getUser(
+    email: string,
+  ): Promise<{ role: Role; permissions?: Permission[]; enabled: boolean } | null> {
     const doc = await this.db.collection(this.collection).doc(email).get();
     if (!doc.exists) return null;
 
@@ -41,6 +45,7 @@ export class FirestoreUserStore {
 
     return {
       role: data.role,
+      permissions: data.permissions,
       enabled: data.enabled,
     };
   }

--- a/packages/mcp-smarthr/src/core/tools.ts
+++ b/packages/mcp-smarthr/src/core/tools.ts
@@ -7,6 +7,45 @@ const paginationShape = {
   per_page: z.number().int().min(1).max(100).optional().describe("1ページあたりの件数（最大100）"),
 };
 
+/** 更新可能フィールド（セキュリティ上、ハードコードで制限） */
+const UPDATABLE_FIELDS = [
+  "last_name",
+  "first_name",
+  "last_name_yomi",
+  "first_name_yomi",
+  "emp_code",
+  "entered_at",
+  "resigned_at",
+  "department",
+  "position",
+  "employment_type",
+] as const;
+
+/** update_employee 用の Zod shape（id 以外の全フィールドを optional で定義） */
+const updatableFieldsShape: Record<string, z.ZodTypeAny> = {
+  last_name: z.string().optional().describe("姓"),
+  first_name: z.string().optional().describe("名"),
+  last_name_yomi: z.string().optional().describe("姓（よみがな）"),
+  first_name_yomi: z.string().optional().describe("名（よみがな）"),
+  emp_code: z.string().optional().describe("社員番号"),
+  entered_at: z.string().optional().describe("入社日（YYYY-MM-DD）"),
+  resigned_at: z.string().optional().describe("退職日（YYYY-MM-DD）"),
+  department: z.string().optional().describe("部署ID"),
+  position: z.string().optional().describe("役職ID"),
+  employment_type: z.string().optional().describe("雇用形態ID"),
+};
+
+/** undefined・空文字列を除去する（SmartHR の空上書き防止） */
+function stripEmptyValues(obj: Record<string, unknown>): Record<string, unknown> {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== undefined && value !== "") {
+      result[key] = value;
+    }
+  }
+  return result;
+}
+
 /** ツール名一覧（TOOL_PERMISSIONS との同期を型で強制するために定義） */
 const TOOL_NAMES = [
   "list_employees",
@@ -15,6 +54,8 @@ const TOOL_NAMES = [
   "get_pay_statements",
   "list_departments",
   "list_positions",
+  "update_employee",
+  "create_employee",
 ] as const;
 
 export type ToolName = (typeof TOOL_NAMES)[number];
@@ -117,6 +158,67 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
       handler: async (params: { page?: number; per_page?: number }) => {
         const result = await client.listPositions(params);
         return formatListResult("役職", result.data, result.totalCount);
+      },
+    },
+
+    update_employee: {
+      description:
+        "SmartHRの従業員情報を部分更新します（PATCH）。write権限が必要です。更新前に必ずユーザーに変更内容を確認してください。空値を送信するとSmartHR側のデータが消えるため、変更するフィールドのみ指定してください。",
+      shape: {
+        id: z.string().describe("SmartHR従業員ID"),
+        ...updatableFieldsShape,
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        title: "従業員更新",
+      },
+      handler: async (
+        params: { id: string } & Partial<Record<(typeof UPDATABLE_FIELDS)[number], string>>,
+      ) => {
+        const { id, ...rest } = params;
+        const fields = stripEmptyValues(rest);
+        if (Object.keys(fields).length === 0) {
+          throw new Error("更新するフィールドを1つ以上指定してください");
+        }
+        return await client.updateEmployee(id, fields);
+      },
+    },
+
+    create_employee: {
+      description:
+        "SmartHRに新しい従業員を登録します。write権限が必要です。登録前に必ずユーザーに入力内容を確認してください。",
+      shape: {
+        last_name: z.string().describe("姓"),
+        first_name: z.string().describe("名"),
+        last_name_yomi: z.string().optional().describe("姓（よみがな）"),
+        first_name_yomi: z.string().optional().describe("名（よみがな）"),
+        emp_code: z.string().optional().describe("社員番号"),
+        entered_at: z.string().optional().describe("入社日（YYYY-MM-DD）"),
+        department: z.string().optional().describe("部署ID"),
+        position: z.string().optional().describe("役職ID"),
+        employment_type: z.string().optional().describe("雇用形態ID"),
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        title: "従業員登録",
+      },
+      handler: async (params: {
+        last_name: string;
+        first_name: string;
+        last_name_yomi?: string;
+        first_name_yomi?: string;
+        emp_code?: string;
+        entered_at?: string;
+        department?: string;
+        position?: string;
+        employment_type?: string;
+      }) => {
+        const fields = stripEmptyValues(params);
+        return await client.createEmployee(fields);
       },
     },
   };

--- a/packages/mcp-smarthr/src/core/tools.ts
+++ b/packages/mcp-smarthr/src/core/tools.ts
@@ -35,11 +35,26 @@ const updatableFieldsShape: Record<string, z.ZodTypeAny> = {
   employment_type: z.string().optional().describe("雇用形態ID"),
 };
 
-/** undefined・空文字列を除去する（SmartHR の空上書き防止） */
+/** undefined・null・空文字列・空白のみ文字列を除去する（SmartHR の空上書き防止） */
 function stripEmptyValues(obj: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};
   for (const [key, value] of Object.entries(obj)) {
-    if (value !== undefined && value !== "") {
+    if (value === undefined || value === null || value === "") continue;
+    if (typeof value === "string" && value.trim() === "") continue;
+    result[key] = value;
+  }
+  return result;
+}
+
+/** ランタイムでフィールド許可リストを強制する（defense-in-depth） */
+function filterAllowedFields(
+  obj: Record<string, unknown>,
+  allowedFields: readonly string[],
+): Record<string, unknown> {
+  const allowed = new Set<string>(allowedFields);
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (allowed.has(key)) {
       result[key] = value;
     }
   }
@@ -121,7 +136,7 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
 
     get_pay_statements: {
       description:
-        "SmartHRの給与明細を取得します。従業員ID・年・月で絞り込み可能。admin権限が必要です。",
+        "SmartHRの給与明細を取得します。従業員ID・年・月で絞り込み可能。pay_statements権限が必要です。",
       annotations: { readOnlyHint: true, idempotentHint: true, title: "給与明細" },
       shape: {
         crew_id: z.string().optional().describe("従業員ID（絞り込み）"),
@@ -178,7 +193,8 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
         params: { id: string } & Partial<Record<(typeof UPDATABLE_FIELDS)[number], string>>,
       ) => {
         const { id, ...rest } = params;
-        const fields = stripEmptyValues(rest);
+        const allowed = filterAllowedFields(rest, UPDATABLE_FIELDS);
+        const fields = stripEmptyValues(allowed);
         if (Object.keys(fields).length === 0) {
           throw new Error("更新するフィールドを1つ以上指定してください");
         }
@@ -190,8 +206,8 @@ export function defineTools(client: SmartHRClient): Record<ToolName, ToolDefinit
       description:
         "SmartHRに新しい従業員を登録します。write権限が必要です。登録前に必ずユーザーに入力内容を確認してください。",
       shape: {
-        last_name: z.string().describe("姓"),
-        first_name: z.string().describe("名"),
+        last_name: z.string().min(1, "姓は必須です").describe("姓"),
+        first_name: z.string().min(1, "名は必須です").describe("名"),
         last_name_yomi: z.string().optional().describe("姓（よみがな）"),
         first_name_yomi: z.string().optional().describe("名（よみがな）"),
         emp_code: z.string().optional().describe("社員番号"),


### PR DESCRIPTION
## Summary
- SmartHR MCP に従業員の更新（PATCH）・作成（POST）ツールを追加
- パーミッションベース認可: `"read" | "write" | "pay_statements"` でアカウント毎に細粒度制御
- 後方互換: 既存の `role: "admin" | "readonly"` ユーザーはそのまま動作
- フィールド許可リスト + 空値除去で SmartHR データの安全性を確保

## Changes
| ファイル | 変更内容 |
|---------|---------|
| `pii-filter.ts` | `Permission` 型、`ROLE_TO_PERMISSIONS` マッピング |
| `auth.ts` | Permission ベース認可、`resolvePermissions()` / `deriveRole()` |
| `firestore-user-store.ts` | `permissions?: Permission[]` フィールド |
| `smarthr-client.ts` | `updateEmployee()` / `createEmployee()` / キャッシュ無効化 |
| `tools.ts` | `update_employee` / `create_employee` ツール定義 |
| `auth.test.ts` | +5 テスト（Permission 認可 + 後方互換） |
| `smarthr-client.test.ts` | +5 テスト（PATCH/POST + キャッシュ + 422エラー） |

## Test plan
- [x] 全 98 テスト PASS（88 → 98）
- [x] lint PASS
- [x] typecheck PASS
- [ ] Cloud Run デプロイ後、Cowork で update_employee / create_employee が表示される
- [ ] admin ユーザーで従業員更新を実行（本番確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)