### PR TITLE
docs: ドキュメント Phase G 対応 + 非エンジニア向けガイド

### DIFF
--- a/packages/mcp-smarthr/src/shells/http.ts
+++ b/packages/mcp-smarthr/src/shells/http.ts
@@ -202,6 +202,13 @@ export async function startHttp(options: HttpShellOptions): Promise<void> {
     return c.html(html);
   });
 
+  // 非エンジニア向けご利用ガイド（認証不要・IP 制限なし）
+  app.get("/guide", (c) => {
+    const __dirname = dirname(fileURLToPath(import.meta.url));
+    const html = readFileSync(resolve(__dirname, "../../static/guide.html"), "utf-8");
+    return c.html(html);
+  });
+
   // Anthropic IP 制限（/mcp のみ）
   if (ipRestrictionEnabled) {
     app.use("/mcp", async (c, next) => {

--- a/packages/mcp-smarthr/static/docs.html
+++ b/packages/mcp-smarthr/static/docs.html
@@ -63,12 +63,12 @@ tailwind.config = {
       サーバーです。
     </p>
     <p>
-      AI アシスタント（Claude）から SmartHR の人事データを安全に参照できるようにします。
-      読み取り専用の 6 つのツールを提供し、従業員情報・部署・役職・給与明細の参照が可能です。
+      AI アシスタント（Claude）から SmartHR の人事データを安全に参照・更新できるようにします。
+      8 つのツールを提供し、従業員情報の閲覧・検索・更新・登録、部署・役職の参照、給与明細の参照が可能です。
     </p>
     <div class="grid md:grid-cols-3 gap-4 mt-6">
       <div class="bg-brand-50 rounded-lg p-4 text-center">
-        <div class="text-3xl font-bold text-brand-700">6</div>
+        <div class="text-3xl font-bold text-brand-700">8</div>
         <div class="text-sm text-gray-600 mt-1">利用可能ツール</div>
       </div>
       <div class="bg-brand-50 rounded-lg p-4 text-center">
@@ -110,7 +110,7 @@ graph TB
 
   subgraph Core["Core（ビジネスロジック）"]
     AUTH["4層認証"]
-    TOOLS["ツール定義<br/>6ツール"]
+    TOOLS["ツール定義<br/>8ツール"]
     PII["PII フィルタ"]
     AUDIT["監査ログ"]
     RL["レート制限"]
@@ -196,8 +196,9 @@ flowchart TD
   L3 -->|"未登録"| DENY3["403 Forbidden"]
 
   L4{"Layer 4: ツール権限"}
-  L4 -->|"admin"| ALL["全ツール利用可"]
-  L4 -->|"readonly"| LIMITED["給与明細以外<br/>利用可"]
+  L4 -->|"read+write+pay"| ALL["全ツール利用可"]
+  L4 -->|"read+write"| WRITE["閲覧+更新"]
+  L4 -->|"read"| LIMITED["閲覧のみ"]
 
   style L1 fill:#fef3c7,stroke:#d97706
   style L2 fill:#e0f2fe,stroke:#0284c7
@@ -208,12 +209,13 @@ flowchart TD
   style DENY3 fill:#fee2e2,stroke:#dc2626
     </div>
 
-    <h3 class="text-lg font-semibold mt-8">ロールと権限</h3>
+    <h3 class="text-lg font-semibold mt-8">パーミッションと権限</h3>
+    <p class="text-gray-600 mb-3">アカウント毎に細かく操作権限を設定できます。</p>
     <div class="overflow-x-auto">
       <table class="w-full text-sm border-collapse">
         <thead>
           <tr class="bg-gray-50">
-            <th class="border border-gray-200 px-4 py-2 text-left">ロール</th>
+            <th class="border border-gray-200 px-4 py-2 text-left">パーミッション</th>
             <th class="border border-gray-200 px-4 py-2 text-left">アクセス可能ツール</th>
             <th class="border border-gray-200 px-4 py-2 text-left">PII アクセス</th>
           </tr>
@@ -221,16 +223,23 @@ flowchart TD
         <tbody>
           <tr>
             <td class="border border-gray-200 px-4 py-2">
-              <span class="bg-purple-100 text-purple-700 px-2 py-0.5 rounded text-xs font-medium">admin</span>
+              <span class="bg-purple-100 text-purple-700 px-2 py-0.5 rounded text-xs font-medium">read + write + pay_statements</span>
             </td>
-            <td class="border border-gray-200 px-4 py-2">全 6 ツール（給与明細含む）</td>
+            <td class="border border-gray-200 px-4 py-2">全 8 ツール（閲覧 + 更新 + 給与明細）</td>
             <td class="border border-gray-200 px-4 py-2">生年月日・性別・連絡先を含む（マイナンバーは除外）</td>
           </tr>
           <tr class="bg-gray-50">
             <td class="border border-gray-200 px-4 py-2">
-              <span class="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs font-medium">readonly</span>
+              <span class="bg-green-100 text-green-700 px-2 py-0.5 rounded text-xs font-medium">read + write</span>
             </td>
-            <td class="border border-gray-200 px-4 py-2">5 ツール（給与明細を除く）</td>
+            <td class="border border-gray-200 px-4 py-2">閲覧 + 更新・登録（給与明細を除く）</td>
+            <td class="border border-gray-200 px-4 py-2">PII フィールドは自動除外</td>
+          </tr>
+          <tr>
+            <td class="border border-gray-200 px-4 py-2">
+              <span class="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs font-medium">read</span>
+            </td>
+            <td class="border border-gray-200 px-4 py-2">閲覧のみ（6 ツール）</td>
             <td class="border border-gray-200 px-4 py-2">PII フィールドは自動除外</td>
           </tr>
         </tbody>
@@ -309,9 +318,9 @@ flowchart TD
     <div class="bg-white rounded-xl border border-gray-200 p-6">
       <div class="flex items-center gap-3 mb-3">
         <code class="bg-gray-100 text-brand-700 px-3 py-1 rounded-lg font-mono text-sm font-bold">get_pay_statements</code>
-        <span class="bg-purple-100 text-purple-700 px-2 py-0.5 rounded text-xs">admin</span>
+        <span class="bg-purple-100 text-purple-700 px-2 py-0.5 rounded text-xs">pay_statements</span>
       </div>
-      <p class="text-gray-600 mb-3">給与明細を取得します。従業員ID・年・月で絞り込み可能。<strong>admin ロール必須。</strong></p>
+      <p class="text-gray-600 mb-3">給与明細を取得します。従業員ID・年・月で絞り込み可能。<strong>pay_statements 権限必須。</strong></p>
       <div class="bg-gray-50 rounded-lg p-4">
         <p class="text-xs text-gray-500 mb-2 font-medium">パラメータ</p>
         <table class="w-full text-sm">
@@ -365,6 +374,56 @@ flowchart TD
       <div class="mt-3 bg-gray-900 text-gray-100 rounded-lg p-4 text-sm">
         <p class="text-gray-400 text-xs mb-1">使用例</p>
         <code>"役職の一覧を整理して"</code>
+      </div>
+    </div>
+
+    <!-- update_employee -->
+    <div class="bg-white rounded-xl border border-green-200 p-6">
+      <div class="flex items-center gap-3 mb-3">
+        <code class="bg-green-50 text-green-700 px-3 py-1 rounded-lg font-mono text-sm font-bold">update_employee</code>
+        <span class="bg-green-100 text-green-700 px-2 py-0.5 rounded text-xs">write</span>
+      </div>
+      <p class="text-gray-600 mb-3">従業員情報を部分更新します（PATCH）。変更するフィールドのみ指定します。</p>
+      <div class="bg-gray-50 rounded-lg p-4">
+        <p class="text-xs text-gray-500 mb-2 font-medium">パラメータ</p>
+        <table class="w-full text-sm">
+          <tr><td class="py-1"><code class="text-xs">id</code> <span class="text-red-500">*</span></td><td class="text-gray-500">SmartHR 従業員ID（必須）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">last_name</code></td><td class="text-gray-500">姓（任意）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">first_name</code></td><td class="text-gray-500">名（任意）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">emp_code</code></td><td class="text-gray-500">社員番号（任意）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">entered_at</code></td><td class="text-gray-500">入社日（任意）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">resigned_at</code></td><td class="text-gray-500">退職日（任意）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">department</code></td><td class="text-gray-500">部署ID（任意）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">position</code></td><td class="text-gray-500">役職ID（任意）</td></tr>
+        </table>
+      </div>
+      <div class="mt-3 bg-gray-900 text-gray-100 rounded-lg p-4 text-sm">
+        <p class="text-gray-400 text-xs mb-1">使用例</p>
+        <code>"田中さんの部署を人事部に変更して"</code>
+      </div>
+    </div>
+
+    <!-- create_employee -->
+    <div class="bg-white rounded-xl border border-green-200 p-6">
+      <div class="flex items-center gap-3 mb-3">
+        <code class="bg-green-50 text-green-700 px-3 py-1 rounded-lg font-mono text-sm font-bold">create_employee</code>
+        <span class="bg-green-100 text-green-700 px-2 py-0.5 rounded text-xs">write</span>
+      </div>
+      <p class="text-gray-600 mb-3">新しい従業員を SmartHR に登録します。</p>
+      <div class="bg-gray-50 rounded-lg p-4">
+        <p class="text-xs text-gray-500 mb-2 font-medium">パラメータ</p>
+        <table class="w-full text-sm">
+          <tr><td class="py-1"><code class="text-xs">last_name</code> <span class="text-red-500">*</span></td><td class="text-gray-500">姓（必須）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">first_name</code> <span class="text-red-500">*</span></td><td class="text-gray-500">名（必須）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">emp_code</code></td><td class="text-gray-500">社員番号（任意）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">entered_at</code></td><td class="text-gray-500">入社日（任意）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">department</code></td><td class="text-gray-500">部署ID（任意）</td></tr>
+          <tr><td class="py-1"><code class="text-xs">position</code></td><td class="text-gray-500">役職ID（任意）</td></tr>
+        </table>
+      </div>
+      <div class="mt-3 bg-gray-900 text-gray-100 rounded-lg p-4 text-sm">
+        <p class="text-gray-400 text-xs mb-1">使用例</p>
+        <code>"新入社員の山田花子さん（社員番号: 2001、入社日: 2026-04-01）を登録して"</code>
       </div>
     </div>
 
@@ -453,7 +512,7 @@ flowchart LR
     IP["IP 制限<br/>Anthropic IP のみ"]
     OAUTH["OAuth 2.0<br/>Google 認証"]
     DOMAIN["ドメイン制限<br/>@aozora-cg.com"]
-    RBAC["RBAC<br/>admin / readonly"]
+    RBAC["パーミッション制御<br/>read / write / pay"]
     PIIF["PII フィルタ<br/>個人情報保護"]
     AUDITL["監査ログ<br/>全操作記録"]
   end
@@ -564,8 +623,10 @@ graph LR
     <details class="bg-white rounded-xl border border-gray-200 p-6 group" open>
       <summary class="font-semibold cursor-pointer">データの書き込み・更新はできますか？</summary>
       <p class="mt-3 text-gray-600">
-        現在は<strong>読み取り専用</strong>です。今後、承認フロー（Human-in-the-loop）を組み込んだ上で、
-        書き込み操作を追加する予定です。AI が直接データを変更することはありません。
+        はい。<strong>write 権限</strong>を持つユーザーは、従業員情報の更新（<code>update_employee</code>）と
+        新規登録（<code>create_employee</code>）が可能です。AI は実行前に必ず変更内容を確認し、
+        ユーザーの承認を得てから SmartHR API を呼び出します。
+        更新可能なフィールドは氏名・社員番号・入退社日・部署・役職に限定されています。
       </p>
     </details>
 
@@ -580,8 +641,8 @@ graph LR
     <details class="bg-white rounded-xl border border-gray-200 p-6 group">
       <summary class="font-semibold cursor-pointer">給与情報は誰でも見られますか？</summary>
       <p class="mt-3 text-gray-600">
-        いいえ。<strong>admin ロール</strong>のユーザーのみが <code>get_pay_statements</code> ツールを利用できます。
-        readonly ユーザーが呼び出すと「権限不足」エラーが返ります。
+        いいえ。<strong>pay_statements 権限</strong>を持つユーザーのみが <code>get_pay_statements</code> ツールを利用できます。
+        権限のないユーザーが呼び出すと「権限不足」エラーが返ります。
       </p>
     </details>
 

--- a/packages/mcp-smarthr/static/guide.html
+++ b/packages/mcp-smarthr/static/guide.html
@@ -1,0 +1,280 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>SmartHR AI アシスタント - ご利用ガイド</title>
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+tailwind.config = {
+  theme: {
+    extend: {
+      colors: {
+        brand: { 50: '#f0f9ff', 100: '#e0f2fe', 500: '#0ea5e9', 600: '#0284c7', 700: '#0369a1', 900: '#0c4a6e' }
+      }
+    }
+  }
+}
+</script>
+<style>
+  html { scroll-behavior: smooth; }
+</style>
+</head>
+<body class="bg-gray-50 text-gray-900">
+
+<!-- Header -->
+<header class="bg-brand-700 text-white">
+  <div class="max-w-3xl mx-auto px-6 py-10 text-center">
+    <h1 class="text-3xl font-bold">SmartHR AI アシスタント</h1>
+    <p class="mt-2 text-brand-100 text-lg">Claude で SmartHR の人事データを検索・更新</p>
+    <p class="mt-4 text-sm text-brand-200">あおぞらケアグループ 社内ツール</p>
+  </div>
+</header>
+
+<main class="max-w-3xl mx-auto px-6 py-10 space-y-12">
+
+<!-- What is this -->
+<section>
+  <h2 class="text-2xl font-bold mb-4">これは何ですか？</h2>
+  <div class="bg-white rounded-xl border border-gray-200 p-6 space-y-4">
+    <p>
+      普段お使いの <strong>Claude</strong>（AI チャット）から、SmartHR の従業員情報を
+      <strong>日本語で質問するだけ</strong>で検索・確認・更新ができるツールです。
+    </p>
+    <div class="bg-brand-50 rounded-lg p-4">
+      <p class="font-semibold text-brand-700 mb-2">例えばこんなことができます</p>
+      <ul class="space-y-2 text-gray-700">
+        <li>「田中さんの社員番号を教えて」</li>
+        <li>「人事部の従業員一覧を出して」</li>
+        <li>「新入社員の山田花子さんを登録して」</li>
+        <li>「佐藤さんの部署を営業部に変更して」</li>
+      </ul>
+    </div>
+    <p class="text-sm text-gray-500">
+      ※ SmartHR の画面を開く必要はありません。Claude との会話の中で完結します。
+    </p>
+  </div>
+</section>
+
+<!-- How to start -->
+<section>
+  <h2 class="text-2xl font-bold mb-4">はじめかた</h2>
+  <div class="space-y-4">
+
+    <div class="bg-white rounded-xl border border-gray-200 p-6">
+      <div class="flex items-start gap-4">
+        <div class="bg-brand-100 text-brand-700 rounded-full w-10 h-10 flex items-center justify-center font-bold text-lg shrink-0">1</div>
+        <div>
+          <h3 class="font-semibold text-lg">Claude にログイン</h3>
+          <p class="text-gray-600 mt-1">
+            <a href="https://claude.ai" class="text-brand-600 underline" target="_blank">claude.ai</a> に
+            <strong>@aozora-cg.com</strong> の Google アカウントでログインしてください。
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-white rounded-xl border border-gray-200 p-6">
+      <div class="flex items-start gap-4">
+        <div class="bg-brand-100 text-brand-700 rounded-full w-10 h-10 flex items-center justify-center font-bold text-lg shrink-0">2</div>
+        <div>
+          <h3 class="font-semibold text-lg">SmartHR コネクタを有効化</h3>
+          <p class="text-gray-600 mt-1">
+            画面左下の <strong>Customize</strong> &gt; <strong>Connectors</strong> から
+            「<strong>SmartHR</strong>」を見つけて <strong>Connect</strong> をクリック。
+            Google アカウントで認証します。
+          </p>
+          <div class="mt-2 bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800">
+            <strong>初回のみ:</strong> 管理者がコネクタを追加するまで表示されません。
+            見つからない場合は管理者にお問い合わせください。
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="bg-white rounded-xl border border-gray-200 p-6">
+      <div class="flex items-start gap-4">
+        <div class="bg-brand-100 text-brand-700 rounded-full w-10 h-10 flex items-center justify-center font-bold text-lg shrink-0">3</div>
+        <div>
+          <h3 class="font-semibold text-lg">会話で使う</h3>
+          <p class="text-gray-600 mt-1">
+            新しい会話を始め、チャット入力欄の <strong>+</strong> ボタンから
+            「<strong>Connectors</strong>」で SmartHR を ON にして、日本語で質問するだけです。
+          </p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- What you can do -->
+<section>
+  <h2 class="text-2xl font-bold mb-4">できること</h2>
+
+  <div class="grid md:grid-cols-2 gap-4">
+
+    <div class="bg-white rounded-xl border border-gray-200 p-6">
+      <div class="flex items-center gap-2 mb-3">
+        <span class="text-2xl">🔍</span>
+        <h3 class="font-semibold">検索・閲覧</h3>
+        <span class="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs ml-auto">全員</span>
+      </div>
+      <ul class="text-gray-600 space-y-1 text-sm">
+        <li>従業員の検索（名前・社員番号）</li>
+        <li>従業員の詳細情報の確認</li>
+        <li>部署一覧の表示</li>
+        <li>役職一覧の表示</li>
+      </ul>
+    </div>
+
+    <div class="bg-white rounded-xl border border-green-200 p-6">
+      <div class="flex items-center gap-2 mb-3">
+        <span class="text-2xl">✏️</span>
+        <h3 class="font-semibold">更新・登録</h3>
+        <span class="bg-green-100 text-green-700 px-2 py-0.5 rounded text-xs ml-auto">write 権限</span>
+      </div>
+      <ul class="text-gray-600 space-y-1 text-sm">
+        <li>従業員情報の変更（氏名・部署・役職 等）</li>
+        <li>新しい従業員の登録</li>
+        <li>退職日の設定</li>
+      </ul>
+      <p class="text-xs text-gray-400 mt-2">※ AI は実行前に必ず確認を求めます</p>
+    </div>
+
+    <div class="bg-white rounded-xl border border-purple-200 p-6">
+      <div class="flex items-center gap-2 mb-3">
+        <span class="text-2xl">💰</span>
+        <h3 class="font-semibold">給与明細</h3>
+        <span class="bg-purple-100 text-purple-700 px-2 py-0.5 rounded text-xs ml-auto">特別権限</span>
+      </div>
+      <ul class="text-gray-600 space-y-1 text-sm">
+        <li>給与明細の参照</li>
+        <li>年月や従業員での絞り込み</li>
+      </ul>
+      <p class="text-xs text-gray-400 mt-2">※ 管理者のみアクセス可能</p>
+    </div>
+
+    <div class="bg-gray-100 rounded-xl border border-gray-200 p-6">
+      <div class="flex items-center gap-2 mb-3">
+        <span class="text-2xl">🚫</span>
+        <h3 class="font-semibold text-gray-500">できないこと</h3>
+      </div>
+      <ul class="text-gray-500 space-y-1 text-sm">
+        <li>従業員の削除</li>
+        <li>銀行口座・マイナンバーの閲覧</li>
+        <li>給与計算（計算は専用システムで行います）</li>
+      </ul>
+    </div>
+
+  </div>
+</section>
+
+<!-- Safety -->
+<section>
+  <h2 class="text-2xl font-bold mb-4">安全性について</h2>
+  <div class="bg-white rounded-xl border border-gray-200 p-6">
+    <div class="grid md:grid-cols-2 gap-6">
+      <div>
+        <h3 class="font-semibold mb-2">🔐 アクセス制限</h3>
+        <p class="text-sm text-gray-600">
+          @aozora-cg.com のアカウントでログインしたメンバーのみ利用可能です。
+          外部の人がアクセスすることはできません。
+        </p>
+      </div>
+      <div>
+        <h3 class="font-semibold mb-2">👤 個人情報の保護</h3>
+        <p class="text-sm text-gray-600">
+          権限に応じて、生年月日・性別・電話番号などの個人情報は自動的に非表示になります。
+          マイナンバーは誰にも表示されません。
+        </p>
+      </div>
+      <div>
+        <h3 class="font-semibold mb-2">📝 操作記録</h3>
+        <p class="text-sm text-gray-600">
+          誰がいつ何を見たか・変更したかは全て記録されています。
+          不正な利用は追跡可能です。
+        </p>
+      </div>
+      <div>
+        <h3 class="font-semibold mb-2">✅ 変更前の確認</h3>
+        <p class="text-sm text-gray-600">
+          データを変更する際、AI は必ず「この内容で更新してよいですか？」と確認します。
+          確認なしに勝手に変更されることはありません。
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- FAQ -->
+<section>
+  <h2 class="text-2xl font-bold mb-4">よくある質問</h2>
+  <div class="space-y-3">
+
+    <details class="bg-white rounded-xl border border-gray-200 p-5 group" open>
+      <summary class="font-semibold cursor-pointer">SmartHR にログインしなくても使えますか？</summary>
+      <p class="mt-3 text-gray-600 text-sm">
+        はい。Claude にログインして SmartHR コネクタを有効にするだけで使えます。
+        SmartHR の画面を開く必要はありません。
+      </p>
+    </details>
+
+    <details class="bg-white rounded-xl border border-gray-200 p-5 group">
+      <summary class="font-semibold cursor-pointer">AI が間違った情報を返すことはありますか？</summary>
+      <p class="mt-3 text-gray-600 text-sm">
+        SmartHR に登録されているデータをそのまま表示するため、データ自体が間違うことはありません。
+        ただし、AI の応答文（要約や解釈）には誤りが含まれる可能性があります。
+        重要な判断は必ず元データを確認してください。
+      </p>
+    </details>
+
+    <details class="bg-white rounded-xl border border-gray-200 p-5 group">
+      <summary class="font-semibold cursor-pointer">うっかり間違ったデータを更新してしまったら？</summary>
+      <p class="mt-3 text-gray-600 text-sm">
+        AI は更新前に必ず確認を求めるので、内容を確認してから承認してください。
+        万が一間違えた場合は、SmartHR の管理画面から修正するか、
+        AI に「元に戻して」と指示してください。全操作は監査ログに記録されています。
+      </p>
+    </details>
+
+    <details class="bg-white rounded-xl border border-gray-200 p-5 group">
+      <summary class="font-semibold cursor-pointer">スマホからも使えますか？</summary>
+      <p class="mt-3 text-gray-600 text-sm">
+        はい。Claude のモバイルアプリまたはブラウザ版（claude.ai）から利用可能です。
+      </p>
+    </details>
+
+    <details class="bg-white rounded-xl border border-gray-200 p-5 group">
+      <summary class="font-semibold cursor-pointer">「権限不足」と表示されます</summary>
+      <p class="mt-3 text-gray-600 text-sm">
+        あなたのアカウントにその操作の権限がありません。
+        必要な場合は管理者に権限の付与を依頼してください。
+      </p>
+    </details>
+
+  </div>
+</section>
+
+<!-- Contact -->
+<section>
+  <div class="bg-brand-50 rounded-xl border border-brand-200 p-6 text-center">
+    <p class="text-brand-700 font-semibold">困ったことがあれば</p>
+    <p class="text-sm text-gray-600 mt-2">
+      管理者または情報システム担当にお問い合わせください。
+    </p>
+  </div>
+</section>
+
+</main>
+
+<!-- Footer -->
+<footer class="bg-gray-100 border-t border-gray-200 mt-16">
+  <div class="max-w-3xl mx-auto px-6 py-6 flex justify-between items-center text-sm text-gray-500">
+    <p>&copy; 2026 Aozora Care Group</p>
+    <a href="/docs" class="text-brand-600 hover:underline">技術ドキュメント &rarr;</a>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- `/docs` ページを Phase G（CRUD + パーミッション）対応に更新
- `/guide` ページを新規作成（非エンジニア向けご利用ガイド）

## 変更内容
- docs.html: 6ツール→8ツール、admin/readonly→パーミッションベース、FAQ更新
- guide.html: はじめかた、できること、安全性、FAQ（非技術者向け）
- http.ts: `/guide` エンドポイント追加

## Test plan
- [x] lint / typecheck / test 全PASS（98テスト）
- [ ] デプロイ後 `/docs` と `/guide` の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)