### PR TITLE
docs: 権限モデルのドキュメント詳細化 + UserStore有効化反映

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -66,14 +66,14 @@
    - オーナーが1回登録すれば、メンバーは「連携させる」をクリックするだけ
    - チームメンバーの接続テスト
 
-2. **Firestore UserStore 有効化 + ユーザー登録**
-   - `USE_FIRESTORE_USER_STORE=true` に変更
-   - ユーザー登録（Claude Code セッションで直接実行）
-   - 権限例: `["read", "write", "pay_statements"]` / `["read", "write"]` / `["read"]`
+2. ~~**Firestore UserStore 有効化 + ユーザー登録**~~ ✅ 完了（PR #432）
+   - `USE_FIRESTORE_USER_STORE=true` に変更済み（rev mcp-smarthr-00018-tts）
+   - 10名登録済み（admin 4名 + readonly 6名）
 
 3. **Cowork で CRUD 動作確認**
    - admin ユーザーで `update_employee` / `create_employee` が実行されること
    - readonly ユーザーでは write ツールが拒否されること
+   - 未登録アカウントで接続が拒否されること
 
 ### Phase F2: Cloud Armor IP 制限（優先度低）
 - Cloud Armor ポリシーで Anthropic IP 範囲を許可
@@ -97,6 +97,19 @@
 | JWT | HS256, 1時間有効 | 短寿命でセキュリティ確保 |
 | fail-closed | UserStore null → 拒否 | PII 保護 |
 | CRUD | PATCH + POST のみ | DELETE スコープ外 |
+
+---
+
+## 登録ユーザー（Firestore `mcp-users`）
+
+| ロール | 権限 | アカウント |
+|--------|------|-----------|
+| **admin** | 閲覧 + 更新 + 登録 + 給与明細 | kosuke.omure, tomohiro.arikawa, makoto.tokunaga, yasushi.honda |
+| **readonly** | 閲覧のみ | ryota.yagi, gen.ichihara, rika.komatsu, shoma.horinouchi, tomoko.hommura, yuka.yoshimura |
+
+- 未登録の @aozora-cg.com アカウントはアクセス不可（fail-closed）
+- 削除操作は全ロールで不可（未実装・スコープ外）
+- ユーザー追加・変更: `npx tsx packages/mcp-smarthr/scripts/seed-users.ts` を編集して実行
 
 ---
 
@@ -129,7 +142,7 @@
 | 変数 | 値 | 備考 |
 |------|-----|------|
 | AUTH_DISABLED | false | OAuth 2.1 有効 |
-| USE_FIRESTORE_USER_STORE | **false** | 次セッションで true に変更予定 |
+| USE_FIRESTORE_USER_STORE | **true** | PR #432 で有効化済み |
 | IP_RESTRICTION_ENABLED | false | Cloud Armor 移行予定 |
 
 ---
@@ -138,7 +151,7 @@
 
 | サービス | 状態 |
 |---------|------|
-| Cloud Run (MCP) | rev 00017 稼働中 |
+| Cloud Run (MCP) | rev 00018 稼働中（UserStore 有効化） |
 | Cloud Run (Worker) | デプロイ済み |
 | Cloud Run (API) | デプロイ済み |
 | Cloud Run (Web) | デプロイ済み |

--- a/packages/mcp-smarthr/static/docs.html
+++ b/packages/mcp-smarthr/static/docs.html
@@ -213,42 +213,115 @@ flowchart TD
   style DENY3 fill:#fee2e2,stroke:#dc2626
     </div>
 
