### PR TITLE
feat: Firestore UserStore 有効化 — 許可リスト方式に切替

### DIFF
--- a/packages/mcp-smarthr/scripts/seed-users.ts
+++ b/packages/mcp-smarthr/scripts/seed-users.ts
@@ -1,0 +1,54 @@
+/**
+ * Firestore mcp-users コレクションに初期ユーザーを登録するスクリプト
+ *
+ * 実行: npx tsx packages/mcp-smarthr/scripts/seed-users.ts
+ * 前提: ADC が設定済みであること
+ */
+
+import { FirestoreUserStore } from "../src/core/stores/firestore-user-store.js";
+
+const ADMIN_USERS = [
+  "kosuke.omure@aozora-cg.com",
+  "tomohiro.arikawa@aozora-cg.com",
+  "makoto.tokunaga@aozora-cg.com",
+  "yasushi.honda@aozora-cg.com",
+];
+
+const READONLY_USERS = [
+  "ryota.yagi@aozora-cg.com",
+  "gen.ichihara@aozora-cg.com",
+  "rika.komatsu@aozora-cg.com",
+  "shoma.horinouchi@aozora-cg.com",
+  "tomoko.hommura@aozora-cg.com",
+  "yuka.yoshimura@aozora-cg.com",
+];
+
+async function main() {
+  const store = new FirestoreUserStore({ projectId: "hr-system-487809" });
+
+  console.log("=== mcp-users シード開始 ===\n");
+
+  for (const email of ADMIN_USERS) {
+    await store.setUser(email, "admin", true);
+    console.log(`  [admin]    ${email}`);
+  }
+
+  for (const email of READONLY_USERS) {
+    await store.setUser(email, "readonly", true);
+    console.log(`  [readonly] ${email}`);
+  }
+
+  console.log("\n=== 登録完了。確認中... ===\n");
+
+  const users = await store.listUsers();
+  for (const u of users) {
+    console.log(`  ${u.email}: role=${u.role}, enabled=${u.enabled}`);
+  }
+
+  console.log(`\n合計: ${users.length} ユーザー`);
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- MCP サーバーのアクセス制御を、ドメイン内全員許可から **Firestore 許可リスト方式** に変更
- admin 4名（全操作可）、readonly 6名（読み取りのみ）を `mcp-users` コレクションに登録するシードスクリプトを追加
- Cloud Run 環境変数 `USE_FIRESTORE_USER_STORE=true` は手動設定済み（rev mcp-smarthr-00018-tts）

## 登録ユーザー
| ロール | アカウント |
|--------|-----------|
| admin | kosuke.omure, tomohiro.arikawa, makoto.tokunaga, yasushi.honda |
| readonly | ryota.yagi, gen.ichihara, rika.komatsu, shoma.horinouchi, tomoko.hommura, yuka.yoshimura |

## Test plan
- [x] Firestore `mcp-users` コレクションに10名登録確認済み
- [x] Cloud Run 環境変数 `USE_FIRESTORE_USER_STORE=true` 設定確認済み
- [ ] admin アカウントで write 操作が可能なことを確認
- [ ] readonly アカウントで write 操作が拒否されることを確認
- [ ] 未登録アカウントで接続が拒否されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)