### PR TITLE
fix: ファビコン追加（favicon.ico 404 解消）

### DIFF
--- a/packages/mcp-smarthr/static/docs.html
+++ b/packages/mcp-smarthr/static/docs.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%230284c7'/><text x='50' y='68' font-size='50' text-anchor='middle' fill='white' font-family='sans-serif' font-weight='bold'>HR</text></svg>">
 <title>ACG SmartHR MCP Server - Documentation</title>
 <script src="https://cdn.tailwindcss.com"></script>
 <script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>

--- a/packages/mcp-smarthr/static/guide.html
+++ b/packages/mcp-smarthr/static/guide.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><rect width='100' height='100' rx='20' fill='%230284c7'/><text x='50' y='68' font-size='50' text-anchor='middle' fill='white' font-family='sans-serif' font-weight='bold'>HR</text></svg>">
 <title>SmartHR AI アシスタント - ご利用ガイド</title>
 <script src="https://cdn.tailwindcss.com"></script>
 <script>


### PR DESCRIPTION
## Summary
- docs.html / guide.html にインライン SVG ファビコンを追加
- ブラウザの favicon.ico 404 エラーを解消
- 青い角丸四角に「HR」の白文字

## Test plan
- [x] HTML のみの変更（link タグ1行追加 x 2ファイル）
- [ ] デプロイ後にブラウザタブにファビコン表示を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)