### PR TITLE
docs: CLAUDE.md に Operational Status セクション追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,12 @@
 
 Google Chat の人事指示を AI が解釈し、給与変更ドラフトを自動作成。人間が承認後、全連携先へ反映する Human-in-the-loop システム。
 
+## Operational Status
+
+- **SmartHR MCP は本番運用中**（Cloud Run + claude.ai Team プラン カスタムコネクタ）
+- 権限・認可・使い方は稼働中 MCP サーバーの `/docs` `/guide`（`packages/mcp-smarthr/static/`）に記載
+- 設定・権限・運用の提案前に `docs/handoff/LATEST.md` と配信ドキュメントを確認すること
+
 ## Architecture
 
 - **GCP Project**: hr-system-487809 (asia-northeast1)


### PR DESCRIPTION
## Summary

- SmartHR MCP が本番運用中である事実をプロジェクト CLAUDE.md の最上部に明記
- 配信ドキュメント（`/docs` `/guide` = `packages/mcp-smarthr/static/`）の存在を示し、設定・権限提案前の参照先として位置づけ
- `docs/handoff/LATEST.md` 確認をプロジェクトスコープでの規律として追加

## 背景

今セッションで SmartHR MCP の接続許可について質問を受けた際、本番運用中の事実（claude.ai Team プランカスタムコネクタ稼働）と稼働中サーバーの配信ドキュメントに気付かず、ローカル `.mcp.json` 経由の stdio 接続提案から入るミスをした。根本原因は `/catchup` 出力でハンドオフの存在を認識していたのに読まなかったこと。

グローバル memory 追加は範囲過大（他プロジェクトに持ち出しても空振り）・既存「調査順序」系 feedback との希釈リスクありと判断し、プロジェクト CLAUDE.md 追記 6 行で対応。

## Test plan

- [x] 構文検証: Markdown として正常（見出しレベル整合）
- [x] 配置確認: Project Overview 直後（最初に目に入る位置）
- [ ] 次セッションの `/catchup` 後に Operational Status が認識に入るかを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)