### PR TITLE
docs: ハンドオフ更新（Phase G 完了・CRUD デプロイ済み）

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -2,51 +2,45 @@
 
 **最終更新**: 2026-04-13（セッション終了時点）
 **ブランチ**: `main`
-**main 最新**: `78eb40c` — feat: OAuth 2.1 Authorization Server + セキュリティ強化（Phase E+F1） (#421)
+**main 最新**: `faec4ba` — feat: SmartHR MCP CRUD 操作追加 + パーミッションベース認可（Phase G） (#423)
 
 ---
 
 ## 現在のフェーズ
 
-**Phase 12 — SmartHR MCP サーバー構築（Phase E+F1 完了・OAuth 本番稼働中）**
+**Phase 12 — SmartHR MCP サーバー構築（Phase G 完了・CRUD 本番デプロイ済み）**
 
 ### 今セッションの成果
 
-1. **Phase E: OAuth 2.1 Authorization Server**（PR #421）
-   - E0: ツールアノテーション追加（readOnlyHint, idempotentHint）+ 監査ログ denied/error 分離 + SDK ピン（1.26.0）
-   - E1: MCP 仕様準拠 OAuth AS 実装
-     - `/.well-known/oauth-protected-resource`（RFC 9728）
-     - `/.well-known/oauth-authorization-server`（RFC 8414）
-     - `/authorize` → Google OIDC 委譲（PKCE S256 必須）
-     - `/oauth/callback` → 認可コード発行
-     - `/token` → JWT 交換（一回限り、PKCE 検証）
-     - `/register` → Dynamic Client Registration（RFC 7591）
-   - E2: Firestore UserStore 実装（`mcp-users` コレクション、`USE_FIRESTORE_USER_STORE=true` で有効化）
-   - E3: JWT 検証モード追加 + AUTH_DISABLED=false（本番認証有効）
-   - E4: Cloud Run デプロイ + Cowork から OAuth ログイン → ツール実行成功
+1. **Phase G: CRUD 操作追加**（PR #423）
+   - G1: SmartHR Client に PATCH/POST メソッド追加（キャッシュ無効化付き）
+   - G2: `update_employee` ツール（PATCH /crews/{id}、フィールド許可リスト強制）
+   - G3: `create_employee` ツール（POST /crews、必須フィールド min(1) バリデーション）
+   - G4: 空値除去（undefined / null / 空文字列 / 空白のみ → SmartHR データ消失防止）
 
-2. **Phase F1: CORS ホワイトリスト化**（PR #421）
-   - `origin: "*"` → 許可オリジンリスト（claude.ai, Cowork, 自サーバー）
+2. **パーミッションベース認可**（PR #423）
+   - `Permission = "read" | "write" | "pay_statements"` 型追加
+   - アカウント毎に細粒度の CRUD 権限制御が可能
+   - 後方互換: 既存 role のみユーザーは ROLE_TO_PERMISSIONS で自動導出
+   - Firestore permissions フィールドのランタイム検証（不正値はロールにフォールバック）
 
-3. **レビュー指摘対応**（Codex セカンドオピニオン + 4 エージェント並列レビュー）
-   - fail-open → fail-closed（UserStore null 時はアクセス拒否）
-   - ドメイン漏洩修正（エラーレスポンスから内部情報除去）
-   - clientState 型安全性（`Record<string, unknown>` キャスト → 型定義）
-   - /register サイズ上限追加（DoS 防止）
-   - /token の redirect_uri を必須に（OAuth 2.1 準拠）
-   - セキュリティイベントログ追加（PKCE, client_id, redirect_uri 失敗）
+3. **レビュー指摘対応**（5エージェント並列レビュー）
+   - POST の 429 リトライ禁止（非冪等操作の重複実行防止）
+   - UPDATABLE_FIELDS をランタイムで強制（defense-in-depth）
+   - stripEmptyValues で null・空白文字列も除去
+   - キャッシュ無効化を try-catch で保護（書き込み成功を隠さない）
+   - 古いコメント4箇所修正（ロール別→パーミッションベース）
 
-4. **Codex セカンドオピニオンによる設計判断**
-   - 自前 AS vs マネージド AS → 自前（10-30名の社内ツールに Auth0 は過剰）
-   - CRUD を OAuth と分離 → Phase G は E+F 安定後に着手
-   - DELETE 初期スコープ外 → SmartHR の退職処理は PATCH（resigned_at）が正規フロー
-   - IP 制限 → Cloud Armor に移行（アプリ内 XFF パースは脆弱）
+4. **Cloud Run デプロイ + SmartHR API 実接続テスト**
+   - rev 00012 デプロイ完了
+   - PATCH フォーマット検証OK（同値更新で 200 確認）
+   - POST フォーマット検証OK（201 確認、テスト従業員は即削除済み）
 
 ### マージ済み PR
 
 | PR | 内容 | 状態 |
 |----|------|------|
-| #421 | OAuth 2.1 AS + セキュリティ強化（Phase E+F1） | マージ済 |
+| #423 | Phase G: CRUD 操作 + パーミッションベース認可 | マージ済 |
 
 ---
 
@@ -58,21 +52,19 @@
    - 組織オーナー（社長）がカスタムコネクタ追加を許可
    - チームメンバーの接続テスト
 
-2. **Firestore UserStore 有効化**
+2. **Firestore UserStore 有効化 + ユーザー登録**
    - `USE_FIRESTORE_USER_STORE=true` に変更
-   - 初期ユーザー登録（admin: 社長, readonly: 他メンバー）
-   - 現在はフォールバック（全ドメインユーザー readonly）で運用中
+   - ユーザー登録（ここの Claude Code セッションで直接実行）
+   - 権限例: admin=`["read", "write", "pay_statements"]`, editor=`["read", "write"]`, viewer=`["read"]`
 
-### Phase F2: Cloud Armor IP 制限
+3. **Cowork で CRUD 動作確認**
+   - admin ユーザーで `update_employee` / `create_employee` が表示・実行されること
+   - readonly ユーザーでは write ツールが拒否されること
+
+### Phase F2: Cloud Armor IP 制限（優先度低）
 - Cloud Armor ポリシーで Anthropic IP 範囲（160.79.104.0/21）を許可
 - アプリ内の XFF パースコード削除
 - IP_RESTRICTION_ENABLED 環境変数廃止
-
-### Phase G: CRUD 操作（E+F 安定後）
-- G1: SmartHR Client に PATCH/POST メソッド追加（DELETE なし）
-- G2: 2 フェーズ書き込み（prepare_* → confirm_*）
-- G3: フィールド許可リスト + 1 操作 = 1 従業員制限
-- G4: admin 限定 RBAC + 監査ログ
 
 ### 既存 Issues
 - #407: Phase 2: Anthropic HR Plugin 導入
@@ -84,14 +76,44 @@
 
 | 判断 | 決定 | 理由 |
 |------|------|------|
-| OAuth AS | 自前（Google OIDC 委譲） | 10-30名の社内ツール。Auth0 は過剰な依存・コスト |
-| OAuth 方式 | auth-code + PKCE のみ、リフレッシュトークンなし | Codex セカンドオピニオン: 意図的に狭い AS |
+| 権限モデル | パーミッション文字列方式 | ロール階層では粒度不足。"read"/"write"/"pay_statements" の3値で十分 |
+| 2フェーズ書き込み | 不要（スキップ） | MCP のAI確認フローが prepare/confirm の役割を果たす |
+| フィールド許可リスト | ハードコード（ランタイム強制） | セキュリティ上、設定変更はコードレビュー経由 |
+| POST リトライ | 禁止 | 非冪等操作の重複実行リスク回避 |
+| 空値除去 | null・空白含む全除去 | SmartHR API の空上書きによるデータ消失防止 |
+| OAuth AS | 自前（Google OIDC 委譲） | 10-30名の社内ツール。Auth0 は過剰 |
 | JWT | HS256, 1時間有効, aud/iss バインド | 短寿命でセキュリティ確保 |
-| fail-closed | UserStore null → アクセス拒否 | HR データ（PII）保護。fail-open は禁止 |
-| CRUD 方針 | PATCH のみ（PUT 禁止）、DELETE スコープ外 | SmartHR API のフィールド消失リスク回避 |
-| IP 制限 | Cloud Armor に移行予定 | アプリ内 XFF パースは脆弱（Codex 指摘） |
-| インスタンス | min=1, max=1 | インメモリ OAuth 状態保持 + コールドスタート防止 |
+| fail-closed | UserStore null → アクセス拒否 | HR データ（PII）保護 |
+| CRUD 方針 | PATCH + POST のみ（DELETE スコープ外） | SmartHR 退職は PATCH resigned_at |
 | CORS | ホワイトリスト | claude.ai, Cowork, 自サーバーのみ |
+
+---
+
+## MCP ツール一覧（8ツール）
+
+| ツール | 権限 | 説明 |
+|--------|------|------|
+| list_employees | read | 従業員一覧 |
+| get_employee | read | 従業員詳細 |
+| search_employees | read | 従業員検索 |
+| list_departments | read | 部署一覧 |
+| list_positions | read | 役職一覧 |
+| get_pay_statements | pay_statements | 給与明細 |
+| **update_employee** | **write** | **従業員更新（PATCH）** |
+| **create_employee** | **write** | **従業員登録（POST）** |
+
+## パーミッション設計
+
+```
+Permission = "read" | "write" | "pay_statements"
+
+Firestore mcp-users/{email}:
+{
+  role: "admin" | "readonly",       // レガシー（後方互換）
+  permissions?: Permission[],        // 細粒度制御（あればこちら優先）
+  enabled: boolean
+}
+```
 
 ---
 
@@ -122,10 +144,10 @@
 | Phase 12B | HTTP Shell + Dockerfile | 完了 |
 | Phase 12C | GCP インフラ + デプロイ | 完了 |
 | Phase 12D | 接続テスト + デモ | 完了（社長接続成功） |
-| Phase 12E | OAuth 2.1 実装 | **完了（Cowork 接続成功）** |
-| Phase 12F1 | CORS ホワイトリスト | **完了** |
+| Phase 12E | OAuth 2.1 実装 | 完了（Cowork 接続成功） |
+| Phase 12F1 | CORS ホワイトリスト | 完了 |
 | Phase 12F2 | Cloud Armor IP 制限 | 未着手 |
-| Phase 12G | CRUD 操作 | 未着手（E+F 安定後） |
+| Phase 12G | CRUD 操作 | **完了（デプロイ済み・実接続テスト済み）** |
 
 ---
 
@@ -136,7 +158,7 @@
 | Cloud Run (Worker) | デプロイ済み | `hr-worker` |
 | Cloud Run (API) | デプロイ済み | `hr-api` |
 | Cloud Run (Web) | デプロイ済み | `hr-web` |
-| Cloud Run (MCP) | **OAuth 本番稼働中** | `mcp-smarthr` (rev 00010, min=1/max=1) |
+| Cloud Run (MCP) | **CRUD 本番デプロイ済み** | `mcp-smarthr` (rev 00012, min=1/max=1) |
 
 ---
 
@@ -144,10 +166,10 @@
 
 | パッケージ | テスト数 | 状態 |
 |-----------|---------|------|
-| packages/mcp-smarthr | **88** | ✅ 全PASS |
-| apps/api | 22+ | ✅ |
-| apps/worker | 80 | ✅ |
-| apps/web | 207 | ✅ |
+| packages/mcp-smarthr | **98** | 全PASS |
+| apps/api | 22+ | 全PASS |
+| apps/worker | 80 | 全PASS |
+| apps/web | 207 | 全PASS |
 
 ---
 
@@ -161,10 +183,10 @@ git checkout main && git pull
 gcloud run services describe mcp-smarthr --region=asia-northeast1 --format="yaml(spec.template.spec.containers[0].env)"
 
 # OAuth エンドポイント動作確認
-curl -s https://mcp-smarthr-1021020088552.asia-northeast1.run.app/.well-known/oauth-protected-resource | python3 -m json.tool
+curl -s https://mcp-smarthr-1021020088552.asia-northeast1.run.app/health
 
 # 次のタスク:
-# 1. チームプラン カスタムコネクタ有効化
+# 1. チームプラン カスタムコネクタ有効化（社長操作）
 # 2. USE_FIRESTORE_USER_STORE=true + ユーザー登録
-# 3. Phase F2: Cloud Armor IP 制限
+# 3. Cowork で CRUD 動作確認
 ```


### PR DESCRIPTION
## Summary
- Phase G（CRUD操作 + パーミッションベース認可）完了を反映
- MCP ツール数: 6 → 8（update_employee, create_employee 追加）
- Cloud Run rev 00012 デプロイ済み
- SmartHR API 実接続テスト完了

## Test plan
- [x] ドキュメントのみの変更（構文確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)