### PR TITLE
docs: ハンドオフ更新（UserStore有効化セッション）

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,102 +1,37 @@
 # HR-AI Agent — Session Handoff
 
-**最終更新**: 2026-04-13（セッション終了時点）
+**最終更新**: 2026-04-13（Firestore UserStore 有効化セッション）
 **ブランチ**: `main`
-**main 最新**: `291ac85` — docs: Team プランのコネクタ共有の説明を追加 (#430)
+**main 最新**: `62263db` — docs: 権限モデルのドキュメントを詳細化 + ハンドオフ更新 (#433)
 
 ---
 
 ## 現在のフェーズ
 
-**Phase 12 — SmartHR MCP サーバー構築（Phase G 完了・CRUD 本番デプロイ済み）**
+**Phase 12 — SmartHR MCP サーバー構築（UserStore 有効化・本番運用中）**
 
 ### 今セッションの成果
 
-1. **Phase G: CRUD 操作追加**（PR #423）
-   - SmartHR Client に PATCH/POST メソッド追加（キャッシュ無効化付き）
-   - `update_employee` ツール（PATCH /crews/{id}、フィールド許可リスト強制）
-   - `create_employee` ツール（POST /crews、必須フィールド min(1) バリデーション）
-   - 空値除去（undefined / null / 空文字列 / 空白のみ → SmartHR データ消失防止）
+1. **Firestore UserStore 有効化**（PR #432）
+   - `USE_FIRESTORE_USER_STORE=true` に変更（Cloud Run rev mcp-smarthr-00018-tts）
+   - Firestore `mcp-users` コレクションに10名登録（admin 4名 + readonly 6名）
+   - ドメイン内でも未登録アカウントはアクセス不可（fail-closed）
 
-2. **パーミッションベース認可**（PR #423）
-   - `Permission = "read" | "write" | "pay_statements"` 型追加
-   - アカウント毎に細粒度の CRUD 権限制御が可能
-   - 後方互換: 既存 role のみユーザーは ROLE_TO_PERMISSIONS で自動導出
-   - Firestore permissions フィールドのランタイム検証
+2. **ドキュメント詳細化**（PR #433）
+   - `/docs` 技術ドキュメント: ロール別カード + ツール×ロール マトリクスに刷新
+   - `/guide` ご利用ガイド: アクセス制限説明を許可リスト方式に更新
+   - ハンドオフ: 登録ユーザー一覧セクション追加
 
-3. **レビュー指摘対応**（5エージェント並列レビュー）
-   - POST の 429 リトライ禁止（非冪等操作の重複実行防止）
-   - UPDATABLE_FIELDS をランタイムで強制（defense-in-depth）
-   - stripEmptyValues で null・空白文字列も除去
-   - キャッシュ無効化を try-catch で保護
-   - Firestore permissions のランタイム検証追加
-
-4. **Cloud Run デプロイ + SmartHR API 実接続テスト**
-   - PATCH フォーマット検証OK（同値更新で 200 確認）
-   - POST フォーマット検証OK（201 確認、テスト従業員は即削除済み）
-
-5. **ドキュメント最終更新**（PR #425〜#430）
-   - `/docs` 技術ドキュメント: OAuth 2.1・8ツール・パーミッション・SmartHR API リンク
-   - `/guide` 非エンジニア向けご利用ガイド: 新規作成
-   - README に MCP セクション + ドキュメントリンク追加
-   - UI 表記を日本語版 Claude に統一、ファビコン追加
-   - Team プランのコネクタ共有説明追加
+3. **カスタムコネクタ動作確認**
+   - claude.ai でカスタムコネクタ接続 + データ取得を確認済み
+   - 読み取り専用ツール6つ、書き込み/削除ツール2つが正しく表示
 
 ### マージ済み PR
 
 | PR | 内容 | 状態 |
 |----|------|------|
-| #423 | Phase G: CRUD 操作 + パーミッションベース認可 | マージ済 |
-| #424 | ハンドオフ更新（Phase G 完了） | マージ済 |
-| #425 | ドキュメント Phase G 対応 + ガイド追加 | マージ済 |
-| #426 | UI 表記を日本語版 Claude に修正 | マージ済 |
-| #427 | README に MCP セクション追加 | マージ済 |
-| #428 | ファビコン追加 | マージ済 |
-| #429 | docs を OAuth 2.1 + SmartHR API リンクに更新 | マージ済 |
-| #430 | Team プランのコネクタ共有説明追加 | マージ済 |
-
----
-
-## 次のアクション
-
-### 即時（次セッション）
-
-1. **チームプラン カスタムコネクタ有効化**
-   - 組織オーナー（社長）が設定 > コネクタ > カスタムコネクタを追加
-   - オーナーが1回登録すれば、メンバーは「連携させる」をクリックするだけ
-   - チームメンバーの接続テスト
-
-2. ~~**Firestore UserStore 有効化 + ユーザー登録**~~ ✅ 完了（PR #432）
-   - `USE_FIRESTORE_USER_STORE=true` に変更済み（rev mcp-smarthr-00018-tts）
-   - 10名登録済み（admin 4名 + readonly 6名）
-
-3. **Cowork で CRUD 動作確認**
-   - admin ユーザーで `update_employee` / `create_employee` が実行されること
-   - readonly ユーザーでは write ツールが拒否されること
-   - 未登録アカウントで接続が拒否されること
-
-### Phase F2: Cloud Armor IP 制限（優先度低）
-- Cloud Armor ポリシーで Anthropic IP 範囲を許可
-- アプリ内の XFF パースコード削除
-
-### 既存 Issues
-- #407: Phase 2: Anthropic HR Plugin 導入
-- #408: Phase 3: 本番 AI エージェント + 実験 UI
-
----
-
-## 重要な設計判断
-
-| 判断 | 決定 | 理由 |
-|------|------|------|
-| 権限モデル | パーミッション文字列方式 | "read"/"write"/"pay_statements" の3値で十分 |
-| 2フェーズ書き込み | 不要 | MCP のAI確認フローが代替 |
-| フィールド許可リスト | ハードコード（ランタイム強制） | セキュリティ上、コードレビュー経由 |
-| POST リトライ | 禁止 | 非冪等操作の重複リスク |
-| OAuth AS | 自前（Google OIDC 委譲） | 10-30名の社内ツール |
-| JWT | HS256, 1時間有効 | 短寿命でセキュリティ確保 |
-| fail-closed | UserStore null → 拒否 | PII 保護 |
-| CRUD | PATCH + POST のみ | DELETE スコープ外 |
+| #432 | Firestore UserStore 有効化 + 初期ユーザー10名登録スクリプト | マージ済 |
+| #433 | 権限モデルのドキュメント詳細化 + UserStore有効化反映 | マージ済 |
 
 ---
 
@@ -113,6 +48,45 @@
 
 ---
 
+## 次のアクション
+
+### 即時（次セッション）
+
+1. **Cowork で CRUD 動作確認**
+   - admin ユーザーで `update_employee` / `create_employee` が実行されること
+   - readonly ユーザーでは write ツールが拒否されること
+   - 未登録アカウントで接続が拒否されること
+
+2. **GCP Owner 切り替え**（請求先アカウント確認後）
+   - dx@aozora-cg.com → shoma.horinouchi@aozora-cg.com + yasushi.honda@aozora-cg.com のみに変更
+   - 請求先アカウントの関係で単純でない可能性あり、システム部部長と要調整
+
+### Phase F2: Cloud Armor IP 制限（優先度低）
+- Cloud Armor ポリシーで Anthropic IP 範囲を許可
+- アプリ内の XFF パースコード削除
+
+### 既存 Issues
+- #407: Phase 2: Anthropic HR Plugin 導入
+- #408: Phase 3: 本番 AI エージェント + 実験 UI
+
+---
+
+## 重要な設計判断
+
+| 判断 | 決定 | 理由 |
+|------|------|------|
+| 権限モデル | パーミッション文字列方式 | "read"/"write"/"pay_statements" の3値で十分 |
+| アクセス制御 | Firestore 許可リスト方式 | ドメイン内全員アクセスは機密性リスクが高い |
+| 2フェーズ書き込み | 不要 | MCP のAI確認フローが代替 |
+| フィールド許可リスト | ハードコード（ランタイム強制） | セキュリティ上、コードレビュー経由 |
+| POST リトライ | 禁止 | 非冪等操作の重複リスク |
+| OAuth AS | 自前（Google OIDC 委譲） | 10-30名の社内ツール |
+| JWT | HS256, 1時間有効 | 短寿命でセキュリティ確保 |
+| fail-closed | UserStore null → 拒否 | PII 保護 |
+| CRUD | PATCH + POST のみ | DELETE スコープ外 |
+
+---
+
 ## MCP ツール一覧（8ツール）
 
 | ツール | 権限 | SmartHR API |
@@ -125,6 +99,17 @@
 | get_pay_statements | pay_statements | GET /pay_statements |
 | update_employee | write | PATCH /crews/{id} |
 | create_employee | write | POST /crews |
+
+---
+
+## GCP IAM（ユーザーアカウントのみ）
+
+| アカウント | ロール | 備考 |
+|-----------|--------|------|
+| dx@aozora-cg.com | Owner | システムアカウント（プロジェクト作成者） |
+| yasushi.honda@aozora-cg.com | Owner | 開発者 |
+
+※ システム部個人アカウントは未付与。後日 Owner 切り替え予定。
 
 ---
 
@@ -179,7 +164,6 @@ git checkout main && git pull
 curl -s https://mcp-smarthr-1021020088552.asia-northeast1.run.app/health
 
 # 次のタスク:
-# 1. チームプラン カスタムコネクタ有効化（社長操作）
-# 2. USE_FIRESTORE_USER_STORE=true + ユーザー登録
-# 3. Cowork で CRUD 動作確認
+# 1. Cowork で CRUD 動作確認（admin / readonly / 未登録）
+# 2. GCP Owner 切り替え（請求先アカウント確認後）
 ```


### PR DESCRIPTION
## Summary
- 今セッションの成果（PR #432, #433, コネクタ動作確認）を記録
- GCP IAM セクション追加（現状の Owner 構成と切り替え予定）
- 次アクション更新（CRUD 動作確認、GCP Owner 切り替え）

## Test plan
- [x] ハンドオフの内容が今セッションの作業と一致している

🤖 Generated with [Claude Code](https://claude.com/claude-code)