### PR TITLE
fix: ガイドの UI 表記を日本語版 Claude に合わせて修正

### DIFF
--- a/packages/mcp-smarthr/static/docs.html
+++ b/packages/mcp-smarthr/static/docs.html
@@ -442,13 +442,19 @@ flowchart TD
         <span class="bg-orange-100 text-orange-700 px-2 py-0.5 rounded text-xs">推奨</span>
         Cowork / claude.ai
       </h3>
+      <p class="text-gray-600 mb-3 font-semibold">管理者（組織オーナー）の操作:</p>
       <ol class="list-decimal list-inside space-y-2 text-gray-600">
         <li><strong>設定</strong> &gt; <strong>コネクタ</strong> を開く</li>
         <li><strong>カスタムコネクタを追加</strong> をクリック</li>
-        <li>名前: <code class="bg-gray-100 px-2 py-0.5 rounded text-sm">ACG_SmartHR_MCP</code></li>
+        <li>名前: <code class="bg-gray-100 px-2 py-0.5 rounded text-sm">SmartHR</code></li>
         <li>URL: MCP サーバーの <code class="bg-gray-100 px-2 py-0.5 rounded text-sm">/mcp</code> エンドポイント URL を入力</li>
         <li><strong>追加</strong> をクリック</li>
-        <li>会話で「従業員一覧を見せて」と入力してテスト</li>
+      </ol>
+      <p class="text-gray-600 mt-4 mb-3 font-semibold">メンバーの操作:</p>
+      <ol class="list-decimal list-inside space-y-2 text-gray-600">
+        <li><strong>設定</strong> &gt; <strong>コネクタ</strong> で「SmartHR」の <strong>連携/連携させる</strong> をクリック</li>
+        <li>Google アカウント（@aozora-cg.com）で認証</li>
+        <li>会話の <strong>+</strong> ボタン &gt; <strong>コネクタ</strong> で SmartHR を ON にして使用</li>
       </ol>
       <div class="mt-4 bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
         <strong>注意:</strong> Team/Enterprise プランではカスタムコネクタの追加に組織オーナー権限が必要です。

--- a/packages/mcp-smarthr/static/guide.html
+++ b/packages/mcp-smarthr/static/guide.html
@@ -80,8 +80,8 @@ tailwind.config = {
         <div>
           <h3 class="font-semibold text-lg">SmartHR コネクタを有効化</h3>
           <p class="text-gray-600 mt-1">
-            画面左下の <strong>Customize</strong> &gt; <strong>Connectors</strong> から
-            「<strong>SmartHR</strong>」を見つけて <strong>Connect</strong> をクリック。
+            <strong>設定</strong> &gt; <strong>コネクタ</strong> から
+            「<strong>SmartHR</strong>」を見つけて <strong>連携/連携させる</strong> をクリック。
             Google アカウントで認証します。
           </p>
           <div class="mt-2 bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800">
@@ -99,7 +99,7 @@ tailwind.config = {
           <h3 class="font-semibold text-lg">会話で使う</h3>
           <p class="text-gray-600 mt-1">
             新しい会話を始め、チャット入力欄の <strong>+</strong> ボタンから
-            「<strong>Connectors</strong>」で SmartHR を ON にして、日本語で質問するだけです。
+            「<strong>コネクタ</strong>」で SmartHR を ON にして、日本語で質問するだけです。
           </p>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- guide.html / docs.html の UI 表記を実際の日本語版 Claude に合わせて修正
- Customize → 設定、Connectors → コネクタ、Connect → 連携/連携させる

## Test plan
- [x] HTML のみの変更
- [ ] デプロイ後に /guide と /docs の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)