-    <h3 class="text-lg font-semibold mt-8">パーミッションと権限</h3>
-    <p class="text-gray-600 mb-3">アカウント毎に細かく操作権限を設定できます。</p>
+    <h3 class="text-lg font-semibold mt-8">ロールとアクセス制御</h3>
+    <p class="text-gray-600 mb-3">Firestore 許可リストに登録されたアカウントのみ接続可能です。未登録のアカウントはドメイン内でもアクセスできません。</p>
+
+    <!-- ロール別概要 -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6">
+      <div class="bg-purple-50 border border-purple-200 rounded-xl p-5">
+        <div class="flex items-center gap-2 mb-2">
+          <span class="bg-purple-200 text-purple-800 px-3 py-1 rounded-full text-xs font-bold">admin</span>
+          <span class="text-sm text-purple-700 font-medium">全操作（削除を除く）</span>
+        </div>
+        <ul class="text-sm text-purple-900 space-y-1 ml-1">
+          <li>&#x2705; 従業員の閲覧・検索</li>
+          <li>&#x2705; 従業員の更新・新規登録</li>
+          <li>&#x2705; 給与明細の閲覧</li>
+          <li>&#x2705; 部署・役職の閲覧</li>
+          <li>&#x2705; 生年月日・性別・連絡先を含む詳細情報</li>
+          <li>&#x274C; 削除操作（未実装・スコープ外）</li>
+        </ul>
+      </div>
+      <div class="bg-blue-50 border border-blue-200 rounded-xl p-5">
+        <div class="flex items-center gap-2 mb-2">
+          <span class="bg-blue-200 text-blue-800 px-3 py-1 rounded-full text-xs font-bold">readonly</span>
+          <span class="text-sm text-blue-700 font-medium">読み取りのみ</span>
+        </div>
+        <ul class="text-sm text-blue-900 space-y-1 ml-1">
+          <li>&#x2705; 従業員の閲覧・検索</li>
+          <li>&#x274C; 従業員の更新・新規登録</li>
+          <li>&#x274C; 給与明細の閲覧</li>
+          <li>&#x2705; 部署・役職の閲覧</li>
+          <li>&#x274C; 生年月日・性別・連絡先（自動除外）</li>
+          <li>&#x274C; 削除操作（未実装・スコープ外）</li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- ツール × ロール マトリクス -->
+    <h4 class="text-md font-semibold mb-2 text-gray-700">ツール別アクセス権限</h4>
     <div class="overflow-x-auto">
       <table class="w-full text-sm border-collapse">
         <thead>
           <tr class="bg-gray-50">
-            <th class="border border-gray-200 px-4 py-2 text-left">パーミッション</th>
-            <th class="border border-gray-200 px-4 py-2 text-left">アクセス可能ツール</th>
-            <th class="border border-gray-200 px-4 py-2 text-left">PII アクセス</th>
+            <th class="border border-gray-200 px-4 py-2 text-left">ツール</th>
+            <th class="border border-gray-200 px-4 py-2 text-left">操作内容</th>
+            <th class="border border-gray-200 px-4 py-2 text-center">必要権限</th>
+            <th class="border border-gray-200 px-4 py-2 text-center">admin</th>
+            <th class="border border-gray-200 px-4 py-2 text-center">readonly</th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td class="border border-gray-200 px-4 py-2">
-              <span class="bg-purple-100 text-purple-700 px-2 py-0.5 rounded text-xs font-medium">read + write + pay_statements</span>
-            </td>
-            <td class="border border-gray-200 px-4 py-2">全 8 ツール（閲覧 + 更新 + 給与明細）</td>
-            <td class="border border-gray-200 px-4 py-2">生年月日・性別・連絡先を含む（マイナンバーは除外）</td>
+            <td class="border border-gray-200 px-4 py-2"><code class="text-xs">list_employees</code></td>
+            <td class="border border-gray-200 px-4 py-2">従業員一覧</td>
+            <td class="border border-gray-200 px-4 py-2 text-center"><span class="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs">read</span></td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
           </tr>
           <tr class="bg-gray-50">
-            <td class="border border-gray-200 px-4 py-2">
-              <span class="bg-green-100 text-green-700 px-2 py-0.5 rounded text-xs font-medium">read + write</span>
-            </td>
-            <td class="border border-gray-200 px-4 py-2">閲覧 + 更新・登録（給与明細を除く）</td>
-            <td class="border border-gray-200 px-4 py-2">PII フィールドは自動除外</td>
+            <td class="border border-gray-200 px-4 py-2"><code class="text-xs">get_employee</code></td>
+            <td class="border border-gray-200 px-4 py-2">従業員詳細</td>
+            <td class="border border-gray-200 px-4 py-2 text-center"><span class="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs">read</span></td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
           </tr>
           <tr>
