### PR TITLE
docs: Phase 14（給与明細排除）完了反映

### DIFF
--- a/docs/handoff/LATEST.md
+++ b/docs/handoff/LATEST.md
@@ -1,27 +1,33 @@
 # HR-AI Agent — Session Handoff
 
-**最終更新**: 2026-04-17（PR #438 マージ + 本番デプロイ完了、T13 実機検証待ち）
+**最終更新**: 2026-04-17（Phase 14 給与明細排除 本番デプロイ完了）
 **ブランチ**: `main`
-**main 最新**: `2c417f3` — feat: SmartHR MCP に外部 readonly 例外メール許可機能を追加 (#438)
+**main 最新**: `6616767` — feat: SmartHR MCP から給与明細機能を完全排除 (#445)
 
 ---
 
 ## 現在のフェーズ
 
-**Phase 13 — SmartHR MCP 外部 readonly 例外許可（実装完了・デプロイ完了、T13 実機検証のみ残）**
+**Phase 14 — 給与明細機能の完全排除（完了、本番稼働中）**
 
-`y@lend.aozora-cg.com` を readonly で恒久許可する機能が本番稼働中。外部ユーザー本人による実機検証のみが残っている状態。
+セキュリティ方針により `get_pay_statements` ツール・関連型・`pay_statements` permission を完全排除。権限モデルを `Permission = "read" | "write"` の 2 値に縮退。Cloud Run rev `mcp-smarthr-00022-wcg` で 100% 稼働中。
+
+**Phase 13 — 外部 readonly 例外（T13 実機検証のみ外部依頼待ち）**
+
+`y@lend.aozora-cg.com` を readonly で恒久許可する機能は本番反映済。外部ユーザー本人への接続依頼は `docs/handoff/y-lend-request-message.md` を送付するのみ。
 
 ---
 
 ## 今セッションの成果
 
-### マージ済み PR
+### マージ済み PR（本セッション）
 
-| PR | 内容 | 状態 |
+| PR | 内容 | マージ SHA |
 |----|------|------|
-| #437 | CLAUDE.md に Operational Status 追加 | ✅ マージ済み（前セッション） |
-| **#438** | **SmartHR MCP に外部 readonly 例外メール許可機能を追加** | ✅ **本セッションでマージ**（`2c417f3`） |
+| #438 | SmartHR MCP に外部 readonly 例外メール許可機能を追加 | `2c417f3` |
+| #443 | Phase 13 本番デプロイ完了反映 + 外部ユーザー接続手順書 | `034aa19` |
+| #444 | y@lend 本人宛の接続依頼文（T13 送付用）を追加 | `96c60dc` |
+| **#445** | **給与明細機能の完全排除** | **`6616767`** |
 
 ### 作成した Issue（follow-up）
 
@@ -36,75 +42,81 @@
 
 | 項目 | 値 |
 |------|-----|
-| Cloud Run リビジョン | `mcp-smarthr-00021-f9x`（100% トラフィック） |
-| イメージ SHA | `2c417f3` |
+| Cloud Run リビジョン | `mcp-smarthr-00022-wcg`（100% トラフィック、Phase 14 反映） |
+| イメージ SHA | `6616767` |
 | `/health` 応答 | `{"status":"ok"}` |
-| 追加環境変数 | `EXTERNAL_READONLY_EMAIL_ALLOWLIST=y@lend.aozora-cg.com` |
-| Firestore 登録 | 11 ユーザー（admin 4, readonly 6, external readonly 1） |
+| 公開 `/docs` のツール数表記 | **「7 つのツール」** |
+| 環境変数 | `EXTERNAL_READONLY_EMAIL_ALLOWLIST=y@lend.aozora-cg.com`（Phase 13 で追加済、維持） |
+| Firestore 登録 | 11 ユーザー（admin 4, readonly 6, external readonly 1）、Phase 14 後 `["read","write"]` に整列済 |
 
-### 追加ドキュメント
+### Phase 14 の変更サマリ
+
+| 層 | 変更 |
+|----|------|
+| コード | 5 ファイル（tools/smarthr-client/types/pii-filter/auth）から get_pay_statements / SmartHRPayStatement* / pay_statements を完全削除 |
+| 権限モデル | `Permission = "read" \| "write"` の 2 値に縮退、`ROLE_TO_PERMISSIONS.admin = ["read","write"]` |
+| テスト | 135 → 132 件（pay_statements 関連 5 件削除、silent-drop 回帰テスト 2 件追加） |
+| 配信ドキュメント | `/docs` `/guide` から給与明細記述を「本 MCP では未提供」に更新 |
+| 設計ドキュメント | ADR-008 の readonly 強制記述を write のみに更新 |
+| README | ツール数・Permission 型の記述を最新化 |
+
+### 追加ドキュメント（Phase 13 + 14 累計）
 
 | ファイル | 内容 |
 |---------|------|
 | `docs/adr/ADR-008-external-readonly-exception.md` | 設計判断の記録（案 A' 採用、案 B 不採用理由、増殖ガード等） |
-| `docs/handoff/external-user-onboarding-y-lend.md` | y@lend.aozora-cg.com 向け接続手順書（3 クライアント対応） |
+| `docs/handoff/external-user-onboarding-y-lend.md` | y@lend 向け接続手順書（claude.ai Connector / CLI） |
+| `docs/handoff/y-lend-request-message.md` | y@lend 本人宛の転送用依頼文（Phase 14 で給与明細記述削除済） |
 
 ---
 
-## WBS 進捗（T1-T14）
+## WBS 完了状況
+
+### Phase 13（T1-T14）
 
 | ID | タスク | 状態 |
 |----|-------|------|
-| T1-T9 | 実装・ユニットテスト | ✅ 完了 |
-| T10 | Firestore 登録 | ✅ **本セッションで完了** |
-| T11 | 配信ドキュメント更新 | ✅ 完了 |
-| T12 | Cloud Run デプロイ + 環境変数 | ✅ **本セッションで完了** |
+| T1-T12, T14 | 実装・テスト・ドキュメント・デプロイ・環境変数・Firestore 登録・ハンドオフ | ✅ 完了 |
 | T13 | 実機検証（y@lend 本人に依頼） | ⏳ **外部依頼待ち** |
-| T14 | ハンドオフ更新 | ✅ 本ドキュメントで完了 |
 
-**進捗: 13/14（93%）** — 残作業は外部ユーザー依頼のみ
+### Phase 14（P14-A〜G）
+
+| ID | タスク | 状態 |
+|----|-------|------|
+| A | コード変更（5 ファイル） | ✅ 完了 |
+| B | テスト調整（135 → 132） | ✅ 完了 |
+| C | ドキュメント更新（/docs /guide / ADR / README / handoff） | ✅ 完了 |
+| D | 品質ゲート（typecheck/lint/build/test + evaluator） | ✅ 完了 |
+| E | PR 作成 + /review-pr + マージ（#445） | ✅ 完了 |
+| F | 本番デプロイ + Firestore 再シード | ✅ 完了 |
+| G | ハンドオフ更新 | ✅ 本ドキュメントで完了 |
 
 ---
 
-## T13（実機検証）の進め方
+## T13（外部ユーザー実機検証）の進め方
 
-### 依頼文テンプレート
+1. `docs/handoff/y-lend-request-message.md` を開いて本文コピー
+2. y@lend.aozora-cg.com 本人へメール／チャットで送付
+3. 本人から接続結果（成功 / 失敗 / 動作確認 3 項目）を受領
+4. 受領後 LATEST.md に結果追記、Phase 13 クローズ
 
-`docs/handoff/external-user-onboarding-y-lend.md` を y@lend.aozora-cg.com 本人に共有。その文書に以下が含まれている:
-
-- 3 クライアント（claude.ai Pro / Claude Desktop / Claude Code CLI）それぞれの接続手順
-- 動作確認シナリオ（read 系成功 + write が 403 になること）
-- トラブルシューティング
-- 連絡先（yasushi.honda@aozora-cg.com）
-
-### 検証完了後のアクション
-
-1. 接続成功 → y@lend 本人から動作確認完了の連絡を受領
-2. `docs/handoff/LATEST.md` に検証結果を追記
-3. T13 を completed に更新
-4. Phase 13 クローズ
-
-### 接続に失敗した場合のデバッグポイント
-
-- Cloud Run ログで `allowedBy` タグを確認（`external_email_exception` が出るか）
-- Firestore `mcp-users` で `y@lend.aozora-cg.com` の `enabled=true` を確認
-- 環境変数 `EXTERNAL_READONLY_EMAIL_ALLOWLIST` の値を確認
+**本依頼文は Phase 14 の給与明細排除を反映済**（動作確認シナリオ 4 項目 → 3 項目、給与明細関連記述削除）。
 
 ---
 
 ## 次セッションでの選択肢
 
-**A. T13 結果待ちの間、Issue #439-442 から着手**（推奨）
-- #440（fail-closed 化）は P1 で優先度高
-- Phase 13 完了を待たず並行処理可能
+**A. follow-up Issue 対応**（#440 P1 優先）
+- #440: fallback UserStore の fail-closed 化（セキュリティ優先）
+- #439/#441/#442: polish・テスト追加
 
 **B. 長期停滞 PR の整理**
-- #410（SmartHR MCP Phase 1）— 既に本番稼働しているため close 判断
-- #409（ADR-008 AI エージェント拡張）— 本 ADR-008（外部例外）とは別物、重複しない名称への改名検討
+- #410（SmartHR MCP Phase 1 古い PR）close 判断
+- #409（ADR-008 名称重複、改名検討）
 
-**C. Issue #407 / #408（積み残し）**
-- Phase 2: Anthropic HR Plugin 導入
-- Phase 3: 本番 AI エージェント + /agent-lab
+**C. Phase 2 / 3 着手**
+- #407: Phase 2 Anthropic HR Plugin 導入
+- #408: Phase 3 本番 AI エージェント + /agent-lab
 
 ---
 
@@ -114,11 +126,13 @@
 |--------|------|-----------|
 | admin | 閲覧 + 更新 + 登録 | kosuke.omure, tomohiro.arikawa, makoto.tokunaga, yasushi.honda |
 | readonly | 閲覧のみ | ryota.yagi, gen.ichihara, rika.komatsu, shoma.horinouchi, tomoko.hommura, yuka.yoshimura |
-| **readonly（外部例外）** | **閲覧のみ（強制）** | **y@lend.aozora-cg.com** |
+| readonly（外部例外） | 閲覧のみ（強制） | **y@lend.aozora-cg.com** |
+
+**※ admin の権限から「給与明細」は Phase 14 で削除済**
 
 ---
 
-## Cloud Run 環境変数（全 11 項目、うち 5 つは Secret）
+## Cloud Run 環境変数
 
 | 変数 | 値 | 備考 |
 |------|-----|------|
@@ -126,49 +140,32 @@
 | ALLOWED_DOMAIN | aozora-cg.com | |
 | AUTH_DISABLED | false | |
 | IP_RESTRICTION_ENABLED | false | |
-| SERVER_URL | https://mcp-smarthr-bdr4g3rk2q-an.a.run.app | OAuth issuer 用の legacy URL 形式。公開 URL は `https://mcp-smarthr-1021020088552.asia-northeast1.run.app`（同じサービスを Cloud Run が両形式で提供） |
+| SERVER_URL | https://mcp-smarthr-bdr4g3rk2q-an.a.run.app | OAuth issuer 用 legacy URL、公開 URL は `-1021020088552` 形式 |
 | USE_FIRESTORE_USER_STORE | true | |
-| **EXTERNAL_READONLY_EMAIL_ALLOWLIST** | **y@lend.aozora-cg.com** | **本セッションで追加** |
-| SMARTHR_API_KEY | (secret) | |
-| SMARTHR_TENANT_ID | (secret) | |
-| GOOGLE_CLIENT_ID | (secret) | |
-| GOOGLE_CLIENT_SECRET | (secret) | |
-| JWT_SECRET | (secret) | |
+| EXTERNAL_READONLY_EMAIL_ALLOWLIST | y@lend.aozora-cg.com | Phase 13 で追加済 |
+| SMARTHR_API_KEY / SMARTHR_TENANT_ID / GOOGLE_CLIENT_ID / GOOGLE_CLIENT_SECRET / JWT_SECRET | (secret) | |
 
 ---
 
-## 外部 readonly 例外の運用ガイド（ADR-008 準拠）
+## MCP ツール一覧（7 ツール、給与明細排除後）
 
-### 狭い恒久例外
-
-- 対象は 1 ユーザーのみ（`y@lend.aozora-cg.com`）
-- 2 人目が発生した場合は多テナント UserStore に再設計（継ぎ足し禁止）
-
-### 二重承認
-
-- 環境変数 `EXTERNAL_READONLY_EMAIL_ALLOWLIST`（Cloud Run、SRE 管轄）
-- Firestore `mcp-users`（管理者管轄）
-- 両方必須で通過
-
-### readonly 強制（Layer 3.5）
-
-- Authorizer と OAuth `/token` の両方で `isExternalReadonlyViolation` を実施
-- Firestore で write 権限が誤付与されても 403 deny
-
-### revoke 手順
-
-| 緊急度 | 手順 |
-|--------|------|
-| 即時停止 | Firestore `mcp-users` で `enabled: false` |
-| 完全削除 | 上記 + 環境変数削除 + Cloud Run 再デプロイ |
+| ツール | 権限 | SmartHR API |
+|--------|------|-------------|
+| list_employees | read | GET /crews |
+| get_employee | read | GET /crews/{id} |
+| search_employees | read | GET /crews?q= |
+| list_departments | read | GET /departments |
+| list_positions | read | GET /positions |
+| update_employee | write | PATCH /crews/{id} |
+| create_employee | write | POST /crews |
 
 ---
 
 ## テスト状況
 
-| パッケージ | テスト数 | 状態 |
+| パッケージ | テスト数 | 備考 |
 |-----------|---------|------|
-| packages/mcp-smarthr | 135 | 全 PASS（前セッション +37） |
+| packages/mcp-smarthr | **132**（Phase 14 で pay_statements 関連 -5 + silent-drop 回帰 +2） | 全 PASS |
 | apps/api | 22+ | 全 PASS |
 | apps/worker | 80 | 全 PASS |
 | apps/web | 207 | 全 PASS |
@@ -179,16 +176,19 @@
 
 | 番号 | 内容 | 状態 |
 |------|------|------|
-| #438 | 外部 readonly 例外 | ✅ マージ済 |
+| **#445** | **給与明細排除**（Phase 14） | ✅ **マージ済** |
+| #444 | y@lend 本人宛依頼文 | ✅ マージ済 |
+| #443 | Phase 13 デプロイ反映 | ✅ マージ済 |
+| #438 | 外部 readonly 例外（Phase 13） | ✅ マージ済 |
 | #437 | CLAUDE.md Operational Status | ✅ マージ済 |
-| #442 | Mermaid 図と email 正規化 polish | 🆕 作成（P2） |
-| #441 | 外部例外 OAuth 統合テスト | 🆕 作成（P2） |
-| #440 | fallback UserStore fail-closed 化 | 🆕 作成（P1） |
-| #439 | 監査ログ silent catch 修正 | 🆕 作成（P2） |
-| #410 | Phase 1 SmartHR MCP 構築（古い PR） | 積み残し、close 判断要 |
-| #409 | ADR-008 AI エージェント拡張（名称重複） | 積み残し、改名検討要 |
-| #408 | Phase 3: 本番 AI エージェント + /agent-lab | 積み残し |
-| #407 | Phase 2: Anthropic HR Plugin 導入 | 積み残し |
+| #442 | Mermaid 図 + email 正規化 polish | 🟡 open |
+| #441 | 外部例外 OAuth 統合テスト | 🟡 open |
+| #440 | fallback UserStore fail-closed 化 | 🟡 open（P1） |
+| #439 | 監査ログ silent catch 修正 | 🟡 open |
+| #410 | Phase 1 SmartHR MCP 構築（古い PR） | 積み残し |
+| #409 | ADR-008 AI エージェント拡張（名称重複） | 積み残し |
+| #408 | Phase 3 本番 AI エージェント + /agent-lab | 積み残し |
+| #407 | Phase 2 Anthropic HR Plugin 導入 | 積み残し |
 
 ---
 
@@ -200,7 +200,7 @@ cd /Users/yyyhhh/Projects/ACG/hr-system
 git fetch origin
 git checkout main
 git pull
-git log --oneline -3  # 2c417f3 が HEAD であること確認
+git log --oneline -3  # 6616767 が HEAD であること確認
 
 # 2. 本番稼働状況確認
 curl -sS https://mcp-smarthr-1021020088552.asia-northeast1.run.app/health
@@ -208,18 +208,25 @@ curl -sS https://mcp-smarthr-1021020088552.asia-northeast1.run.app/health
 # 3. Cloud Run リビジョン確認
 gcloud run services describe mcp-smarthr --region=asia-northeast1 \
   --format="value(status.latestReadyRevisionName)"
-# 期待値: mcp-smarthr-00021-f9x
+# 期待値: mcp-smarthr-00022-wcg
 
-# 4. T13 状況確認（y@lend.aozora-cg.com からの連絡）
+# 4. ツール数確認（公開 /docs）
+curl -sS https://mcp-smarthr-1021020088552.asia-northeast1.run.app/docs | grep -oE "7 つのツール|8 つのツール"
+# 期待値: 7 つのツール
 
-# 5. 次セッションでの選択肢（上記「次セッションでの選択肢」参照）
+# 5. T13 状況確認（y@lend.aozora-cg.com からの連絡）
+
+# 6. 次セッションでの選択肢（上記「次セッションでの選択肢」参照）
 ```
 
 ---
 
 ## 参考資料
 
+- PR #445: https://github.com/yasushihonda-acg/hr-system/pull/445
+- PR #444: https://github.com/yasushihonda-acg/hr-system/pull/444
+- PR #443: https://github.com/yasushihonda-acg/hr-system/pull/443
 - PR #438: https://github.com/yasushihonda-acg/hr-system/pull/438
 - ADR-008: `docs/adr/ADR-008-external-readonly-exception.md`
-- 接続手順書: `docs/handoff/external-user-onboarding-y-lend.md`
-- Issue #439-442: follow-up で対応予定
+- 外部ユーザー接続手順書: `docs/handoff/external-user-onboarding-y-lend.md`
+- 外部ユーザー向け依頼文（転送用）: `docs/handoff/y-lend-request-message.md`


### PR DESCRIPTION
## Summary

- PR #445 マージ + Cloud Run rev `mcp-smarthr-00022-wcg` デプロイ + Firestore 再シード完了をハンドオフに反映
- Phase 13 / 14 両方の WBS と関連 PR・Issue を整理

## 変更内容

- `docs/handoff/LATEST.md`:
  - 最終更新日・ブランチ・main 最新を更新
  - Phase 14 サマリセクション新設（コード/権限/テスト/ドキュメント変更を記載）
  - MCP ツール一覧を 7 ツールに整理（給与明細削除）
  - admin 権限欄から「給与明細」削除
  - WBS（Phase 13 T1-T14 + Phase 14 A-G）の完了状況を明示
  - 再開手順・次セッション選択肢を更新

## Test plan

- [x] Cloud Run rev `mcp-smarthr-00022-wcg` 100% トラフィック
- [x] `/health` `{"status":"ok"}`
- [x] 公開 `/docs` が「7 つのツール」表記
- [x] Firestore 11 ユーザー再シード完了（admin permissions が `["read","write"]` に整列）
- [x] ハンドオフ内コマンドの実機検証済

🤖 Generated with [Claude Code](https://claude.com/claude-code)