### PR TITLE
docs: Team プランのコネクタ共有説明を追加

### DIFF
--- a/packages/mcp-smarthr/static/docs.html
+++ b/packages/mcp-smarthr/static/docs.html
@@ -446,7 +446,10 @@ flowchart TD
         <span class="bg-orange-100 text-orange-700 px-2 py-0.5 rounded text-xs">推奨</span>
         Cowork / claude.ai
       </h3>
-      <p class="text-gray-600 mb-3 font-semibold">管理者（組織オーナー）の操作:</p>
+      <div class="bg-brand-50 border border-brand-200 rounded-lg p-4 mb-4 text-sm text-brand-800">
+        <strong>Team プラン:</strong> 組織オーナーが 1 回コネクタを登録すれば、メンバーは個別にカスタムコネクタを追加する必要はありません。メンバーは「連携させる」をクリックして Google 認証するだけで利用開始できます。
+      </div>
+      <p class="text-gray-600 mb-3 font-semibold">管理者（組織オーナー）の操作（初回のみ）:</p>
       <ol class="list-decimal list-inside space-y-2 text-gray-600">
         <li><strong>設定</strong> &gt; <strong>コネクタ</strong> を開く</li>
         <li><strong>カスタムコネクタを追加</strong> をクリック</li>
@@ -460,10 +463,6 @@ flowchart TD
         <li>Google アカウント（@aozora-cg.com）で認証</li>
         <li>会話の <strong>+</strong> ボタン &gt; <strong>コネクタ</strong> で SmartHR を ON にして使用</li>
       </ol>
-      <div class="mt-4 bg-amber-50 border border-amber-200 rounded-lg p-4 text-sm text-amber-800">
-        <strong>注意:</strong> Team/Enterprise プランではカスタムコネクタの追加に組織オーナー権限が必要です。
-        個人 Pro/Max プランでは制限なく追加できます。
-      </div>
     </div>
 
     <!-- Claude Code -->

--- a/packages/mcp-smarthr/static/guide.html
+++ b/packages/mcp-smarthr/static/guide.html
@@ -83,11 +83,14 @@ tailwind.config = {
           <p class="text-gray-600 mt-1">
             <strong>設定</strong> &gt; <strong>コネクタ</strong> から
             「<strong>SmartHR</strong>」を見つけて <strong>連携/連携させる</strong> をクリック。
-            Google アカウントで認証します。
+            Google アカウント（@aozora-cg.com）で認証します。
+          </p>
+          <p class="text-gray-500 text-sm mt-2">
+            管理者が既にコネクタを登録済みなので、URL の入力などは不要です。
+            「連携させる」をクリックするだけで使えます。
           </p>
           <div class="mt-2 bg-amber-50 border border-amber-200 rounded-lg p-3 text-sm text-amber-800">
-            <strong>初回のみ:</strong> 管理者がコネクタを追加するまで表示されません。
-            見つからない場合は管理者にお問い合わせください。
+            <strong>見つからない場合:</strong> 管理者がまだコネクタを追加していない可能性があります。管理者にお問い合わせください。
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- docs/guide 両ページに「オーナーが1回登録すればメンバーは個別追加不要」の説明追加
- メンバー向けの手順を「連携させるをクリックするだけ」に明確化

## Test plan
- [x] HTML のみの変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)