### PR TITLE
docs: ツール表示と実行権限の違いを明記

### DIFF
--- a/packages/mcp-smarthr/static/docs.html
+++ b/packages/mcp-smarthr/static/docs.html
@@ -322,6 +322,13 @@ flowchart TD
       </table>
     </div>
     <p class="text-xs text-gray-500 mt-2">※ 削除操作（DELETE）は全ロールで利用不可（未実装・安全性のためスコープ外）</p>
+    <div class="bg-amber-50 border border-amber-200 rounded-lg p-4 mt-4">
+      <p class="text-sm text-amber-800"><strong>&#x26A0;&#xFE0F; コネクタ設定画面の表示について</strong></p>
+      <p class="text-sm text-amber-700 mt-1">
+        claude.ai のコネクタ設定画面にはサーバーが提供する全ツールが一覧表示されますが、<strong>表示 ≠ 実行可能</strong>です。
+        各ツールの実行時にサーバー側でユーザーの権限を検証し、権限不足の場合はリクエストを拒否します（fail-closed）。
+      </p>
+    </div>
   </div>
 </section>
 

--- a/packages/mcp-smarthr/static/guide.html
+++ b/packages/mcp-smarthr/static/guide.html
@@ -187,6 +187,14 @@ tailwind.config = {
         </p>
       </div>
       <div>
+        <h3 class="font-semibold mb-2">🛡️ 権限による操作制限</h3>
+        <p class="text-sm text-gray-600">
+          アカウントごとに操作権限が設定されています。
+          <strong>読み取り専用</strong>のアカウントでは、給与明細の閲覧や従業員情報の変更・登録はできません。
+          設定画面にツール名が表示されていても、権限がなければサーバー側で実行がブロックされます。
+        </p>
+      </div>
+      <div>
         <h3 class="font-semibold mb-2">👤 個人情報の保護</h3>
         <p class="text-sm text-gray-600">
           権限に応じて、生年月日・性別・電話番号などの個人情報は自動的に非表示になります。
@@ -246,6 +254,17 @@ tailwind.config = {
       <summary class="font-semibold cursor-pointer">スマホからも使えますか？</summary>
       <p class="mt-3 text-gray-600 text-sm">
         はい。Claude のモバイルアプリまたはブラウザ版（claude.ai）から利用可能です。
+      </p>
+    </details>
+
+    <details class="bg-white rounded-xl border border-gray-200 p-5 group">
+      <summary class="font-semibold cursor-pointer">設定画面に「給与明細」や「従業員登録」が表示されていますが、見れてしまいませんか？</summary>
+      <p class="mt-3 text-gray-600 text-sm">
+        コネクタの設定画面にはサーバーが提供する全ツールが一覧表示されますが、
+        <strong>表示されていることと実行できることは別</strong>です。
+        実際にツールを使おうとしたとき、サーバー側であなたのアカウントの権限をチェックし、
+        権限がなければ「権限不足」エラーを返します。
+        読み取り専用アカウントでは、給与明細の取得や従業員情報の変更は実行できません。
       </p>
     </details>
 


### PR DESCRIPTION
## Summary
- `/guide` FAQ: 「設定画面に給与明細が表示されているが見れてしまわないか？」を追加
- `/guide` 安全性: 「権限による操作制限」セクションを追加
- `/docs` ツール権限マトリクス下部: 表示≠実行可能の注意書きを追加

## 背景
コネクタ設定画面に全ツールが表示されるため、readonly ユーザーが
給与明細にアクセスできてしまうのではという懸念が上がった。
実際にはサーバー側で権限チェックが行われるため問題ないが、
ドキュメントで明言しておくことで安心感を提供する。

## Test plan
- [ ] `/guide` の安全性セクションに「権限による操作制限」が表示される
- [ ] `/guide` の FAQ に「設定画面に給与明細が表示されていますが...」が表示される
- [ ] `/docs` のツール権限マトリクス下部に注意書きが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)