### PR TITLE
docs: Phase 13 本番デプロイ完了反映 + 外部ユーザー接続手順書

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -126,7 +126,7 @@
 | ALLOWED_DOMAIN | aozora-cg.com | |
 | AUTH_DISABLED | false | |
 | IP_RESTRICTION_ENABLED | false | |
-| SERVER_URL | https://mcp-smarthr-bdr4g3rk2q-an.a.run.app | |
+| SERVER_URL | https://mcp-smarthr-bdr4g3rk2q-an.a.run.app | OAuth issuer 用の legacy URL 形式。公開 URL は `https://mcp-smarthr-1021020088552.asia-northeast1.run.app`（同じサービスを Cloud Run が両形式で提供） |
 | USE_FIRESTORE_USER_STORE | true | |
 | **EXTERNAL_READONLY_EMAIL_ALLOWLIST** | **y@lend.aozora-cg.com** | **本セッションで追加** |
 | SMARTHR_API_KEY | (secret) | |

--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,60 +1,53 @@
 # HR-AI Agent — Session Handoff
 
-**最終更新**: 2026-04-17（外部 readonly 例外許可機能 実装セッション）
-**ブランチ**: `feat/external-readonly-allowlist`（**未マージ、作業継続中**）
-**main 最新**: `31a7c3f` — docs: CLAUDE.md に Operational Status セクション追加 (#437)
+**最終更新**: 2026-04-17（PR #438 マージ + 本番デプロイ完了、T13 実機検証待ち）
+**ブランチ**: `main`
+**main 最新**: `2c417f3` — feat: SmartHR MCP に外部 readonly 例外メール許可機能を追加 (#438)
 
 ---
 
 ## 現在のフェーズ
 
-**Phase 13 — SmartHR MCP 外部 readonly 例外ユーザー許可（実装完了、デプロイ待機）**
+**Phase 13 — SmartHR MCP 外部 readonly 例外許可（実装完了・デプロイ完了、T13 実機検証のみ残）**
 
-別テナント `y@lend.aozora-cg.com` を readonly で恒久許可する機能を追加中。
-Codex `/codex plan` の案 A'（`EXTERNAL_READONLY_EMAIL_ALLOWLIST` 環境変数 + Firestore `mcp-users` の二重承認方式）を採用。
+`y@lend.aozora-cg.com` を readonly で恒久許可する機能が本番稼働中。外部ユーザー本人による実機検証のみが残っている状態。
 
 ---
 
 ## 今セッションの成果
 
-### マージ済み PR（本セッション）
+### マージ済み PR
 
 | PR | 内容 | 状態 |
 |----|------|------|
-| #437 | CLAUDE.md に Operational Status セクション追加 | ✅ マージ済み（`31a7c3f`） |
+| #437 | CLAUDE.md に Operational Status 追加 | ✅ マージ済み（前セッション） |
+| **#438** | **SmartHR MCP に外部 readonly 例外メール許可機能を追加** | ✅ **本セッションでマージ**（`2c417f3`） |
 
-### 進行中 PR
+### 作成した Issue（follow-up）
 
-| PR | 内容 | 状態 |
-|----|------|------|
-| **#438** | **SmartHR MCP に外部 readonly 例外メール許可機能を追加** | 🟡 **OPEN、レビュー完了、マージ判断待ち** |
+| # | 内容 | ラベル |
+|----|------|--------|
+| #439 | 監査ログ失敗時の silent catch 修正 | bug, P2 |
+| #440 | fallback UserStore の fail-closed 化 | bug, P1 |
+| #441 | 外部例外 OAuth 統合テスト追加 | enhancement, P2 |
+| #442 | Mermaid 図と email 正規化の polish | enhancement, P2 |
 
-### PR #438 の内容
+### デプロイ状況
 
-**実装内容:**
-- `isAllowedIdentity` 共通関数（Layer 2 判定、ドメイン優先、email 小文字正規化）
-- `Authorizer` に `externalAllowlist` 対応 + 外部ユーザー readonly 強制ガード
-- `EXTERNAL_READONLY_EMAIL_ALLOWLIST` 環境変数（ワイルドカード拒否、重複排除）
-- OAuth `/authorize` の `hd` パラメータ条件付き送信（外部例外時は省略）
-- OAuth `/token` で外部 readonly 不変条件を JWT 発行前に再検証
-- 監査ログに `allowedBy` タグ（`domain` / `external_email_exception` / `denied`）
-- stdio shell でも externalAllowlist を配線
-- Firestore `UserDocument` に運用メタデータ（`external`, `approvedBy`, `approvedAt`, `reason`）
-- `seed-users.ts` に `y@lend.aozora-cg.com` を readonly + external=true で追加
-- `/docs` `/guide` 更新
+| 項目 | 値 |
+|------|-----|
+| Cloud Run リビジョン | `mcp-smarthr-00021-f9x`（100% トラフィック） |
+| イメージ SHA | `2c417f3` |
+| `/health` 応答 | `{"status":"ok"}` |
+| 追加環境変数 | `EXTERNAL_READONLY_EMAIL_ALLOWLIST=y@lend.aozora-cg.com` |
+| Firestore 登録 | 11 ユーザー（admin 4, readonly 6, external readonly 1） |
 
-**変更規模:** 14 ファイル / +768/-21 行（2 コミット: `4a7e70e`, `f474769`）
+### 追加ドキュメント
 
-**テスト:** 98 → 135（+37 件、全 PASS）
-
-### 実施した品質ゲート
-
-| ゲート | 結果 | 対応 |
-|--------|------|------|
-| `/codex plan` | 案 A' 推奨、追加安全策提示 | ✅ 採用 |
-| `/codex review` | Medium 2 件指摘（`/token` readonly 再検証、stdio 配線） | ✅ `f474769` で修正 |
-| Evaluator | AC 10/11 PASS + 1 軽微な構造差（logging path） | ✅ 許容 |
-| `/review-pr`（6 エージェント並列） | Critical 4 件、Important/Suggestion 多数 | 🟡 **対応範囲未決** |
+| ファイル | 内容 |
+|---------|------|
+| `docs/adr/ADR-008-external-readonly-exception.md` | 設計判断の記録（案 A' 採用、案 B 不採用理由、増殖ガード等） |
+| `docs/handoff/external-user-onboarding-y-lend.md` | y@lend.aozora-cg.com 向け接続手順書（3 クライアント対応） |
 
 ---
 
@@ -62,156 +55,112 @@ Codex `/codex plan` の案 A'（`EXTERNAL_READONLY_EMAIL_ALLOWLIST` 環境変数
 
 | ID | タスク | 状態 |
 |----|-------|------|
-| T1 | `isAllowedIdentity` 共通関数 | ✅ 完了 |
-| T2 | Authorizer 外部例外対応 | ✅ 完了 |
-| T3 | OAuth callback ドメイン検証を共通関数化 | ✅ 完了 |
-| T4 | OAuth `/authorize` の hd 条件付き送信 | ✅ 完了 |
-| T5 | 環境変数パースと起動時ガード | ✅ 完了 |
-| T6 | 外部例外ユーザー readonly 強制ガード | ✅ 完了 |
-| T7 | 監査ログ `allowedBy` タグ | ✅ 完了 |
-| T8 | FirestoreUserStore 型拡張 | ✅ 完了 |
-| T9 | ユニットテスト追加 | ✅ 完了（135/135 PASS） |
-| T10 | Firestore `mcp-users` に y@lend 登録 | ⏳ **未実施** |
+| T1-T9 | 実装・ユニットテスト | ✅ 完了 |
+| T10 | Firestore 登録 | ✅ **本セッションで完了** |
 | T11 | 配信ドキュメント更新 | ✅ 完了 |
-| T12 | Cloud Run デプロイ + 環境変数更新 | ⏳ **未実施** |
-| T13 | 実機検証（y@lend 本人に依頼） | ⏳ **未実施** |
+| T12 | Cloud Run デプロイ + 環境変数 | ✅ **本セッションで完了** |
+| T13 | 実機検証（y@lend 本人に依頼） | ⏳ **外部依頼待ち** |
 | T14 | ハンドオフ更新 | ✅ 本ドキュメントで完了 |
 
-**進捗: 11/14（79%）** — 実装・テスト・ドキュメントは完了、残りはデプロイ・検証フェーズ
+**進捗: 13/14（93%）** — 残作業は外部ユーザー依頼のみ
 
 ---
 
-## 次のアクション
+## T13（実機検証）の進め方
 
-### 即時（次セッション冒頭、必須）
+### 依頼文テンプレート
 
-```bash
-cd /Users/yyyhhh/Projects/ACG/hr-system
-git fetch origin
-git checkout feat/external-readonly-allowlist
-git pull
-pwd  # /Users/yyyhhh/Projects/ACG/hr-system
-```
+`docs/handoff/external-user-onboarding-y-lend.md` を y@lend.aozora-cg.com 本人に共有。その文書に以下が含まれている:
 
-**注意事項:** 今セッション中にローカルブランチが `main` に切り替わる事象が発生（原因不明、リモート側に影響なし、手動で `feat/external-readonly-allowlist` に復帰）。`/review-pr` の 6 並列エージェント実行中の副作用の可能性あり。次セッションでは **`git checkout` 後に `git log --oneline -3` で `f474769` を確認**すること。
+- 3 クライアント（claude.ai Pro / Claude Desktop / Claude Code CLI）それぞれの接続手順
+- 動作確認シナリオ 6 項目（read 系成功 + write/pay_statements が 403 になること）
+- トラブルシューティング
+- 連絡先（yasushi.honda@aozora-cg.com）
 
-### 次の意思決定（優先順）
+### 検証完了後のアクション
 
-**1. `/review-pr` 指摘への対応範囲（A/B/C 判断）**
+1. 接続成功 → y@lend 本人から動作確認完了の連絡を受領
+2. `docs/handoff/LATEST.md` に検証結果を追記
+3. T13 を completed に更新
+4. Phase 13 クローズ
 
-/review-pr 結果の Critical 相当:
-- **silent-failure C1**: `server.ts:113-115` 空 catch（監査ログ失敗を隠蔽）
-- **silent-failure C4**: `serve.ts` fallback UserStore がデフォルト fail-open
-- **pr-test-analyzer C1**: OAuth `/token` 外部例外ガードの統合テスト無し
-- **pr-test-analyzer C2**: OAuth callback Layer 2 統一の統合テスト無し
-- **comment-analyzer C1**: Mermaid 図 `hd == aozora-cg.com` が外部例外経路を反映していない
-- **code-simplifier C1**: `authorizeStdio` の email 正規化を `isAllowedIdentity` に集約推奨
+### 接続に失敗した場合のデバッグポイント
 
-**選択肢:**
-- **A. 本 PR で polish**（+30-60 分）: silent-failure C1 / comment C1 / code-simplifier C1 を修正してからマージ
-- **B. 現状でマージ → T10-T13 進行**（推奨、WBS 優先）: 上記指摘は follow-up issue 化
-- **C. 追加 codex review** でさらに精査
-
-**前回の推奨: B**（実機検証 T13 が真の最終ゲートであり、polish 系の指摘は運用後で十分）
-
-**2. T10-T13 実行順序**
-
-マージ後のデプロイ手順:
-```bash
-# T10: Firestore に y@lend.aozora-cg.com を登録
-npx tsx packages/mcp-smarthr/scripts/seed-users.ts
-
-# T12: Cloud Run デプロイ + 環境変数追加
-# EXTERNAL_READONLY_EMAIL_ALLOWLIST=y@lend.aozora-cg.com を Cloud Run サービスに追加
-# （詳細コマンドは次セッションで調整）
-
-# T13: y@lend.aozora-cg.com 本人に接続試行を依頼
-# - claude.ai Pro カスタムコネクタ登録
-# - Claude Desktop / Claude Code CLI リモート MCP 接続
-# - read ツールが通る / write/pay_statements が 403 / hd 条件送信の挙動確認
-```
+- Cloud Run ログで `allowedBy` タグを確認（`external_email_exception` が出るか）
+- Firestore `mcp-users` で `y@lend.aozora-cg.com` の `enabled=true` を確認
+- 環境変数 `EXTERNAL_READONLY_EMAIL_ALLOWLIST` の値を確認
 
 ---
 
-## 登録ユーザー（Firestore `mcp-users`）
+## 次セッションでの選択肢
+
+**A. T13 結果待ちの間、Issue #439-442 から着手**（推奨）
+- #440（fail-closed 化）は P1 で優先度高
+- Phase 13 完了を待たず並行処理可能
+
+**B. 長期停滞 PR の整理**
+- #410（SmartHR MCP Phase 1）— 既に本番稼働しているため close 判断
+- #409（ADR-008 AI エージェント拡張）— 本 ADR-008（外部例外）とは別物、重複しない名称への改名検討
+
+**C. Issue #407 / #408（積み残し）**
+- Phase 2: Anthropic HR Plugin 導入
+- Phase 3: 本番 AI エージェント + /agent-lab
+
+---
+
+## 登録ユーザー（Firestore `mcp-users`、11 名）
 
 | ロール | 権限 | アカウント |
 |--------|------|-----------|
-| **admin** | 閲覧 + 更新 + 登録 + 給与明細 | kosuke.omure, tomohiro.arikawa, makoto.tokunaga, yasushi.honda |
-| **readonly** | 閲覧のみ | ryota.yagi, gen.ichihara, rika.komatsu, shoma.horinouchi, tomoko.hommura, yuka.yoshimura |
-| **readonly（外部例外、T10 実施後に追加予定）** | 閲覧のみ | **y@lend.aozora-cg.com** ← 別テナント、恒久許可 |
+| admin | 閲覧 + 更新 + 登録 + 給与明細 | kosuke.omure, tomohiro.arikawa, makoto.tokunaga, yasushi.honda |
+| readonly | 閲覧のみ | ryota.yagi, gen.ichihara, rika.komatsu, shoma.horinouchi, tomoko.hommura, yuka.yoshimura |
+| **readonly（外部例外）** | **閲覧のみ（強制）** | **y@lend.aozora-cg.com** |
 
 ---
 
-## 外部 readonly 例外の運用方針
+## Cloud Run 環境変数（全 11 項目、うち 5 つは Secret）
 
-- **狭い恒久例外**として扱う（1 名限定）
-- **二重承認**: 環境変数 `EXTERNAL_READONLY_EMAIL_ALLOWLIST` + Firestore `mcp-users` 両方必須
-- **readonly コード強制**: Authorizer と OAuth `/token` で `isExternalReadonlyViolation` を実施（admin/write/pay_statements permission 付与時に 403）
-- **revoke 手順**:
-  - 緊急: Firestore `enabled: false` で即時停止
-  - 完全: env 変数削除 + Cloud Run 再デプロイ
-- **増殖ガード**: 2 人目が出た場合は多テナント UserStore に再設計（本方式の継ぎ足しは禁止）
-
----
-
-## 重要な設計判断（本セッション追加）
-
-| 判断 | 決定 | 理由 |
-|------|------|------|
-| 外部ユーザー許可方式 | 案 A'（env + Firestore 二重承認） | 案 B（bypassDomainCheck フラグ）は Layer 2/3 独立性を損なう（Codex 指摘） |
-| 外部ユーザーの権限 | readonly コード強制 | Firestore 誤設定で write 付与されても deny する最終防衛線 |
-| `hd` パラメータ | 外部例外あり時は省略 | 外部テナントユーザーの認可画面到達を保証、セキュリティは callback 側で担保 |
-| JWT 寿命 | 既存のまま（差別化なし） | 信頼レベルがドメインユーザーと同等なため |
-| SmartHR API key 分離 | 不要 | 同上、Layer 4 で十分 |
+| 変数 | 値 | 備考 |
+|------|-----|------|
+| NODE_ENV | production | |
+| ALLOWED_DOMAIN | aozora-cg.com | |
+| AUTH_DISABLED | false | |
+| IP_RESTRICTION_ENABLED | false | |
+| SERVER_URL | https://mcp-smarthr-bdr4g3rk2q-an.a.run.app | |
+| USE_FIRESTORE_USER_STORE | true | |
+| **EXTERNAL_READONLY_EMAIL_ALLOWLIST** | **y@lend.aozora-cg.com** | **本セッションで追加** |
+| SMARTHR_API_KEY | (secret) | |
+| SMARTHR_TENANT_ID | (secret) | |
+| GOOGLE_CLIENT_ID | (secret) | |
+| GOOGLE_CLIENT_SECRET | (secret) | |
+| JWT_SECRET | (secret) | |
 
 ---
 
-## 既存 PR・Issue
+## 外部 readonly 例外の運用ガイド（ADR-008 準拠）
 
-| 番号 | 内容 | 状態 |
-|------|------|------|
-| #437 | CLAUDE.md Operational Status | ✅ マージ済 |
-| **#438** | **外部 readonly 例外** | 🟡 **OPEN、本セッション継続作業** |
-| #407 | Phase 2: Anthropic HR Plugin 導入 | 積み残し |
-| #408 | Phase 3: 本番 AI エージェント + 実験 UI | 積み残し |
+### 狭い恒久例外
 
----
+- 対象は 1 ユーザーのみ（`y@lend.aozora-cg.com`）
+- 2 人目が発生した場合は多テナント UserStore に再設計（継ぎ足し禁止）
 
-## MCP ツール一覧（8ツール、変更なし）
+### 二重承認
 
-| ツール | 権限 | SmartHR API |
-|--------|------|-------------|
-| list_employees | read | GET /crews |
-| get_employee | read | GET /crews/{id} |
-| search_employees | read | GET /crews?q= |
-| list_departments | read | GET /departments |
-| list_positions | read | GET /positions |
-| get_pay_statements | pay_statements | GET /pay_statements |
-| update_employee | write | PATCH /crews/{id} |
-| create_employee | write | POST /crews |
+- 環境変数 `EXTERNAL_READONLY_EMAIL_ALLOWLIST`（Cloud Run、SRE 管轄）
+- Firestore `mcp-users`（管理者管轄）
+- 両方必須で通過
 
----
+### readonly 強制（Layer 3.5）
 
-## Cloud Run 環境変数
+- Authorizer と OAuth `/token` の両方で `isExternalReadonlyViolation` を実施
+- Firestore で write 権限が誤付与されても 403 deny
 
-| 変数 | 現状値 | PR #438 マージ後の追加値 |
-|------|--------|------------------------|
-| AUTH_DISABLED | false | 変更なし |
-| USE_FIRESTORE_USER_STORE | true | 変更なし |
-| IP_RESTRICTION_ENABLED | false | 変更なし |
-| **EXTERNAL_READONLY_EMAIL_ALLOWLIST** | 未設定 | **`y@lend.aozora-cg.com` を追加予定（T12）** |
+### revoke 手順
 
----
-
-## デプロイ環境
-
-| サービス | 状態 |
-|---------|------|
-| Cloud Run (MCP) | rev 00020 稼働中（PR #438 マージ後に新 rev 予定） |
-| Cloud Run (Worker) | デプロイ済み |
-| Cloud Run (API) | デプロイ済み |
-| Cloud Run (Web) | デプロイ済み |
+| 緊急度 | 手順 |
+|--------|------|
+| 即時停止 | Firestore `mcp-users` で `enabled: false` |
+| 完全削除 | 上記 + 環境変数削除 + Cloud Run 再デプロイ |
 
 ---
 
@@ -219,10 +168,27 @@ npx tsx packages/mcp-smarthr/scripts/seed-users.ts
 
 | パッケージ | テスト数 | 状態 |
 |-----------|---------|------|
-| packages/mcp-smarthr | **135**（本セッションで +37） | 全 PASS |
+| packages/mcp-smarthr | 135 | 全 PASS（前セッション +37） |
 | apps/api | 22+ | 全 PASS |
 | apps/worker | 80 | 全 PASS |
 | apps/web | 207 | 全 PASS |
+
+---
+
+## 既存 PR・Issue
+
+| 番号 | 内容 | 状態 |
+|------|------|------|
+| #438 | 外部 readonly 例外 | ✅ マージ済 |
+| #437 | CLAUDE.md Operational Status | ✅ マージ済 |
+| #442 | Mermaid 図と email 正規化 polish | 🆕 作成（P2） |
+| #441 | 外部例外 OAuth 統合テスト | 🆕 作成（P2） |
+| #440 | fallback UserStore fail-closed 化 | 🆕 作成（P1） |
+| #439 | 監査ログ silent catch 修正 | 🆕 作成（P2） |
+| #410 | Phase 1 SmartHR MCP 構築（古い PR） | 積み残し、close 判断要 |
+| #409 | ADR-008 AI エージェント拡張（名称重複） | 積み残し、改名検討要 |
+| #408 | Phase 3: 本番 AI エージェント + /agent-lab | 積み残し |
+| #407 | Phase 2: Anthropic HR Plugin 導入 | 積み残し |
 
 ---
 
@@ -232,18 +198,21 @@ npx tsx packages/mcp-smarthr/scripts/seed-users.ts
 # 1. 環境確認
 cd /Users/yyyhhh/Projects/ACG/hr-system
 git fetch origin
-git checkout feat/external-readonly-allowlist
-git log --oneline -3  # f474769 が HEAD であること確認
+git checkout main
+git pull
+git log --oneline -3  # 2c417f3 が HEAD であること確認
 
-# 2. PR 状態確認
-gh pr view 438 --json state,mergeable
+# 2. 本番稼働状況確認
+curl -sS https://mcp-smarthr-1021020088552.asia-northeast1.run.app/health
 
-# 3. Cloud Run 現状確認
-curl -s https://mcp-smarthr-1021020088552.asia-northeast1.run.app/health
+# 3. Cloud Run リビジョン確認
+gcloud run services describe mcp-smarthr --region=asia-northeast1 \
+  --format="value(status.latestReadyRevisionName)"
+# 期待値: mcp-smarthr-00021-f9x
 
-# 4. 次の判断（上記「次の意思決定」参照）:
-#    - /review-pr 指摘への対応範囲（A/B/C 判断）
-#    - マージ → T10 → T12 → T13 の実行
+# 4. T13 状況確認（y@lend.aozora-cg.com からの連絡）
+
+# 5. 次セッションでの選択肢（上記「次セッションでの選択肢」参照）
 ```
 
 ---
@@ -251,7 +220,6 @@ curl -s https://mcp-smarthr-1021020088552.asia-northeast1.run.app/health
 ## 参考資料
 
 - PR #438: https://github.com/yasushihonda-acg/hr-system/pull/438
-- Codex plan レビュー: 案 A'（EXTERNAL_READONLY_EMAIL_ALLOWLIST + 二重承認）
-- Codex review: Medium 2 件（`f474769` で対応済み）
-- Evaluator: AC 10/11 PASS（logging path 構造差 1 件は機能影響なし）
-- /review-pr: 6 エージェント並列、Critical 4 件（詳細は前セッション会話ログ）
+- ADR-008: `docs/adr/ADR-008-external-readonly-exception.md`
+- 接続手順書: `docs/handoff/external-user-onboarding-y-lend.md`
+- Issue #439-442: follow-up で対応予定

--- a/docs/handoff/external-user-onboarding-y-lend.md
+++ b/docs/handoff/external-user-onboarding-y-lend.md
@@ -1,0 +1,135 @@
+# y@lend.aozora-cg.com 接続手順書（T13 実機検証用）
+
+**対象**: `y@lend.aozora-cg.com`
+**権限**: readonly（閲覧のみ、恒久許可）
+**有効期限**: なし
+**承認者**: yasushi.honda@aozora-cg.com
+**MCP サーバー URL**: `https://mcp-smarthr-1021020088552.asia-northeast1.run.app`
+**デプロイリビジョン**: `mcp-smarthr-00021-f9x`（2026-04-17 稼働）
+
+---
+
+## このドキュメントの目的
+
+別テナント `lend.aozora-cg.com` のユーザー（y@lend.aozora-cg.com）が、aozora-cg.com の SmartHR データを readonly で参照できるように接続する手順。
+
+**利用可能な 3 つのクライアント**（どれか 1 つでも OK、用途に応じて選択）:
+
+- A. claude.ai Pro（Web 版、カスタムコネクタ）
+- B. Claude Desktop（アプリ版、リモート MCP 接続）
+- C. Claude Code CLI（ターミナル版、リモート MCP 接続）
+
+---
+
+## 事前情報
+
+| 項目 | 値 |
+|------|-----|
+| MCP サーバー URL | `https://mcp-smarthr-1021020088552.asia-northeast1.run.app` |
+| 認可エンドポイント | `https://mcp-smarthr-1021020088552.asia-northeast1.run.app/authorize` |
+| トークンエンドポイント | `https://mcp-smarthr-1021020088552.asia-northeast1.run.app/token` |
+| クライアント登録 | 自動（Dynamic Client Registration） |
+| 利用可能ツール | `list_employees`, `get_employee`, `search_employees`, `list_departments`, `list_positions`（5 種、readonly） |
+| 拒否されるツール | `update_employee`, `create_employee`, `get_pay_statements`（403 エラーが期待動作） |
+
+---
+
+## A. claude.ai Pro（Web 版）
+
+1. https://claude.ai にログイン（`y@lend.aozora-cg.com` アカウント）
+2. 設定 → Connectors → Custom Connector 追加
+3. 以下を入力:
+   - **Name**: `aozora-hr-readonly`（任意）
+   - **URL**: `https://mcp-smarthr-1021020088552.asia-northeast1.run.app`
+4. 「Connect」をクリック
+5. Google OAuth 画面が開く → `y@lend.aozora-cg.com` を選択
+6. 権限同意 → Claude に戻る
+7. チャット画面で `@aozora-hr-readonly list_employees` のように呼び出し、従業員一覧が取れれば成功
+
+---
+
+## B. Claude Desktop
+
+1. Claude Desktop を最新版に更新
+2. 設定 → Developer → Edit Config
+3. `claude_desktop_config.json` に以下を追記（既存の `mcpServers` があればマージ）:
+
+```json
+{
+  "mcpServers": {
+    "aozora-hr-readonly": {
+      "url": "https://mcp-smarthr-1021020088552.asia-northeast1.run.app"
+    }
+  }
+}
+```
+
+4. Claude Desktop を再起動
+5. 初回接続時に Google OAuth 画面が開く → `y@lend.aozora-cg.com` を選択
+6. チャット画面でツール欄に 5 つの readonly ツールが表示されることを確認
+
+---
+
+## C. Claude Code CLI
+
+1. Claude Code CLI を最新版に更新（`claude --version` で確認）
+2. ターミナルで以下を実行:
+
+```bash
+claude mcp add aozora-hr-readonly \
+  --transport http \
+  --url https://mcp-smarthr-1021020088552.asia-northeast1.run.app
+```
+
+3. 初回接続時に Google OAuth URL がターミナルに表示される → ブラウザで開く
+4. `y@lend.aozora-cg.com` を選択 → 認証完了
+5. `claude` を起動し、`/mcp` でサーバーが Connected になっていることを確認
+
+---
+
+## 動作確認シナリオ
+
+接続成功後、以下を試してください。**期待する挙動どおりなら正常**:
+
+| # | 試すこと | 期待される結果 |
+|---|---------|---------------|
+| 1 | 従業員一覧取得（list_employees） | 成功（200）、従業員データが返る |
+| 2 | 特定従業員取得（get_employee） | 成功（200） |
+| 3 | 部署一覧取得（list_departments） | 成功（200） |
+| 4 | 従業員更新（update_employee） | **403 エラー**（readonly 強制、これが正しい動作） |
+| 5 | 給与明細取得（get_pay_statements） | **403 エラー**（readonly 強制、これが正しい動作） |
+| 6 | 従業員作成（create_employee） | **403 エラー**（readonly 強制、これが正しい動作） |
+
+---
+
+## トラブルシューティング
+
+### 「access_denied」が OAuth 画面で表示される
+
+- Google アカウントが `y@lend.aozora-cg.com` か確認
+- 他のアカウントでログインしていないか確認（プライベートブラウジングで試す）
+
+### 「403 Forbidden」が接続時（ツール呼出時ではなく）に出る
+
+- 管理者（yasushi.honda@aozora-cg.com）に連絡
+- Firestore `mcp-users` への登録または環境変数設定に問題がある可能性
+
+### ツールが readonly 以外も見える / 実行できてしまう
+
+- **セキュリティインシデント**として即座に管理者に連絡（readonly 強制が効いていない）
+
+---
+
+## 連絡先
+
+- 技術的な問題: yasushi.honda@aozora-cg.com
+- 権限変更依頼: 同上
+- 緊急停止が必要な場合: 同上（Firestore `enabled: false` で即時停止可能）
+
+---
+
+## 設計背景（参考）
+
+- ADR-008: SmartHR MCP 外部 readonly 例外メール許可（docs/adr/ADR-008-external-readonly-exception.md）
+- 承認方式: 環境変数 `EXTERNAL_READONLY_EMAIL_ALLOWLIST` + Firestore `mcp-users` の二重承認
+- 2 人目の外部ユーザーが発生した場合は多テナント UserStore に再設計予定（本方式の継ぎ足しは禁止）

--- a/docs/handoff/external-user-onboarding-y-lend.md
+++ b/docs/handoff/external-user-onboarding-y-lend.md
@@ -13,11 +13,11 @@
 
 別テナント `lend.aozora-cg.com` のユーザー（y@lend.aozora-cg.com）が、aozora-cg.com の SmartHR データを readonly で参照できるように接続する手順。
 
-**利用可能な 3 つのクライアント**（どれか 1 つでも OK、用途に応じて選択）:
+**利用可能な接続方法**:
 
-- A. claude.ai Pro（Web 版、カスタムコネクタ）
-- B. Claude Desktop（アプリ版、リモート MCP 接続）
-- C. Claude Code CLI（ターミナル版、リモート MCP 接続）
+- **A. claude.ai Custom Connector**（Pro/Max プラン、Web・Desktop 共通）
+  - claude.ai にログインして Connector を 1 回追加すれば、同じアカウントの Web ブラウザと Claude Desktop の両方で自動的に使えるようになる
+- **B. Claude Code CLI**（ターミナル版、リモート MCP 接続）
 
 ---
 
@@ -34,56 +34,43 @@
 
 ---
 
-## A. claude.ai Pro（Web 版）
+## A. claude.ai Custom Connector（Web / Desktop 共通）
+
+Claude Desktop は **リモート HTTP MCP サーバーを設定ファイル（`claude_desktop_config.json`）で直接指定できない**。claude.ai（Web）で Connector を追加すると、同一アカウントでログインしている Desktop にも自動反映される仕組みのため、Web で 1 回設定すれば OK。
+
+### 手順
 
 1. https://claude.ai にログイン（`y@lend.aozora-cg.com` アカウント）
-2. 設定 → Connectors → Custom Connector 追加
+2. 左下のプロフィールアイコン → **Settings** → **Connectors** → **Add custom connector**
 3. 以下を入力:
    - **Name**: `aozora-hr-readonly`（任意）
-   - **URL**: `https://mcp-smarthr-1021020088552.asia-northeast1.run.app`
-4. 「Connect」をクリック
-5. Google OAuth 画面が開く → `y@lend.aozora-cg.com` を選択
-6. 権限同意 → Claude に戻る
-7. チャット画面で `@aozora-hr-readonly list_employees` のように呼び出し、従業員一覧が取れれば成功
+   - **Remote MCP server URL**: `https://mcp-smarthr-1021020088552.asia-northeast1.run.app`
+4. 「Add」をクリック
+5. Connector 一覧の `aozora-hr-readonly` に「Connect」ボタンが出るのでクリック
+6. Google OAuth 画面が開く → `y@lend.aozora-cg.com` を選択 → 権限同意
+7. claude.ai に戻り、Connector が「Connected」状態になっていることを確認
+8. チャット画面で attach（添付）アイコンからツールを選び、`list_employees` 等を呼び出して動作確認
+
+Claude Desktop を使っている場合は同アカウントでログインすれば同じ Connector が自動で利用可能。
 
 ---
 
-## B. Claude Desktop
-
-1. Claude Desktop を最新版に更新
-2. 設定 → Developer → Edit Config
-3. `claude_desktop_config.json` に以下を追記（既存の `mcpServers` があればマージ）:
-
-```json
-{
-  "mcpServers": {
-    "aozora-hr-readonly": {
-      "url": "https://mcp-smarthr-1021020088552.asia-northeast1.run.app"
-    }
-  }
-}
-```
-
-4. Claude Desktop を再起動
-5. 初回接続時に Google OAuth 画面が開く → `y@lend.aozora-cg.com` を選択
-6. チャット画面でツール欄に 5 つの readonly ツールが表示されることを確認
-
----
-
-## C. Claude Code CLI
+## B. Claude Code CLI
 
 1. Claude Code CLI を最新版に更新（`claude --version` で確認）
-2. ターミナルで以下を実行:
+2. ターミナルで以下を実行（URL は位置引数として最後に渡す）:
 
 ```bash
-claude mcp add aozora-hr-readonly \
+claude mcp add \
   --transport http \
-  --url https://mcp-smarthr-1021020088552.asia-northeast1.run.app
+  aozora-hr-readonly \
+  https://mcp-smarthr-1021020088552.asia-northeast1.run.app
 ```
 
 3. 初回接続時に Google OAuth URL がターミナルに表示される → ブラウザで開く
 4. `y@lend.aozora-cg.com` を選択 → 認証完了
 5. `claude` を起動し、`/mcp` でサーバーが Connected になっていることを確認
+6. チャット画面で `list_employees` 等を呼び出して動作確認
 
 ---
 
@@ -99,6 +86,8 @@ claude mcp add aozora-hr-readonly \
 | 4 | 従業員更新（update_employee） | **403 エラー**（readonly 強制、これが正しい動作） |
 | 5 | 給与明細取得（get_pay_statements） | **403 エラー**（readonly 強制、これが正しい動作） |
 | 6 | 従業員作成（create_employee） | **403 エラー**（readonly 強制、これが正しい動作） |
+
+いずれの接続方法でも、認証成功後は同じ 6 項目が同じ挙動になるはず。
 
 ---
 


### PR DESCRIPTION
## Summary

- PR #438 マージ + Cloud Run rev 00021-f9x 本番デプロイ完了をハンドオフに反映
- 外部ユーザー y@lend.aozora-cg.com 向けの接続手順書（3 クライアント対応）を追加
- /review-pr 指摘を follow-up Issue #439-442 に切り出し、本 PR から参照

## 変更内容

- `docs/handoff/LATEST.md`: 最終更新日・デプロイ情報・Firestore 11 ユーザー登録・WBS 13/14（93%）を反映
- `docs/handoff/external-user-onboarding-y-lend.md`: 新規作成（claude.ai Pro / Claude Desktop / Claude Code CLI の 3 クライアント接続手順、動作確認シナリオ、トラブルシューティング）

## Test plan

- [x] ハンドオフ内のコマンド（curl, gcloud, git log）を実機確認
- [x] Cloud Run rev `mcp-smarthr-00021-f9x` が 100% トラフィック
- [x] /health 応答 `{"status":"ok"}`
- [x] 環境変数 `EXTERNAL_READONLY_EMAIL_ALLOWLIST=y@lend.aozora-cg.com` 設定済
- [x] Firestore `mcp-users` に 11 ユーザー登録済（`y@lend.aozora-cg.com` 含む）
- [ ] T13 実機検証: 次セッション、y@lend.aozora-cg.com 本人に依頼（本 PR 範囲外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)