-            <td class="border border-gray-200 px-4 py-2">
-              <span class="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs font-medium">read</span>
-            </td>
-            <td class="border border-gray-200 px-4 py-2">閲覧のみ（6 ツール）</td>
-            <td class="border border-gray-200 px-4 py-2">PII フィールドは自動除外</td>
+            <td class="border border-gray-200 px-4 py-2"><code class="text-xs">search_employees</code></td>
+            <td class="border border-gray-200 px-4 py-2">従業員検索</td>
+            <td class="border border-gray-200 px-4 py-2 text-center"><span class="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs">read</span></td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+          </tr>
+          <tr class="bg-gray-50">
+            <td class="border border-gray-200 px-4 py-2"><code class="text-xs">list_departments</code></td>
+            <td class="border border-gray-200 px-4 py-2">部署一覧</td>
+            <td class="border border-gray-200 px-4 py-2 text-center"><span class="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs">read</span></td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+          </tr>
+          <tr>
+            <td class="border border-gray-200 px-4 py-2"><code class="text-xs">list_positions</code></td>
+            <td class="border border-gray-200 px-4 py-2">役職一覧</td>
+            <td class="border border-gray-200 px-4 py-2 text-center"><span class="bg-blue-100 text-blue-700 px-2 py-0.5 rounded text-xs">read</span></td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+          </tr>
+          <tr class="bg-gray-50">
+            <td class="border border-gray-200 px-4 py-2"><code class="text-xs">update_employee</code></td>
+            <td class="border border-gray-200 px-4 py-2">従業員情報の更新</td>
+            <td class="border border-gray-200 px-4 py-2 text-center"><span class="bg-green-100 text-green-700 px-2 py-0.5 rounded text-xs">write</span></td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x274C;</td>
+          </tr>
+          <tr>
+            <td class="border border-gray-200 px-4 py-2"><code class="text-xs">create_employee</code></td>
+            <td class="border border-gray-200 px-4 py-2">従業員の新規登録</td>
+            <td class="border border-gray-200 px-4 py-2 text-center"><span class="bg-green-100 text-green-700 px-2 py-0.5 rounded text-xs">write</span></td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x274C;</td>
+          </tr>
+          <tr class="bg-gray-50">
+            <td class="border border-gray-200 px-4 py-2"><code class="text-xs">get_pay_statements</code></td>
+            <td class="border border-gray-200 px-4 py-2">給与明細の取得</td>
+            <td class="border border-gray-200 px-4 py-2 text-center"><span class="bg-purple-100 text-purple-700 px-2 py-0.5 rounded text-xs">pay_statements</span></td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x2705;</td>
+            <td class="border border-gray-200 px-4 py-2 text-center">&#x274C;</td>
           </tr>
         </tbody>
       </table>
     </div>
+    <p class="text-xs text-gray-500 mt-2">※ 削除操作（DELETE）は全ロールで利用不可（未実装・安全性のためスコープ外）</p>
   </div>
 </section>
 

--- a/packages/mcp-smarthr/static/guide.html
+++ b/packages/mcp-smarthr/static/guide.html
@@ -182,8 +182,8 @@ tailwind.config = {
       <div>
         <h3 class="font-semibold mb-2">🔐 アクセス制限</h3>
         <p class="text-sm text-gray-600">
-          @aozora-cg.com のアカウントでログインしたメンバーのみ利用可能です。
-          外部の人がアクセスすることはできません。
+          @aozora-cg.com ドメイン内で、<strong>管理者が許可したアカウントのみ</strong>利用可能です。
+          ドメイン内でも未登録のアカウントはアクセスできません。
         </p>
       </div>
       <div>


### PR DESCRIPTION
## Summary
- `/docs` 技術ドキュメント: パーミッション表をロール別カード＋ツール×ロール マトリクスに刷新し、admin/readonly の違いを一目で把握可能に
- `/guide` ご利用ガイド: アクセス制限の説明を「ドメイン内全員」から「許可リスト方式」に更新
- ハンドオフ: UserStore 有効化完了を反映、登録ユーザー10名の一覧セクション追加

## Test plan
- [ ] `/docs` ページでロール別カードとツール×ロール マトリクスが正しく表示される
- [ ] `/guide` ページのアクセス制限説明が「管理者が許可したアカウントのみ」になっている
- [ ] ハンドオフに登録ユーザー一覧が記載されている

🤖 Generated with [Claude Code](https://claude.com/claude-code)